### PR TITLE
Bootstrap k8s-operator

### DIFF
--- a/charms/k8s/charmcraft.yaml
+++ b/charms/k8s/charmcraft.yaml
@@ -11,3 +11,11 @@ bases:
     run-on:
     - name: ubuntu
       channel: "22.04"
+config:
+  options:
+    channel:
+      default: edge
+      type: string
+      description: |
+        Snap channel to install k8s snap from
+      

--- a/charms/k8s/lxd-profile.yaml
+++ b/charms/k8s/lxd-profile.yaml
@@ -1,0 +1,30 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+description: "LXD profile for Canonical Kubernetes"
+config:
+  boot.autostart: "true"
+  linux.kernel_modules: ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh,ip_tables,ip6_tables,netlink_diag,nf_nat,overlay,br_netfilter
+  raw.lxc: |
+    lxc.apparmor.profile=unconfined
+    lxc.mount.auto=proc:rw sys:rw cgroup:rw
+    lxc.cgroup.devices.allow=a
+    lxc.cap.drop=
+  security.nesting: "true"
+  security.privileged: "true"
+devices:
+  aadisable:
+    path: /sys/module/nf_conntrack/parameters/hashsize
+    source: /sys/module/nf_conntrack/parameters/hashsize
+    type: disk
+  aadisable2:
+    path: /dev/kmsg
+    source: /dev/kmsg
+    type: unix-char
+  aadisable3:
+    path: /sys/fs/bpf
+    source: /sys/fs/bpf
+    type: disk
+  aadisable4:
+    path: /proc/sys/net/netfilter/nf_conntrack_max
+    source: /proc/sys/net/netfilter/nf_conntrack_max
+    type: disk

--- a/charms/k8s/pyproject.toml
+++ b/charms/k8s/pyproject.toml
@@ -44,7 +44,7 @@ namespace_packages = true
 [tool.pylint]
 # Ignore too-few-public-methods due to pydantic models
 # Ignore no-self-argument due to pydantic validators
-disable = "wrong-import-order,redefined-outer-name,too-few-public-methods,no-self-argument"
+disable = "wrong-import-order,redefined-outer-name,too-few-public-methods,no-self-argument,fixme"
 # Ignore Pydantic check: https://github.com/pydantic/pydantic/issues/1961
 extension-pkg-whitelist = "pydantic" # wokeignore:rule=whitelist
 

--- a/charms/k8s/pyproject.toml
+++ b/charms/k8s/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.bandit]
 exclude_dirs = ["/venv/", "tests"]
+skips = ["B404","B603"]
 [tool.bandit.assert_used]
 skips = ["*/*test.py", "*/test_*.py", "*tests/*.py"]
 
@@ -77,3 +78,5 @@ max-complexity = 10
 
 [tool.codespell]
 skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
+[tool.pyright]
+extraPaths = ["./lib"]

--- a/charms/k8s/src/charm.py
+++ b/charms/k8s/src/charm.py
@@ -16,35 +16,143 @@ certificate storage.
 """
 
 import logging
+import re
+import shlex
+import subprocess
+from typing import Optional
 
 import ops
+from charms.k8s.v0.k8sd_api_manager import (
+    InvalidResponseError,
+    K8sdAPIManager,
+    K8sdConnectionError,
+    UnixSocketConnectionFactory,
+)
+from charms.operator_libs_linux.v2.snap import SnapCache, SnapError, SnapState
+from ops.model import WaitingStatus
+from pydantic import ValidationError
 
 # Log messages can be retrieved using juju debug-log
 logger = logging.getLogger(__name__)
 
 VALID_LOG_LEVELS = ["info", "debug", "warning", "error", "critical"]
-K8SD_SNAP_SOCKET = "/var/snap/k8s/common/var/lib/k8sd/control.socket"
+K8SD_SNAP_SOCKET = "/var/snap/k8s/common/var/lib/k8sd/state/control.socket"
 
 
 class K8sCharm(ops.CharmBase):
-    """Charm the service."""
+    """A charm for managing a K8s cluster via the k8s snap."""
 
     def __init__(self, *args):
-        """Construct.
+        """Initialise the K8s charm.
 
         Args:
             args: Arguments passed to the CharmBase parent constructor.
         """
         super().__init__(*args)
         self.framework.observe(self.on.update_status, self._on_update_status)
