### PR TITLE
Add node-labeling charm config using the LabelMaker library

### DIFF
--- a/charms/worker/charmcraft.yaml
+++ b/charms/worker/charmcraft.yaml
@@ -46,6 +46,12 @@ config:
       default: edge
       type: string
       description: Snap channel of the k8s snap
+    labels:
+      default: "node-role.kubernetes.io/worker="
+      type: string
+      description: |
+        Labels can be used to organize and to select subsets of nodes in the
+        cluster. Declare node labels in key=value format, separated by spaces.      
 parts:
   charm:
     build-packages: [git]

--- a/charms/worker/charmcraft.yaml
+++ b/charms/worker/charmcraft.yaml
@@ -47,11 +47,14 @@ config:
       type: string
       description: Snap channel of the k8s snap
     labels:
-      default: "node-role.kubernetes.io/worker="
+      default: ""
       type: string
       description: |
         Labels can be used to organize and to select subsets of nodes in the
-        cluster. Declare node labels in key=value format, separated by spaces.      
+        cluster. Declare node labels in key=value format, separated by spaces.
+        
+        Note: Due to NodeRestriction, workers are limited to how they can label themselves
+        https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction
 parts:
   charm:
     build-packages: [git]

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -55,6 +55,12 @@ config:
       default: edge
       type: string
       description: Snap channel of the k8s snap
+    labels:
+      default: "node-role.kubernetes.io/control-plane="
+      type: string
+      description: |
+        Labels can be used to organize and to select subsets of nodes in the
+        cluster. Declare node labels in key=value format, separated by spaces.      
 parts:
   charm:
     build-packages: [git]

--- a/charms/worker/k8s/requirements.txt
+++ b/charms/worker/k8s/requirements.txt
@@ -3,4 +3,4 @@ cosl == 0.0.8
 pydantic == 1.*
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@main
 charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status@main
-charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@KU-325/pass-kubectl-path#subdirectory=ops
+charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@main#subdirectory=ops

--- a/charms/worker/k8s/requirements.txt
+++ b/charms/worker/k8s/requirements.txt
@@ -1,5 +1,6 @@
 ops >= 2.2.0
 cosl == 0.0.8
 pydantic == 1.*
-charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
-charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status
+charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@main
+charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status@main
+charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@KU-325/pass-kubectl-path#subdirectory=ops

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -35,7 +35,8 @@ from charms.k8s.v0.k8sd_api_manager import (
     UnixSocketConnectionFactory,
 )
 from charms.node_base import LabelMaker
-from charms.operator_libs_linux.v2.snap import SnapCache, SnapError, SnapState
+from charms.operator_libs_linux.v2.snap import SnapError, SnapState
+from charms.operator_libs_linux.v2.snap import ensure as snap_ensure
 from charms.reconciler import Reconciler
 
 from cos_integration import COSIntegration
@@ -73,7 +74,6 @@ class K8sCharm(ops.CharmBase):
         self.reconciler = Reconciler(self, self._reconcile)
         self.distributor = TokenDistributor(self, self.api_manager)
         self.collector = TokenCollector(self, self.get_node_name())
