### PR TITLE
Render kubeconfig in root ${HOME}/.kube/config

### DIFF
--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -41,6 +41,7 @@ log = logging.getLogger(__name__)
 VALID_LOG_LEVELS = ["info", "debug", "warning", "error", "critical"]
 K8SD_SNAP_SOCKET = "/var/snap/k8s/common/var/lib/k8sd/state/control.socket"
 KUBECONFIG = Path.home() / ".kube/config"
+ETC_KUBERNETES = Path("/etc/kubernetes")
 K8SD_PORT = 6400
 
 
@@ -278,9 +279,8 @@ class K8sCharm(ops.CharmBase):
         """Generate kubeconfig."""
         status.add(ops.MaintenanceStatus("Generating KubeConfig"))
         KUBECONFIG.parent.mkdir(parents=True, exist_ok=True)
-        cmd = "k8s kubectl config view --raw"
-        output = subprocess.check_output(shlex.split(cmd))
-        KUBECONFIG.write_bytes(output)
+        src = ETC_KUBERNETES / ("admin.conf" if self.is_control_plane else "kubelet.conf")
+        KUBECONFIG.write_bytes(src.read_bytes())
 
     def _on_update_status(self, _event: ops.UpdateStatusEvent):
         """Handle update-status event."""

--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -32,7 +32,6 @@ async def ready_nodes(k8s, expected_count):
     log.info("Parsing node list...")
     node_list = json.loads(result.results["stdout"])
     assert node_list["kind"] == "List", "Should have found a list of nodes"
-    log.info("Finding ready nodes...")
     nodes = {
         node["metadata"]["name"]: all(
             condition["status"] == "False"
@@ -41,10 +40,10 @@ async def ready_nodes(k8s, expected_count):
         )
         for node in node_list["items"]
     }
-    log.info(f"Found {len(nodes)} nodes...")
+    log.info("Found %d/%d nodes...", len(nodes), expected_count)
     assert len(nodes) == expected_count, f"Expect {expected_count} nodes in the list"
     for node, ready in nodes.items():
-        log.info(f"Node {node} is not yet ready...")
+        log.info("Node %s is %sready...", node, "" if ready else "not ")
         assert ready, f"Node not yet ready: {node}."
     return nodes
 

--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -43,7 +43,7 @@ async def ready_nodes(k8s, expected_count):
     log.info("Found %d/%d nodes...", len(nodes), expected_count)
     assert len(nodes) == expected_count, f"Expect {expected_count} nodes in the list"
     for node, ready in nodes.items():
-        log.info("Node %s is %sready...", node, "" if ready else "not ")
+        log.info("Node %s is %s..", node, "ready" if ready else "not ready")
         assert ready, f"Node not yet ready: {node}."
     return nodes
 

--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -14,7 +14,7 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 log = logging.getLogger(__name__)
 
 
-@retry(reraise=True, stop=stop_after_attempt(10), wait=wait_fixed(15))
+@retry(reraise=True, stop=stop_after_attempt(12), wait=wait_fixed(15))
 async def ready_nodes(k8s, expected_count):
     """Get a list of the ready nodes.
 
@@ -25,21 +25,27 @@ async def ready_nodes(k8s, expected_count):
     Returns:
         list of nodes
     """
+    log.info("Finding all nodes...")
     action = await k8s.run("k8s kubectl get nodes -o json")
     result = await action.wait()
     assert result.results["return-code"] == 0, "Failed to get nodes with kubectl"
+    log.info("Parsing node list...")
     node_list = json.loads(result.results["stdout"])
     assert node_list["kind"] == "List", "Should have found a list of nodes"
-    nodes = [
-        node
-        for node in node_list["items"]
-        if all(
+    log.info("Finding ready nodes...")
+    nodes = {
+        node["metadata"]["name"]: all(
             condition["status"] == "False"
             for condition in node["status"]["conditions"]
             if condition["type"] != "Ready"
         )
-    ]
+        for node in node_list["items"]
+    }
+    log.info(f"Found {len(nodes)} nodes...")
     assert len(nodes) == expected_count, f"Expect {expected_count} nodes in the list"
+    for node, ready in nodes.items():
+        log.info(f"Node {node} is not yet ready...")
+        assert ready, f"Node not yet ready: {node}."
     return nodes
 
 
@@ -47,4 +53,6 @@ async def ready_nodes(k8s, expected_count):
 async def test_nodes_ready(kubernetes_cluster):
     """Deploy the charm and wait for active/idle status."""
     k8s = kubernetes_cluster.applications["k8s"]
-    await ready_nodes(k8s.units[0], 3)
+    worker = kubernetes_cluster.applications["k8s-worker"]
+    expected_nodes = len(k8s.units) + len(worker.units)
+    await ready_nodes(k8s.units[0], expected_nodes)


### PR DESCRIPTION
Applicable spec: https://warthogs.atlassian.net/browse/KU-327

### Overview
Generate kubeconfig file in `/root/.kube/config` on the control-plane nodes

### Rationale

In order for admins to access the cluster with tools they are familiar with, the charm should copy out the admin kubeconfig out to `/root/.kube/config

### Module Changes

Adds a new method to the reconcile routine
Reorder all the reconciler routines in the order they are called

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