+        self.framework.observe(self.on.install, self._on_install)
 
-    def _on_update_status(self, _event: ops.UpdateStatusEvent):
+        factory = UnixSocketConnectionFactory(unix_socket=K8SD_SNAP_SOCKET)
+        self.api_manager = K8sdAPIManager(factory)
+        self.snap_cache = SnapCache()
+
+    def _apply_snap_requirements(self):
+        """Apply necessary snap requirements for the k8s snap.
+
+        This method executes necessary scripts to ensure that the snap
+        meets the network and interface requirements.
+        """
+        self.unit.status = ops.MaintenanceStatus("Applying K8s requirements")
+        commands = [
+            "/snap/k8s/current/k8s/connect-interfaces.sh",
+            "/snap/k8s/current/k8s/network-requirements.sh",
+        ]
+        for c in commands:
+            subprocess.check_call(shlex.split(c))
+
+    def _bootstrap_k8s_snap(self):
+        """Bootstrap the k8s if it's not already bootstrapped."""
+        if not self.api_manager.is_cluster_bootstrapped():
+            self.unit.status = ops.MaintenanceStatus("Bootstrapping Cluster")
+            cmd = "k8s bootstrap"
+            subprocess.check_call(shlex.split(cmd), shell=False)
+
+    def _enable_components(self):
+        """Enable necessary components for the Kubernetes cluster."""
+        self.unit.status = ops.MaintenanceStatus("Enabling DNS")
+        self.api_manager.enable_component("dns", True)
+        self.unit.status = ops.MaintenanceStatus("Enabling Network")
+        self.api_manager.enable_component("network", True)
+
+    def _get_snap_version(self) -> Optional[str]:
+        """Retrieve the version of the installed Kubernetes snap package.
+
+        Returns:
+            Optional[str]: The version of the installed k8s snap package, or None if
+            not available.
+        """
+        cmd = "snap list k8s"
+        result = subprocess.check_output(shlex.split(cmd))
+        output = result.decode().strip()
+        match = re.search(r"(\d+\.\d+(?:\.\d+)?)", output)
+
+        if match:
+            return match.group()
+
+        logger.info("Snap k8s not found or no version available.")
+        return None
+
+    def _install_k8s_snap(self):
+        """Install the k8s snap package."""
+        self.unit.status = ops.MaintenanceStatus("Installing k8s snap")
+        k8s_snap = self.snap_cache["k8s"]
+        if not k8s_snap.present:
+            k8s_snap.ensure(SnapState.Latest, channel="edge")
+
+    def _on_install(self, event):
+        """Handle install event for the charm.
+
+        Args:
+            event: The event that triggered this handler.
+        """
+        try:
+            self._install_k8s_snap()
+            self._apply_snap_requirements()
+            self._bootstrap_k8s_snap()
+            self._enable_components()
+            self.unit.status = WaitingStatus("K8s not ready")
+        except (ValidationError, InvalidResponseError) as e:
+            logger.warning("Failed to query k8s snap. Reason: %s", e)
+            self.unit.status = ops.WaitingStatus("Waiting for K8sd API.")
+        except SnapError as e:
+            logger.error("Failed to install k8s snap. Reason: %s", e.message)
+            self.unit.status = ops.BlockedStatus("Failed to install k8s snap")
+        except subprocess.CalledProcessError as e:
+            logger.error("Failed to run subprocess: %s", e)
+        except K8sdConnectionError as e:
+            logger.warning("Unable to contact K8sd API: %s", e)
+            self.unit.status = ops.WaitingStatus("Waiting for K8sd API.")
+        finally:
+            event.defer()
+
+    def _on_update_status(self, event: ops.UpdateStatusEvent):
         """Handle update-status event.
 
         Args:
-            _event: event triggering the handler.
+            event: event triggering the handler.
         """