-        self.snap_cache = SnapCache()
 
         self.cos_agent = COSAgentProvider(
             self,
@@ -145,10 +145,7 @@ class K8sCharm(ops.CharmBase):
     def _install_k8s_snap(self):
         """Install the k8s snap package."""
         status.add(ops.MaintenanceStatus("Installing k8s snap"))
-        k8s_snap = self.snap_cache["k8s"]
-        if not k8s_snap.present:
-            channel = self.config["channel"]
-            k8s_snap.ensure(SnapState.Latest, channel=channel)
+        snap_ensure("k8s", SnapState.Latest.value, self.config["channel"])
 
     @on_error(WaitingStatus("Failed to apply snap requirements"), subprocess.CalledProcessError)
     def _apply_snap_requirements(self):

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -67,8 +67,6 @@ class K8sCharm(ops.CharmBase):
             args: Arguments passed to the CharmBase parent constructor.
         """
         super().__init__(*args)
-        self.is_worker = self.meta.name == "k8s-worker"
-
         factory = UnixSocketConnectionFactory(unix_socket=K8SD_SNAP_SOCKET, timeout=320)
         self.label_maker = LabelMaker(
             self, kubeconfig_path=self._source_kubeconfig, kubectl=KUBECTL_PATH

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -67,9 +67,12 @@ class K8sCharm(ops.CharmBase):
             args: Arguments passed to the CharmBase parent constructor.
         """
         super().__init__(*args)
+        self.is_worker = self.meta.name == "k8s-worker"
 
         factory = UnixSocketConnectionFactory(unix_socket=K8SD_SNAP_SOCKET, timeout=320)
-        self.label_maker = LabelMaker(self, kubeconfig_path=KUBECONFIG, kubectl=KUBECTL_PATH)
+        self.label_maker = LabelMaker(
+            self, kubeconfig_path=self._source_kubeconfig, kubectl=KUBECTL_PATH
+        )
         self.api_manager = K8sdAPIManager(factory)
         self.cos = COSIntegration(self)
         self.reconciler = Reconciler(self, self._reconcile)

--- a/charms/worker/k8s/tests/unit/test_base.py
+++ b/charms/worker/k8s/tests/unit/test_base.py
@@ -7,6 +7,9 @@
 """Unit tests."""
 
 
+import contextlib
+from unittest import mock
+
 import ops
 import ops.testing
 import pytest
@@ -23,6 +26,36 @@ def harness(request):
     harness.cleanup()
 
 
+@contextlib.contextmanager
+def mock_reconciler_handlers(harness):
+    """Mock out reconciler handlers.
+
+    Args:
+        harness: the harness under stest
+
+    Yields:
+        Mapping of handler_names to their mock methods.
+    """
+    handler_names = {
+        "_install_k8s_snap",
+        "_apply_snap_requirements",
+        "_join_cluster",
+        "_update_status",
+        "_apply_node_labels",
+    }
+    if harness.charm.is_control_plane:
+        handler_names |= {
+            "_bootstrap_k8s_snap",
+            "_enable_components",
+            "_create_cluster_tokens",
+        }
+
+    handlers = [mock.patch(f"charm.K8sCharm.{name}") for name in handler_names]
+    yield dict(zip(handler_names, (h.start() for h in handlers)))
+    for handler in handlers:
+        handler.stop()
+
+
 def test_config_changed_invalid(harness):
     # Trigger a config-changed event with an unknown-config option
     with pytest.raises(ValueError):
@@ -33,3 +66,13 @@ def test_update_status(harness):
     harness.charm.reconciler.stored.reconciled = True  # Pretended to be reconciled
     harness.charm.on.update_status.emit()
     assert harness.model.unit.status == ops.WaitingStatus("Cluster not yet ready")
+
+
+def test_set_leader(harness):
+    harness.charm.reconciler.stored.reconciled = False  # Pretended to not be reconciled
+    with mock_reconciler_handlers(harness) as handlers:
+        harness.set_leader(True)
+    assert harness.model.unit.status == ops.ActiveStatus("Ready")
+    assert harness.charm.reconciler.stored.reconciled
+    called = {name: h for name, h in handlers.items() if h.called}
+    assert len(called) == len(handlers)

--- a/charms/worker/k8s/tests/unit/test_base.py
+++ b/charms/worker/k8s/tests/unit/test_base.py
@@ -31,7 +31,7 @@ def mock_reconciler_handlers(harness):
     """Mock out reconciler handlers.
 
     Args:
-        harness: the harness under stest
+        harness: the harness under test
 
     Yields:
         Mapping of handler_names to their mock methods.
@@ -41,6 +41,7 @@ def mock_reconciler_handlers(harness):
         "_apply_snap_requirements",
         "_check_k8sd_ready",
         "_join_cluster",
+        "_configure_cos_integration",
         "_update_status",
         "_apply_node_labels",
     }
@@ -49,6 +50,8 @@ def mock_reconciler_handlers(harness):
             "_bootstrap_k8s_snap",
             "_enable_components",
             "_create_cluster_tokens",
+            "_create_cos_tokens",
+            "_apply_cos_requirements",
             "_generate_kubeconfig",
         }
 

--- a/charms/worker/k8s/tests/unit/test_base.py
+++ b/charms/worker/k8s/tests/unit/test_base.py
@@ -42,7 +42,6 @@ def mock_reconciler_handlers(harness):
         "_check_k8sd_ready",
         "_join_cluster",
         "_update_status",
-        "_generate_kubeconfig",
         "_apply_node_labels",
     }
     if harness.charm.is_control_plane:
@@ -50,6 +49,7 @@ def mock_reconciler_handlers(harness):
             "_bootstrap_k8s_snap",
             "_enable_components",
             "_create_cluster_tokens",
+            "_generate_kubeconfig",
         }
 
     handlers = [mock.patch(f"charm.K8sCharm.{name}") for name in handler_names]

--- a/charms/worker/k8s/tests/unit/test_base.py
+++ b/charms/worker/k8s/tests/unit/test_base.py
@@ -39,8 +39,10 @@ def mock_reconciler_handlers(harness):
     handler_names = {
         "_install_k8s_snap",
         "_apply_snap_requirements",
+        "_check_k8sd_ready",
         "_join_cluster",
         "_update_status",
+        "_generate_kubeconfig",
         "_apply_node_labels",
     }
     if harness.charm.is_control_plane:

--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -15,6 +15,14 @@ log = logging.getLogger(__name__)
 
 
 async def get_nodes(k8s):
+    """Return Node list
+
+    Args:
+        k8s: any k8s unit
+
+    Returns:
+        list of nodes
+    """
     action = await k8s.run("k8s kubectl get nodes -o json")
     result = await action.wait()
     assert result.results["return-code"] == 0, "Failed to get nodes with kubectl"
@@ -31,9 +39,6 @@ async def ready_nodes(k8s, expected_count):
     Args:
         k8s: k8s unit
         expected_count: number of expected nodes
-
-    Returns:
-        list of nodes
     """
     log.info("Finding all nodes...")
     nodes = await get_nodes(k8s)
@@ -62,6 +67,7 @@ async def test_nodes_ready(kubernetes_cluster):
 
 
 async def test_nodes_labelled(kubernetes_cluster):
+    """Test the charms label the nodes appropriately."""
     k8s = kubernetes_cluster.applications["k8s"]
     worker = kubernetes_cluster.applications["k8s-worker"]
     nodes = await get_nodes(k8s.units[0])

--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -14,6 +14,16 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 log = logging.getLogger(__name__)
 
 
+async def get_nodes(k8s):
+    action = await k8s.run("k8s kubectl get nodes -o json")
+    result = await action.wait()
+    assert result.results["return-code"] == 0, "Failed to get nodes with kubectl"
+    log.info("Parsing node list...")
+    node_list = json.loads(result.results["stdout"])
+    assert node_list["kind"] == "List", "Should have found a list of nodes"
+    return node_list["items"]
+
+
 @retry(reraise=True, stop=stop_after_attempt(12), wait=wait_fixed(15))
 async def ready_nodes(k8s, expected_count):
     """Get a list of the ready nodes.
@@ -26,26 +36,20 @@ async def ready_nodes(k8s, expected_count):
         list of nodes
     """
     log.info("Finding all nodes...")
-    action = await k8s.run("k8s kubectl get nodes -o json")
-    result = await action.wait()
-    assert result.results["return-code"] == 0, "Failed to get nodes with kubectl"
-    log.info("Parsing node list...")
-    node_list = json.loads(result.results["stdout"])
-    assert node_list["kind"] == "List", "Should have found a list of nodes"
-    nodes = {
+    nodes = await get_nodes(k8s)
+    ready_nodes = {
         node["metadata"]["name"]: all(
             condition["status"] == "False"
             for condition in node["status"]["conditions"]
             if condition["type"] != "Ready"
         )
-        for node in node_list["items"]
+        for node in nodes
     }
-    log.info("Found %d/%d nodes...", len(nodes), expected_count)
-    assert len(nodes) == expected_count, f"Expect {expected_count} nodes in the list"
-    for node, ready in nodes.items():
+    log.info("Found %d/%d nodes...", len(ready_nodes), expected_count)
+    assert len(ready_nodes) == expected_count, f"Expect {expected_count} nodes in the list"
+    for node, ready in ready_nodes.items():
         log.info("Node %s is %s..", node, "ready" if ready else "not ready")
         assert ready, f"Node not yet ready: {node}."
-    return nodes
 
 
 @pytest.mark.abort_on_fail
@@ -55,3 +59,14 @@ async def test_nodes_ready(kubernetes_cluster):
     worker = kubernetes_cluster.applications["k8s-worker"]
     expected_nodes = len(k8s.units) + len(worker.units)
     await ready_nodes(k8s.units[0], expected_nodes)
+
+
+async def test_nodes_labelled(kubernetes_cluster):
+    k8s = kubernetes_cluster.applications["k8s"]
+    worker = kubernetes_cluster.applications["k8s-worker"]
+    nodes = await get_nodes(k8s.units[0])
+    control_plane_label = "node-role.kubernetes.io/control-plane"
+    control_plane = [n for n in nodes if control_plane_label in n["metadata"]["labels"]]
+    assert len(k8s.units) == len(control_plane), "Not all control-plane nodes labeled"
+    juju_nodes = [n for n in nodes if "juju-charm" in n["metadata"]["labels"]]
+    assert len(k8s.units + worker.units) == len(juju_nodes), "Not all nodes labeled as juju-charms"


### PR DESCRIPTION
Applicable spec: https://warthogs.atlassian.net/browse/KU-325

### Overview

Allows for charm config to label worker and control-plane nodes

### Rationale

Allows a juju administrator to specify certain node labels so that dependent workloads can run on properly labeled kubelets.  Will need access to the kubeconfig via https://github.com/canonical/k8s-operator/pull/22

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

Addition of the node-label library 
* https://github.com/charmed-kubernetes/layer-kubernetes-node-base/pull/11

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
