### PR TITLE
Adjust publish to edge paths for k8s and k8s-worker

### DIFF
--- a/.github/workflows/publish-k8s-worker.yaml
+++ b/.github/workflows/publish-k8s-worker.yaml
@@ -12,5 +12,5 @@ jobs:
     secrets: inherit
     with:
       channel: latest/edge
-      working-directory:  ./charms/worker/k8s/
+      working-directory:  ./charms/worker/
       tag-prefix: k8s-worker

--- a/.github/workflows/publish-k8s.yaml
+++ b/.github/workflows/publish-k8s.yaml
@@ -12,5 +12,5 @@ jobs:
     secrets: inherit
     with:
       channel: latest/edge
-      working-directory:  ./charms/k8s/
+      working-directory:  ./charms/worker/k8s/
       tag-prefix: k8s


### PR DESCRIPTION
Fix Path to k8s and k8s-worker charm.

depends on
*  https://github.com/canonical/charming-actions/pull/132