-        self.unit.status = ops.ActiveStatus("Ready")
+        try:
+            if self.api_manager.is_cluster_ready():
+                if version := self._get_snap_version():
+                    self.unit.set_workload_version(version)
+                self.unit.status = ops.ActiveStatus("Ready")
+        except ValidationError:
+            self.unit.status = ops.WaitingStatus("Waiting for K8s to be ready")
+        except K8sdConnectionError:
+            logger.exception("Unable to contact K8sdAPI")
+            self.unit.status = ops.WaitingStatus("Waiting for K8sd API")
+        finally:
+            event.defer()
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/charms/k8s/tests/unit/test_base.py
+++ b/charms/k8s/tests/unit/test_base.py
@@ -30,4 +30,4 @@ def test_config_changed_invalid(harness):
 
 def test_update_status(harness):
     harness.charm.on.update_status.emit()
-    assert harness.model.unit.status == ops.ActiveStatus("Ready")
+    assert harness.model.unit.status == ops.WaitingStatus("Waiting for K8sd API")

--- a/charms/k8s/tests/unit/test_k8sd_api_manager.py
+++ b/charms/k8s/tests/unit/test_k8sd_api_manager.py
@@ -150,7 +150,7 @@ class TestK8sdAPIManager(unittest.TestCase):
 
         self.api_manager.create_join_token("test-node")
         mock_send_request.assert_called_once_with(
-            "/1.0/k8sd/tokens", "POST", {"name": "test-node"}, CreateJoinTokenResponse
+            "/1.0/k8sd/tokens", "POST", CreateJoinTokenResponse, {"name": "test-node"}
         )
 
     @patch("lib.charms.k8s.v0.k8sd_api_manager.K8sdAPIManager._send_request")
@@ -161,7 +161,10 @@ class TestK8sdAPIManager(unittest.TestCase):
 
         self.api_manager.enable_component("foo", True)
         mock_send_request.assert_called_once_with(
-            "/1.0/k8sd/components/foo", "PUT", {"status": "enable"}, UpdateComponentResponse
+            "/1.0/k8sd/components/foo",
+            "PUT",
+            UpdateComponentResponse,
+            {"status": "enabled"},
         )
 
     @patch("lib.charms.k8s.v0.k8sd_api_manager.K8sdAPIManager._send_request")
@@ -172,7 +175,7 @@ class TestK8sdAPIManager(unittest.TestCase):
 
         self.api_manager.enable_component("foo", False)
         mock_send_request.assert_called_once_with(
-            "/1.0/k8sd/components/foo", "PUT", {"status": "disable"}, UpdateComponentResponse
+            "/1.0/k8sd/components/foo", "PUT", UpdateComponentResponse, {"status": "disabled"}
         )
 
     @patch("lib.charms.k8s.v0.k8sd_api_manager.K8sdAPIManager._send_request")
@@ -189,6 +192,6 @@ class TestK8sdAPIManager(unittest.TestCase):
         mock_send_request.assert_called_once_with(
             "/1.0/kubernetes/auth/tokens",
             "POST",
-            {"username": test_user, "groups": test_groups},
             AuthTokenResponse,
+            {"username": test_user, "groups": test_groups},
         )


### PR DESCRIPTION
## Overview

Generate a first version of the `k8s-operator` charm.

### Rationale

This pull request introduces an initial version of the `k8s-operator`, which has the option to bootstrap and deploy a one-node cluster. This is a stepping stone for future work that has to be done in the charm.

### Juju Events Changes

- Refactored `on_install` handler
- Refactored `update_status` handler

### Library Changes
- Bumped `k8s_api_manager` patch.
- Added Pydantic models and validators for the ClusterStatus endpoint.
- Added methods for checking k8sd cluster state
