### PR TITLE
Implement `k8s` clustering

### DIFF
--- a/charms/k8s/charmcraft.yaml
+++ b/charms/k8s/charmcraft.yaml
@@ -18,10 +18,6 @@ config:
       type: string
       description: |
         Snap channel to install k8s snap from
-peers:
-  cluster:
-    interface: cluster
-
 parts:
   charm:
     build-packages: [git]

--- a/charms/k8s/charmcraft.yaml
+++ b/charms/k8s/charmcraft.yaml
@@ -18,6 +18,10 @@ config:
       type: string
       description: |
         Snap channel to install k8s snap from
+peers:
+  cluster:
+    interface: cluster
+
 parts:
   charm:
     build-packages: [git]

--- a/charms/k8s/metadata.yaml
+++ b/charms/k8s/metadata.yaml
@@ -34,3 +34,7 @@ description: |
   This charm can optionally disable the following components:
   * A Kubernetes Backing Store
   * A Kubernetes CNI
+
+peers:
+  cluster:
+    interface: cluster

--- a/charms/k8s/src/charm.py
+++ b/charms/k8s/src/charm.py
@@ -62,7 +62,6 @@ class K8sCharm(ops.CharmBase):
         self.framework.observe(self.on.update_status, self._on_update_status)
         self._stored.set_default(joined=False)
 
-
     @on_error(WaitingStatus("Failed to apply snap requirements"), subprocess.CalledProcessError)
     def _apply_snap_requirements(self):
         """Apply necessary snap requirements for the k8s snap.

--- a/charms/k8s/src/charm.py
+++ b/charms/k8s/src/charm.py
@@ -184,8 +184,7 @@ class K8sCharm(ops.CharmBase):
             self._bootstrap_k8s_snap()
             self._enable_components()
             self._create_cluster_tokens()
-        else:
-            self._join_cluster()
+        self._join_cluster()
         self._update_status()
 
     @on_error(

--- a/charms/k8s/src/charm.py
+++ b/charms/k8s/src/charm.py
@@ -43,6 +43,8 @@ K8SD_SNAP_SOCKET = "/var/snap/k8s/common/var/lib/k8sd/state/control.socket"
 class K8sCharm(ops.CharmBase):
     """A charm for managing a K8s cluster via the k8s snap."""
 
+    _stored = ops.StoredState()
+
     def __init__(self, *args):
         """Initialise the K8s charm.
 
@@ -58,15 +60,7 @@ class K8sCharm(ops.CharmBase):
         self.reconciler = Reconciler(self, self._reconcile)
 
         self.framework.observe(self.on.update_status, self._on_update_status)
-
-    def _reconcile(self, _):
-        """Reconcile state change events."""
-        # TODO: Implement clustering using leader units.
-        self._install_k8s_snap()
-        self._apply_snap_requirements()
-        self._bootstrap_k8s_snap()
-        self._enable_components()
-        self._update_status()
+        self._stored.set_default(joined=False)
 
     @on_error(WaitingStatus("Failed to apply snap requirements"), subprocess.CalledProcessError)
     def _apply_snap_requirements(self):
@@ -90,6 +84,29 @@ class K8sCharm(ops.CharmBase):
             status.add(ops.MaintenanceStatus("Bootstrapping Cluster"))
             cmd = "k8s bootstrap"
             subprocess.check_call(shlex.split(cmd))
+
+    def _create_cluster_tokens(self):
+        """Create tokens for the units in the peer cluster relation."""
+        if not self.unit.is_leader():
+            return
+
+        relation = self.model.get_relation("cluster")
+        if not relation:
+            return
+
+        units = {u for u in relation.units if u.name != self.unit.name}
+        app_databag = relation.data.get(self.model.app, {})
+
+        for unit in units:
+            if app_databag.get(unit.name):
+                continue
+
+            name = unit.name.replace("/", "-")
+            token = self.api_manager.create_join_token(name)
+            content = {"token": token}
+            secret = self.app.add_secret(content)
+            secret.grant(relation, unit=unit)
+            relation.data[self.app][unit.name] = secret.id or ""
 
     @on_error(
         WaitingStatus("Waiting for enable components"), InvalidResponseError, K8sdConnectionError
@@ -127,6 +144,36 @@ class K8sCharm(ops.CharmBase):
         if not k8s_snap.present:
             channel = self.config["channel"]
             k8s_snap.ensure(SnapState.Latest, channel=channel)
+
+    @on_error(WaitingStatus("Waiting for Cluster token"), TypeError)
+    def _join_cluster(self):
+        """Retrieve the join token from secret databag and join the cluster."""
+        if self.unit.is_leader() or self._stored.joined:
+            return
+
+        status.add(ops.MaintenanceStatus("Joining cluster"))
+
+        if relation := self.model.get_relation("cluster"):
+            app_databag = relation.data.get(self.model.app, {})
+            secret_id = app_databag.get(self.unit.name, "")
+            secret = self.model.get_secret(id=secret_id)
+            content = secret.get_content()
+            token = content["token"]
+            cmd = f"k8s join-cluster {shlex.quote(token)}"
+            subprocess.check_call(shlex.split(cmd))
+            self._stored.joined = True
+
+    def _reconcile(self, _):
+        """Reconcile state change events."""
+        self._install_k8s_snap()
+        self._apply_snap_requirements()
+        if self.unit.is_leader():
+            self._bootstrap_k8s_snap()
+            self._enable_components()
+            self._create_cluster_tokens()
+        else:
+            self._join_cluster()
+        self._update_status()
 
     @on_error(
         ops.WaitingStatus("Cluster not yet ready"),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -45,6 +45,7 @@ class CharmDeploymentArgs:
     application_name: str
     resources: dict
     series: str
+    num_units: int
 
 
 @dataclass
@@ -184,6 +185,7 @@ async def kubernetes_cluster(request: pytest.FixtureRequest, ops_test: OpsTest):
             application_name=charm.app_name,
             resources=charm.resources,
             series="jammy",
+            num_units=1 if charm.app_name == "k8s-worker" else 2
         )
         for path, charm in zip(charm_files, charms)
     ]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -39,6 +39,7 @@ class CharmDeploymentArgs:
         application_name:  name of juju application
         resources:         all resources for this charm
         series:            os series for the machine
+        num_units:         unit instances of the charm
     """
 
     entity_url: str
@@ -190,7 +191,7 @@ async def kubernetes_cluster(request: pytest.FixtureRequest, ops_test: OpsTest):
             application_name=charm.app_name,
             resources=charm.resources,
             series="jammy",
-            num_units=1 if charm.app_name == "k8s-worker" else 2
+            num_units=1 if charm.app_name == "k8s-worker" else 2,
         )
         for path, charm in zip(charm_files, charms)
     ]


### PR DESCRIPTION
## Overview

Implement the Join Cluster process for `k8s` charm units.

### Rationale

This pull request introduces the implementation for joining multiple control plane units into the cluster via the `cluster` peer relation. This relation utilizes Juju secrets for distributing the cluster join tokens over the relation data.

### Juju Events Changes

- Handlers have been added for the cluster relation (`create_cluster_tokens` and `join_cluster`).

