### PR TITLE
Implement `cos-agent` integration

### DIFF
--- a/charms/worker/charmcraft.yaml
+++ b/charms/worker/charmcraft.yaml
@@ -60,6 +60,9 @@ parts:
       rm -rf $CRAFT_PRIME/lib
       mv $CRAFT_PRIME/k8s/lib $CRAFT_PRIME/lib
 
+provides:
+  cos-agent:
+    interface: cos_agent
 requires:
   cluster:
     interface: k8s-cluster
@@ -67,3 +70,5 @@ requires:
     # authentication token via a secret in order to cluster
     # this machine as a worker unit.
     #   juju integrate k8s:k8s-cluster k8s-worker:cluster
+  cos-tokens:
+    interface: cos-tokens

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -62,7 +62,13 @@ parts:
 peers:
   cluster:
     interface: cluster
+  cos-tokens:
+    interface: cos-tokens
 
 provides:
+  cos-agent:
+    interface: cos_agent
   k8s-cluster:
     interface: k8s-cluster
+  cos-worker-tokens:
+    interface: cos-tokens

--- a/charms/worker/k8s/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/charms/worker/k8s/lib/charms/grafana_agent/v0/cos_agent.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 r"""## Overview.

--- a/charms/worker/k8s/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/charms/worker/k8s/lib/charms/grafana_agent/v0/cos_agent.py
@@ -1,0 +1,819 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+r"""## Overview.
+
+This library can be used to manage the cos_agent relation interface:
+
+- `COSAgentProvider`: Use in machine charms that need to have a workload's metrics
+  or logs scraped, or forward rule files or dashboards to Prometheus, Loki or Grafana through
+  the Grafana Agent machine charm.
+
+- `COSAgentConsumer`: Used in the Grafana Agent machine charm to manage the requirer side of
+  the `cos_agent` interface.
+
+
+## COSAgentProvider Library Usage
+
+Grafana Agent machine Charmed Operator interacts with its clients using the cos_agent library.
+Charms seeking to send telemetry, must do so using the `COSAgentProvider` object from
+this charm library.
+
+Using the `COSAgentProvider` object only requires instantiating it,
+typically in the `__init__` method of your charm (the one which sends telemetry).
+
+The constructor of `COSAgentProvider` has only one required and nine optional parameters:
+
+```python
+    def __init__(
+        self,
+        charm: CharmType,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        metrics_endpoints: Optional[List[_MetricsEndpointDict]] = None,
+        metrics_rules_dir: str = "./src/prometheus_alert_rules",
+        logs_rules_dir: str = "./src/loki_alert_rules",
+        recurse_rules_dirs: bool = False,
+        log_slots: Optional[List[str]] = None,
+        dashboard_dirs: Optional[List[str]] = None,
+        refresh_events: Optional[List] = None,
+        scrape_configs: Optional[Union[List[Dict], Callable]] = None,
+    ):
+```
+
+### Parameters
+
+- `charm`: The instance of the charm that instantiates `COSAgentProvider`, typically `self`.
+
+- `relation_name`: If your charmed operator uses a relation name other than `cos-agent` to use
+    the `cos_agent` interface, this is where you have to specify that.
+
+- `metrics_endpoints`: In this parameter you can specify the metrics endpoints that Grafana Agent
+    machine Charmed Operator will scrape. The configs of this list will be merged with the configs
+    from `scrape_configs`.
+
+- `metrics_rules_dir`: The directory in which the Charmed Operator stores its metrics alert rules
+  files.
+
+- `logs_rules_dir`: The directory in which the Charmed Operator stores its logs alert rules files.
+
+- `recurse_rules_dirs`: This parameters set whether Grafana Agent machine Charmed Operator has to
+  search alert rules files recursively in the previous two directories or not.
+
+- `log_slots`: Snap slots to connect to for scraping logs in the form ["snap-name:slot", ...].
+
+- `dashboard_dirs`: List of directories where the dashboards are stored in the Charmed Operator.
+
+- `refresh_events`: List of events on which to refresh relation data.
+
+- `scrape_configs`: List of standard scrape_configs dicts or a callable that returns the list in
+    case the configs need to be generated dynamically. The contents of this list will be merged
+    with the configs from `metrics_endpoints`.
+
+
+### Example 1 - Minimal instrumentation:
+
+In order to use this object the following should be in the `charm.py` file.
+
+```python
+from charms.grafana_agent.v0.cos_agent import COSAgentProvider
+...
+class TelemetryProviderCharm(CharmBase):
+    def __init__(self, *args):
+        ...
+        self._grafana_agent = COSAgentProvider(self)
+```
+
+### Example 2 - Full instrumentation:
+
+In order to use this object the following should be in the `charm.py` file.
+
+```python
+from charms.grafana_agent.v0.cos_agent import COSAgentProvider
+...
+class TelemetryProviderCharm(CharmBase):
+    def __init__(self, *args):
+        ...
+        self._grafana_agent = COSAgentProvider(
+            self,
+            relation_name="custom-cos-agent",
+            metrics_endpoints=[
+                # specify "path" and "port" to scrape from localhost
+                {"path": "/metrics", "port": 9000},
+                {"path": "/metrics", "port": 9001},
+                {"path": "/metrics", "port": 9002},
+            ],
+            metrics_rules_dir="./src/alert_rules/prometheus",
+            logs_rules_dir="./src/alert_rules/loki",
+            recursive_rules_dir=True,
+            log_slots=["my-app:slot"],
+            dashboard_dirs=["./src/dashboards_1", "./src/dashboards_2"],
+            refresh_events=["update-status", "upgrade-charm"],
+            scrape_configs=[
+                {
+                    "job_name": "custom_job",
+                    "metrics_path": "/metrics",
+                    "authorization": {"credentials": "bearer-token"},
+                    "static_configs": [
+                        {
+                            "targets": ["localhost:9003"]},
+                            "labels": {"key": "value"},
+                        },
+                    ],
+                },
+            ]
+        )
+```
+
+### Example 3 - Dynamic scrape configs generation:
+
+Pass a function to the `scrape_configs` to decouple the generation of the configs
+from the instantiation of the COSAgentProvider object.
+
+```python
+from charms.grafana_agent.v0.cos_agent import COSAgentProvider
+...
+
+class TelemetryProviderCharm(CharmBase):
+    def generate_scrape_configs(self):
+        return [
+            {
+                "job_name": "custom",
+                "metrics_path": "/metrics",
+                "static_configs": [{"targets": ["localhost:9000"]}],
+            },
+        ]
+
+    def __init__(self, *args):
+        ...
+        self._grafana_agent = COSAgentProvider(
+            self,
+            scrape_configs=self.generate_scrape_configs,
+        )
+```
+
+## COSAgentConsumer Library Usage
+
+This object may be used by any Charmed Operator which gathers telemetry data by
+implementing the consumer side of the `cos_agent` interface.
+For instance Grafana Agent machine Charmed Operator.
+
+For this purpose the charm needs to instantiate the `COSAgentConsumer` object with one mandatory
+and two optional arguments.
+
+### Parameters
+
+- `charm`: A reference to the parent (Grafana Agent machine) charm.
+
+- `relation_name`: The name of the relation that the charm uses to interact
+  with its clients that provides telemetry data using the `COSAgentProvider` object.
+
+  If provided, this relation name must match a provided relation in metadata.yaml with the
+  `cos_agent` interface.
+  The default value of this argument is "cos-agent".
+
+- `refresh_events`: List of events on which to refresh relation data.
+
+
+### Example 1 - Minimal instrumentation:
+
+In order to use this object the following should be in the `charm.py` file.
+
+```python
+from charms.grafana_agent.v0.cos_agent import COSAgentConsumer
+...
+class GrafanaAgentMachineCharm(GrafanaAgentCharm)
+    def __init__(self, *args):
+        ...
+        self._cos = COSAgentRequirer(self)
+```
+
+
+### Example 2 - Full instrumentation:
+
+In order to use this object the following should be in the `charm.py` file.
+
+```python
+from charms.grafana_agent.v0.cos_agent import COSAgentConsumer
+...
+class GrafanaAgentMachineCharm(GrafanaAgentCharm)
+    def __init__(self, *args):
+        ...
+        self._cos = COSAgentRequirer(
+            self,
+            relation_name="cos-agent-consumer",
+            refresh_events=["update-status", "upgrade-charm"],
+        )
+```
+"""
+
+import json
+import logging
+from collections import namedtuple
+from itertools import chain
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Optional, Set, Union
+
+import pydantic
+from cosl import GrafanaDashboard, JujuTopology
+from cosl.rules import AlertRules
+from ops.charm import RelationChangedEvent
+from ops.framework import EventBase, EventSource, Object, ObjectEvents
+from ops.model import Relation, Unit
+from ops.testing import CharmType
+
+if TYPE_CHECKING:
+    try:
+        from typing import TypedDict
+
+        class _MetricsEndpointDict(TypedDict):
+            path: str
+            port: int
+
+    except ModuleNotFoundError:
+        _MetricsEndpointDict = Dict  # pyright: ignore
+
+LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
+LIBAPI = 0
+LIBPATCH = 7
+
+PYDEPS = ["cosl", "pydantic < 2"]
+
+DEFAULT_RELATION_NAME = "cos-agent"
+DEFAULT_PEER_RELATION_NAME = "peers"
+DEFAULT_SCRAPE_CONFIG = {
+    "static_configs": [{"targets": ["localhost:80"]}],
+    "metrics_path": "/metrics",
+}
+
+logger = logging.getLogger(__name__)
+SnapEndpoint = namedtuple("SnapEndpoint", "owner, name")
+
+
+class CosAgentProviderUnitData(pydantic.BaseModel):
+    """Unit databag model for `cos-agent` relation."""
+
+    # The following entries are the same for all units of the same principal.
+    # Note that the same grafana agent subordinate may be related to several apps.
+    # this needs to make its way to the gagent leader
+    metrics_alert_rules: dict
+    log_alert_rules: dict
+    dashboards: List[GrafanaDashboard]
+    subordinate: Optional[bool]
+
+    # The following entries may vary across units of the same principal app.
+    # this data does not need to be forwarded to the gagent leader
+    metrics_scrape_jobs: List[Dict]
+    log_slots: List[str]
+
+    # when this whole datastructure is dumped into a databag, it will be nested under this key.
+    # while not strictly necessary (we could have it 'flattened out' into the databag),
+    # this simplifies working with the model.
+    KEY: ClassVar[str] = "config"
+
+
+class CosAgentPeersUnitData(pydantic.BaseModel):
+    """Unit databag model for `peers` cos-agent machine charm peer relation."""
+
+    # We need the principal unit name and relation metadata to be able to render identifiers
+    # (e.g. topology) on the leader side, after all the data moves into peer data (the grafana
+    # agent leader can only see its own principal, because it is a subordinate charm).
+    principal_unit_name: str
+    principal_relation_id: str
+    principal_relation_name: str
+
+    # The only data that is forwarded to the leader is data that needs to go into the app databags
+    # of the outgoing o11y relations.
+    metrics_alert_rules: Optional[dict]
+    log_alert_rules: Optional[dict]
+    dashboards: Optional[List[GrafanaDashboard]]
+
+    # when this whole datastructure is dumped into a databag, it will be nested under this key.
+    # while not strictly necessary (we could have it 'flattened out' into the databag),
+    # this simplifies working with the model.
+    KEY: ClassVar[str] = "config"
+
+    @property
+    def app_name(self) -> str:
+        """Parse out the app name from the unit name.
+
+        TODO: Switch to using `model_post_init` when pydantic v2 is released?
+          https://github.com/pydantic/pydantic/issues/1729#issuecomment-1300576214
+        """
+        return self.principal_unit_name.split("/")[0]
+
+
+class COSAgentProvider(Object):
+    """Integration endpoint wrapper for the provider side of the cos_agent interface."""
+
+    def __init__(
+        self,
+        charm: CharmType,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        metrics_endpoints: Optional[List["_MetricsEndpointDict"]] = None,
+        metrics_rules_dir: str = "./src/prometheus_alert_rules",
+        logs_rules_dir: str = "./src/loki_alert_rules",
+        recurse_rules_dirs: bool = False,
+        log_slots: Optional[List[str]] = None,
+        dashboard_dirs: Optional[List[str]] = None,
+        refresh_events: Optional[List] = None,
+        *,
+        scrape_configs: Optional[Union[List[dict], Callable]] = None,
+    ):
+        """Create a COSAgentProvider instance.
+
+        Args:
+            charm: The `CharmBase` instance that is instantiating this object.
+            relation_name: The name of the relation to communicate over.
+            metrics_endpoints: List of endpoints in the form [{"path": path, "port": port}, ...].
+                This argument is a simplified form of the `scrape_configs`.
+                The contents of this list will be merged with the contents of `scrape_configs`.
+            metrics_rules_dir: Directory where the metrics rules are stored.
+            logs_rules_dir: Directory where the logs rules are stored.
+            recurse_rules_dirs: Whether to recurse into rule paths.
+            log_slots: Snap slots to connect to for scraping logs
+                in the form ["snap-name:slot", ...].
+            dashboard_dirs: Directory where the dashboards are stored.
+            refresh_events: List of events on which to refresh relation data.
+            scrape_configs: List of standard scrape_configs dicts or a callable
+                that returns the list in case the configs need to be generated dynamically.
+                The contents of this list will be merged with the contents of `metrics_endpoints`.
+        """
+        super().__init__(charm, relation_name)
+        dashboard_dirs = dashboard_dirs or ["./src/grafana_dashboards"]
+
+        self._charm = charm
+        self._relation_name = relation_name
+        self._metrics_endpoints = metrics_endpoints or []
+        self._scrape_configs = scrape_configs or []
+        self._metrics_rules = metrics_rules_dir
+        self._logs_rules = logs_rules_dir
+        self._recursive = recurse_rules_dirs
+        self._log_slots = log_slots or []
+        self._dashboard_dirs = dashboard_dirs
+        self._refresh_events = refresh_events or [self._charm.on.config_changed]
+
+        events = self._charm.on[relation_name]
+        self.framework.observe(events.relation_joined, self._on_refresh)
+        self.framework.observe(events.relation_changed, self._on_refresh)
+        for event in self._refresh_events:
+            self.framework.observe(event, self._on_refresh)
+
+    def _on_refresh(self, event):
+        """Trigger the class to update relation data."""
+        relations = self._charm.model.relations[self._relation_name]
+
+        for relation in relations:
+            # Before a principal is related to the grafana-agent subordinate, we'd get
+            # ModelError: ERROR cannot read relation settings: unit "zk/2": settings not found
+            # Add a guard to make sure it doesn't happen.
+            if relation.data and self._charm.unit in relation.data:
+                # Subordinate relations can communicate only over unit data.
+                try:
+                    data = CosAgentProviderUnitData(
+                        metrics_alert_rules=self._metrics_alert_rules,
+                        log_alert_rules=self._log_alert_rules,
+                        dashboards=self._dashboards,
+                        metrics_scrape_jobs=self._scrape_jobs,
+                        log_slots=self._log_slots,
+                        subordinate=self._charm.meta.subordinate,
+                    )
+                    relation.data[self._charm.unit][data.KEY] = data.json()
+                except (
+                    pydantic.ValidationError,
+                    json.decoder.JSONDecodeError,
+                ) as e:
+                    logger.error("Invalid relation data provided: %s", e)
+
+    @property
+    def _scrape_jobs(self) -> List[Dict]:
+        """Return a prometheus_scrape-like data structure for jobs.
+
+        https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
+        """
+        if callable(self._scrape_configs):
+            scrape_configs = self._scrape_configs()
+        else:
+            # Create a copy of the user scrape_configs, since we will mutate this object
+            scrape_configs = self._scrape_configs.copy()
+
+        # Convert "metrics_endpoints" to standard scrape_configs, and add them in
+        for endpoint in self._metrics_endpoints:
+            scrape_configs.append(
+                {
+                    "metrics_path": endpoint["path"],
+                    "static_configs": [{"targets": [f"localhost:{endpoint['port']}"]}],
+                }
+            )
+
+        scrape_configs = scrape_configs or [DEFAULT_SCRAPE_CONFIG]
+
+        # Augment job name to include the app name and a unique id (index)
+        for idx, scrape_config in enumerate(scrape_configs):
+            scrape_config["job_name"] = "_".join(
+                [self._charm.app.name, str(idx), scrape_config.get("job_name", "default")]
+            )
+
+        return scrape_configs
+
+    @property
+    def _metrics_alert_rules(self) -> Dict:
+        """Use (for now) the prometheus_scrape AlertRules to initialize this."""
+        alert_rules = AlertRules(
+            query_type="promql", topology=JujuTopology.from_charm(self._charm)
+        )
+        alert_rules.add_path(self._metrics_rules, recursive=self._recursive)
+        return alert_rules.as_dict()
+
+    @property
+    def _log_alert_rules(self) -> Dict:
+        """Use (for now) the loki_push_api AlertRules to initialize this."""
+        alert_rules = AlertRules(query_type="logql", topology=JujuTopology.from_charm(self._charm))
+        alert_rules.add_path(self._logs_rules, recursive=self._recursive)
+        return alert_rules.as_dict()
+
+    @property
+    def _dashboards(self) -> List[GrafanaDashboard]:
+        dashboards: List[GrafanaDashboard] = []
+        for d in self._dashboard_dirs:
+            for path in Path(d).glob("*"):
+                dashboard = GrafanaDashboard._serialize(path.read_bytes())
+                dashboards.append(dashboard)
+        return dashboards
+
+
+class COSAgentDataChanged(EventBase):
+    """Event emitted by `COSAgentRequirer` when relation data changes."""
+
+
+class COSAgentValidationError(EventBase):
+    """Event emitted by `COSAgentRequirer` when there is an error in the relation data."""
+
+    def __init__(self, handle, message: str = ""):
+        super().__init__(handle)
+        self.message = message
+
+    def snapshot(self) -> Dict:
+        """Save COSAgentValidationError source information."""
+        return {"message": self.message}
+
+    def restore(self, snapshot):
+        """Restore COSAgentValidationError source information."""
+        self.message = snapshot["message"]
+
+
+class COSAgentRequirerEvents(ObjectEvents):
+    """`COSAgentRequirer` events."""
+
+    data_changed = EventSource(COSAgentDataChanged)
+    validation_error = EventSource(COSAgentValidationError)
+
+
+class MultiplePrincipalsError(Exception):
+    """Custom exception for when there are multiple principal applications."""
+
+    pass
+
+
+class COSAgentRequirer(Object):
+    """Integration endpoint wrapper for the Requirer side of the cos_agent interface."""
+
+    on = COSAgentRequirerEvents()  # pyright: ignore
+
+    def __init__(
+        self,
+        charm: CharmType,
+        *,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        peer_relation_name: str = DEFAULT_PEER_RELATION_NAME,
+        refresh_events: Optional[List[str]] = None,
+    ):
+        """Create a COSAgentRequirer instance.
+
+        Args:
+            charm: The `CharmBase` instance that is instantiating this object.
+            relation_name: The name of the relation to communicate over.
+            peer_relation_name: The name of the peer relation to communicate over.
+            refresh_events: List of events on which to refresh relation data.
+        """
+        super().__init__(charm, relation_name)
+        self._charm = charm
+        self._relation_name = relation_name
+        self._peer_relation_name = peer_relation_name
+        self._refresh_events = refresh_events or [self._charm.on.config_changed]
+
+        events = self._charm.on[relation_name]
+        self.framework.observe(
+            events.relation_joined, self._on_relation_data_changed
+        )  # TODO: do we need this?
+        self.framework.observe(events.relation_changed, self._on_relation_data_changed)
+        for event in self._refresh_events:
+            self.framework.observe(event, self.trigger_refresh)  # pyright: ignore
+
+        # Peer relation events
+        # A peer relation is needed as it is the only mechanism for exchanging data across
+        # subordinate units.
+        # self.framework.observe(
+        #     self.on[self._peer_relation_name].relation_joined, self._on_peer_relation_joined
+        # )
+        peer_events = self._charm.on[peer_relation_name]
+        self.framework.observe(peer_events.relation_changed, self._on_peer_relation_changed)
+
+    @property
+    def peer_relation(self) -> Optional["Relation"]:
+        """Helper function for obtaining the peer relation object.
+
+        Returns: peer relation object
+        (NOTE: would return None if called too early, e.g. during install).
+        """
+        return self.model.get_relation(self._peer_relation_name)
+
+    def _on_peer_relation_changed(self, _):
+        # Peer data is used for forwarding data from principal units to the grafana agent
+        # subordinate leader, for updating the app data of the outgoing o11y relations.
+        if self._charm.unit.is_leader():
+            self.on.data_changed.emit()  # pyright: ignore
+
+    def _on_relation_data_changed(self, event: RelationChangedEvent):
+        # Peer data is the only means of communication between subordinate units.
+        if not self.peer_relation:
+            event.defer()
+            return
+
+        cos_agent_relation = event.relation
+        if not event.unit or not cos_agent_relation.data.get(event.unit):
+            return
+        principal_unit = event.unit
+
+        # Coherence check
+        units = cos_agent_relation.units
+        if len(units) > 1:
+            # should never happen
+            raise ValueError(
+                f"unexpected error: subordinate relation {cos_agent_relation} "
+                f"should have exactly one unit"
+            )
+
+        if not (raw := cos_agent_relation.data[principal_unit].get(CosAgentProviderUnitData.KEY)):
+            return
+
+        if not (provider_data := self._validated_provider_data(raw)):
+            return
+
+        # Copy data from the principal relation to the peer relation, so the leader could
+        # follow up.
+        # Save the originating unit name, so it could be used for topology later on by the leader.
+        data = CosAgentPeersUnitData(  # peer relation databag model
+            principal_unit_name=event.unit.name,
+            principal_relation_id=str(event.relation.id),
+            principal_relation_name=event.relation.name,
+            metrics_alert_rules=provider_data.metrics_alert_rules,
+            log_alert_rules=provider_data.log_alert_rules,
+            dashboards=provider_data.dashboards,
+        )
+        self.peer_relation.data[self._charm.unit][
+            f"{CosAgentPeersUnitData.KEY}-{event.unit.name}"
+        ] = data.json()
+
+        # We can't easily tell if the data that was changed is limited to only the data
+        # that goes into peer relation (in which case, if this is not a leader unit, we wouldn't
+        # need to emit `on.data_changed`), so we're emitting `on.data_changed` either way.
+        self.on.data_changed.emit()  # pyright: ignore
+
+    def _validated_provider_data(self, raw) -> Optional[CosAgentProviderUnitData]:
+        try:
+            return CosAgentProviderUnitData(**json.loads(raw))
+        except (pydantic.ValidationError, json.decoder.JSONDecodeError) as e:
+            self.on.validation_error.emit(message=str(e))  # pyright: ignore
+            return None
+
+    def trigger_refresh(self, _):
+        """Trigger a refresh of relation data."""
+        # FIXME: Figure out what we should do here
+        self.on.data_changed.emit()  # pyright: ignore
+
+    @property
+    def _principal_unit(self) -> Optional[Unit]:
+        """Return the principal unit for a relation.
+
+        Assumes that the relation is of type subordinate.
+        Relies on the fact that, for subordinate relations, the only remote unit visible to
+        *this unit* is the principal unit that this unit is attached to.
+        """
+        if relations := self._principal_relations:
+            # Technically it's a list, but for subordinates there can only be one relation
+            principal_relation = next(iter(relations))
+            if units := principal_relation.units:
+                # Technically it's a list, but for subordinates there can only be one
+                return next(iter(units))
+
+        return None
+
+    @property
+    def _principal_relations(self):
+        relations = []
+        for relation in self._charm.model.relations[self._relation_name]:
+            if not json.loads(relation.data[next(iter(relation.units))]["config"]).get(
+                ["subordinate"], False
+            ):
+                relations.append(relation)
+        if len(relations) > 1:
+            logger.error(
+                "Multiple applications claiming to be principal. Update the cos-agent library in the client application charms."
+            )
+            raise MultiplePrincipalsError("Multiple principal applications.")
+        return relations
+
+    @property
+    def _remote_data(self) -> List[CosAgentProviderUnitData]:
+        """Return a list of remote data from each of the related units.
+
+        Assumes that the relation is of type subordinate.
+        Relies on the fact that, for subordinate relations, the only remote unit visible to
+        *this unit* is the principal unit that this unit is attached to.
+        """
+        all_data = []
+
+        for relation in self._charm.model.relations[self._relation_name]:
+            if not relation.units:
+                continue
+            unit = next(iter(relation.units))
+            if not (raw := relation.data[unit].get(CosAgentProviderUnitData.KEY)):
+                continue
+            if not (provider_data := self._validated_provider_data(raw)):
+                continue
+            all_data.append(provider_data)
+
+        return all_data
+
+    def _gather_peer_data(self) -> List[CosAgentPeersUnitData]:
+        """Collect data from the peers.
+
+        Returns a trimmed-down list of CosAgentPeersUnitData.
+        """
+        relation = self.peer_relation
+
+        # Ensure that whatever context we're running this in, we take the necessary precautions:
+        if not relation or not relation.data or not relation.app:
+            return []
+
+        # Iterate over all peer unit data and only collect every principal once.
+        peer_data: List[CosAgentPeersUnitData] = []
+        app_names: Set[str] = set()
+
+        for unit in chain((self._charm.unit,), relation.units):
+            if not relation.data.get(unit):
+                continue
+
+            for unit_name in relation.data.get(unit):  # pyright: ignore
+                if not unit_name.startswith(CosAgentPeersUnitData.KEY):
+                    continue
+                raw = relation.data[unit].get(unit_name)
+                if raw is None:
+                    continue
+                data = CosAgentPeersUnitData(**json.loads(raw))
+                # Have we already seen this principal app?
+                if (app_name := data.app_name) in app_names:
+                    continue
+                peer_data.append(data)
+                app_names.add(app_name)
+
+        return peer_data
+
+    @property
+    def metrics_alerts(self) -> Dict[str, Any]:
+        """Fetch metrics alerts."""
+        alert_rules = {}
+
+        seen_apps: List[str] = []
+        for data in self._gather_peer_data():
+            if rules := data.metrics_alert_rules:
+                app_name = data.app_name
+                if app_name in seen_apps:
+                    continue  # dedup!
+                seen_apps.append(app_name)
+                # This is only used for naming the file, so be as specific as we can be
+                identifier = JujuTopology(
+                    model=self._charm.model.name,
+                    model_uuid=self._charm.model.uuid,
+                    application=app_name,
+                    # For the topology unit, we could use `data.principal_unit_name`, but that unit
+                    # name may not be very stable: `_gather_peer_data` de-duplicates by app name so
+                    # the exact unit name that turns up first in the iterator may vary from time to
+                    # time. So using the grafana-agent unit name instead.
+                    unit=self._charm.unit.name,
+                ).identifier
+
+                alert_rules[identifier] = rules
+
+        return alert_rules
+
+    @property
+    def metrics_jobs(self) -> List[Dict]:
+        """Parse the relation data contents and extract the metrics jobs."""
+        scrape_jobs = []
+        for data in self._remote_data:
+            for job in data.metrics_scrape_jobs:
+                # In #220, relation schema changed from a simplified dict to the standard
+                # `scrape_configs`.
+                # This is to ensure backwards compatibility with Providers older than v0.5.
+                if "path" in job and "port" in job and "job_name" in job:
+                    job = {
+                        "job_name": job["job_name"],
+                        "metrics_path": job["path"],
+                        "static_configs": [{"targets": [f"localhost:{job['port']}"]}],
+                        # We include insecure_skip_verify because we are always scraping localhost.
+                        # Even if we have the certs for the scrape targets, we'd rather specify the scrape
+                        # jobs with localhost rather than the SAN DNS the cert was issued for.
+                        "tls_config": {"insecure_skip_verify": True},
+                    }
+
+                scrape_jobs.append(job)
+
+        return scrape_jobs
+
+    @property
+    def snap_log_endpoints(self) -> List[SnapEndpoint]:
+        """Fetch logging endpoints exposed by related snaps."""
+        plugs = []
+        for data in self._remote_data:
+            targets = data.log_slots
+            if targets:
+                for target in targets:
+                    if target in plugs:
+                        logger.warning(
+                            f"plug {target} already listed. "
+                            "The same snap is being passed from multiple "
+                            "endpoints; this should not happen."
+                        )
+                    else:
+                        plugs.append(target)
+
+        endpoints = []
+        for plug in plugs:
+            if ":" not in plug:
+                logger.error(f"invalid plug definition received: {plug}. Ignoring...")
+            else:
+                endpoint = SnapEndpoint(*plug.split(":"))
+                endpoints.append(endpoint)
+        return endpoints
+
+    @property
+    def logs_alerts(self) -> Dict[str, Any]:
+        """Fetch log alerts."""
+        alert_rules = {}
+        seen_apps: List[str] = []
+
+        for data in self._gather_peer_data():
+            if rules := data.log_alert_rules:
+                # This is only used for naming the file, so be as specific as we can be
+                app_name = data.app_name
+                if app_name in seen_apps:
+                    continue  # dedup!
+                seen_apps.append(app_name)
+
+                identifier = JujuTopology(
+                    model=self._charm.model.name,
+                    model_uuid=self._charm.model.uuid,
+                    application=app_name,
+                    # For the topology unit, we could use `data.principal_unit_name`, but that unit
+                    # name may not be very stable: `_gather_peer_data` de-duplicates by app name so
+                    # the exact unit name that turns up first in the iterator may vary from time to
+                    # time. So using the grafana-agent unit name instead.
+                    unit=self._charm.unit.name,
+                ).identifier
+
+                alert_rules[identifier] = rules
+
+        return alert_rules
+
+    @property
+    def dashboards(self) -> List[Dict[str, str]]:
+        """Fetch dashboards as encoded content.
+
+        Dashboards are assumed not to vary across units of the same primary.
+        """
+        dashboards: List[Dict[str, Any]] = []
+
+        seen_apps: List[str] = []
+        for data in self._gather_peer_data():
+            app_name = data.app_name
+            if app_name in seen_apps:
+                continue  # dedup!
+            seen_apps.append(app_name)
+
+            for encoded_dashboard in data.dashboards or ():
+                content = GrafanaDashboard(encoded_dashboard)._deserialize()
+
+                title = content.get("title", "no_title")
+
+                dashboards.append(
+                    {
+                        "relation_id": data.principal_relation_id,
+                        # We have the remote charm name - use it for the identifier
+                        "charm": f"{data.principal_relation_name}-{app_name}",
+                        "content": content,
+                        "title": title,
+                    }
+                )
+
+        return dashboards

--- a/charms/worker/k8s/requirements.txt
+++ b/charms/worker/k8s/requirements.txt
@@ -1,4 +1,5 @@
 ops >= 2.2.0
+cosl == 0.0.8
 pydantic == 1.*
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler
 charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -252,6 +252,9 @@ class K8sCharm(ops.CharmBase):
         if match:
             return match.group()
 
+        log.info("Snap k8s not found or no version available.")
+        return None
+
     def _request_token(self, relation):
         """Request a token by setting the node name in the relation data.
 

--- a/charms/worker/k8s/src/cos_integration.py
+++ b/charms/worker/k8s/src/cos_integration.py
@@ -1,3 +1,6 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 """COS Integration module."""
 
 import logging

--- a/charms/worker/k8s/src/cos_integration.py
+++ b/charms/worker/k8s/src/cos_integration.py
@@ -1,0 +1,192 @@
+"""COS Integration module."""
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, List
+
+import ops
+
+log = logging.getLogger(__name__)
+
+OBSERVABILITY_ROLE = "system:cos"
+
+
+@dataclass
+class JobConfig:
+    """Data class representing the configuration for a Prometheus scrape job.
+
+    Attributes:
+        name (str): The name of the scrape job. Corresponds to the name of the Kubernetes
+                    component being monitored (e.g., 'kube-apiserver').
+        metrics_path (str): The endpoint path where the metrics are exposed by the
+                            component (e.g., '/metrics').
+        scheme (str): The scheme used for the endpoint. (e.g.'http' or 'https').
+        target (str): The network address of the target component along with
+                      the port.
+                      Format is 'hostname:port' (e.g., 'localhost:6443').
+        relabel_configs (List[Dict[str, str | List[str]]]): Additional
+                      configurations for relabeling.
+    """
+
+    name: str
+    metrics_path: str
+    scheme: str
+    target: str
+    relabel_configs: List[Dict[str, str | List[str]]]
+
+
+class COSIntegration(ops.Object):
+    """Utility class that handles the integration with COS.
+
+    This class provides methods to retrieve and configure Prometheus metrics
+    scraping endpoints based on the Kubernetes components running within
+    the cluster.
+
+    Attributes:
+        charm (CharmBase): Reference to the base charm instance.
+    """
+
+    _stored = ops.StoredState()
+
+    def __init__(self, charm) -> None:
+        """Initialize a COSIntegration instance.
+
+        Args:
+            charm (CharmBase): A charm object representing the current charm.
+        """
+        super().__init__(charm, "cos-integration")
+        self.charm = charm
+        self._stored.set_default(token="")
+
+    def save_token(self, token: str):
+        """Save the token in the StoredState.
+
+        Args:
+            token (str): A token to save in the StoredState instance.
+        """
+        self._stored.token = token
+
+    def _create_scrape_job(self, config: JobConfig, node_name: str, token: str) -> dict:
+        """Create a scrape job configuration.
+
+        Args:
+            config (JobConfig): The configuration for the scrape job.
+            node_name (str): The name of the node.
+            token (str): The token for authorization.
+
+        Returns:
+            dict: The scrape job configuration.
+        """
+        return {
+            "tls_config": {"insecure_skip_verify": True},
+            "authorization": {"credentials": token},
+            "job_name": config.name,
+            "metrics_path": config.metrics_path,
+            "scheme": config.scheme,
+            "static_configs": [
+                {
+                    "targets": [config.target],
+                    "labels": {"node": node_name, "cluster": self.charm.model.name},
+                }
+            ],
+            "relabel_configs": config.relabel_configs,
+        }
+
+    def get_metrics_endpoints(self) -> list:
+        """Return the metrics endpoints for K8s components.
+
+        Returns:
+            list: A list of Prometheus scrape job configurations.
+        """
+        log.info("Building Prometheus scraping jobs.")
+
+        if not self._stored.token:
+            log.info("COS token not yet available")
+            return []
+
+        control_plane_jobs = [
+            JobConfig(
+                "apiserver",
+                "/metrics",
+                "https",
+                "localhost:6443",
+                [
+                    {
+                        "source_labels": ["job"],
+                        "target_label": "job",
+                        "replacement": "apiserver",
+                    }
+                ],
+            ),
+            JobConfig(
+                "kube-scheduler",
+                "/metrics",
+                "https",
+                "localhost:10259",
+                [{"target_label": "job", "replacement": "kube-scheduler"}],
+            ),
+            JobConfig(
+                "kube-controller-manager",
+                "/metrics",
+                "https",
+                "localhost:10257",
+                [{"target_label": "job", "replacement": "kube-controller-manager"}],
+            ),
+        ]
+
+        shared_jobs = [
+            JobConfig(
+                "kube-proxy",
+                "/metrics",
+                "http",
+                "localhost:10249",
+                [{"target_label": "job", "replacement": "kube-proxy"}],
+            ),
+        ]
+
+        kubelet_metrics_paths = [
+            "/metrics",
+            "/metrics/resource",
+            "/metrics/cadvisor",
+            "/metrics/probes",
+        ]
+
+        kubelet_jobs = [
+            JobConfig(
+                f"kubelet-{metric}" if metric else "kubelet",
+                path,
+                "https",
+                "localhost:10250",
+                [
+                    {"target_label": "metrics_path", "replacement": path},
+                    {"target_label": "job", "replacement": "kubelet"},
+                ],
+            )
+            for path in kubelet_metrics_paths
+            if (metric := path.strip("/metrics")) is not None
+        ]
+        kube_state_metrics = (
+            [
+                JobConfig(
+                    "kube-state-metrics",
+                    "/api/v1/namespaces/kube-system/services/"
+                    + "kube-state-metrics:8080/proxy/metrics",
+                    "https",
+                    "localhost:6443",
+                    [
+                        {"target_label": "job", "replacement": "kube-state-metrics"},
+                    ],
+                )
+            ]
+            if self.charm.unit.is_leader()
+            else []
+        )
+
+        jobs = shared_jobs + kubelet_jobs
+        if self.charm.is_control_plane:
+            jobs += control_plane_jobs + kube_state_metrics
+
+        return [
+            self._create_scrape_job(job, self.charm.get_node_name(), self._stored.token)
+            for job in jobs
+        ]

--- a/charms/worker/k8s/src/token_distributor.py
+++ b/charms/worker/k8s/src/token_distributor.py
@@ -1,3 +1,6 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 """Token Distributor module."""
 
 from enum import Enum, auto

--- a/charms/worker/k8s/src/token_distributor.py
+++ b/charms/worker/k8s/src/token_distributor.py
@@ -1,0 +1,120 @@
+"""Token Distributor module."""
+
+from enum import Enum, auto
+
+import ops
+from charms.k8s.v0.k8sd_api_manager import K8sdAPIManager
+from ops import CharmBase
+
+
+class TokenStrategy(Enum):
+    """Enumeration defining strategy for token creation.
+
+    Attributes:
+        CLUSTER: Strategy for creating cluster tokens.
+        COS: Strategy for creating COS tokens.
+    """
+
+    CLUSTER = auto()
+    COS = auto()
+
+
+class ClusterTokenType(Enum):
+    """Enumeration defining types for cluster tokens.
+
+    Attributes:
+        CONTROL_PLANE: Token type for control plane.
+        WORKER: Token type for worker nodes.
+        NONE: No specific token type.
+    """
+
+    CONTROL_PLANE = "control-plane"
+    WORKER = "worker"
+    NONE = ""
+
+
+class TokenDistributor:
+    """Helper class for distributing tokens to units in a relation."""
+
+    def __init__(self, api_manager: K8sdAPIManager, charm: CharmBase):
+        """Initialize a TokenDistributor instance.
+
+        Args:
+            api_manager: An K8sdAPIManager object for interacting with k8sd API.
+            charm (CharmBase): A charm object representing the current charm.
+        """
+        self.api_manager = api_manager
+        self.charm = charm
+        self.token_creation_strategies = {
+            TokenStrategy.CLUSTER: self._create_cluster_token,
+            TokenStrategy.COS: self._create_cos_token,
+        }
+
+    def _create_cluster_token(self, name: str, token_type: ClusterTokenType):
+        """Create a cluster token.
+
+        Args:
+            name (str): The name of the node.
+            token_type (ClusterTokenType): The type of cluster token.
+
+        Returns:
+            str: The created cluster token.
+        """
+        worker = token_type == ClusterTokenType.WORKER
+        return self.api_manager.create_join_token(name, worker=worker)
+
+    def _create_cos_token(self, name: str, _):
+        """Create a COS token.
+
+        Args:
+            name (str): The name of the node.
+
+        Returns:
+            str: The created COS token.
+        """
+        return self.api_manager.request_auth_token(
+            username=f"system:cos:{name}", groups=["system:cos"]
+        )
+
+    def distribute_tokens(
+        self,
+        relation: ops.Relation,
+        token_strategy: TokenStrategy,
+        token_type: ClusterTokenType = ClusterTokenType.NONE,
+    ):
+        """Distribute tokens to units in a relation.
+
+        Args:
+            relation (ops.Relation): The relation object.
+            token_strategy (TokenStrategy): The strategy of token creation.
+            token_type (ClusterTokenType, optional): The type of cluster token.
+                Defaults to ClusterTokenType.NONE.
+
+        Raises:
+            ValueError: If an invalid token_strategy is provided.
+        """
+        units = {u for u in relation.units if u.name != self.charm.unit.name}
+        app_databag: ops.RelationDataContent | dict[str, str] = relation.data.get(
+            self.charm.model.app, {}
+        )
+        sec_key_suffix = (
+            "-cluster-secret" if token_strategy == TokenStrategy.CLUSTER else "-cos-secret"
+        )
+
+        for unit in units:
+            sec_key = f"{unit.name}{sec_key_suffix}"
+            if app_databag.get(sec_key):
+                continue
+            if not (name := relation.data[unit].get("node-name")):
+                continue  # wait for the joining unit to provide its node-name
+
+            # Select the appropriate token creation strategy
+            token_creator = self.token_creation_strategies.get(token_strategy)
+            if not token_creator:
+                raise ValueError(f"Invalid token_strategy: {token_strategy}")
+
+            token = token_creator(name, token_type)
+            content = {"token": token}
+            secret = self.charm.app.add_secret(content)
+            secret.grant(relation, unit=unit)
+            relation.data[self.charm.app][sec_key] = secret.id or ""

--- a/charms/worker/k8s/src/token_distributor.py
+++ b/charms/worker/k8s/src/token_distributor.py
@@ -81,6 +81,7 @@ class TokenDistributor:
         relation: ops.Relation,
         token_strategy: TokenStrategy,
         token_type: ClusterTokenType = ClusterTokenType.NONE,
+        all_units: bool = False,
     ):
         """Distribute tokens to units in a relation.
 
@@ -89,11 +90,16 @@ class TokenDistributor:
             token_strategy (TokenStrategy): The strategy of token creation.
             token_type (ClusterTokenType, optional): The type of cluster token.
                 Defaults to ClusterTokenType.NONE.
+            all_units (bool, optional): Whether to include all units in the relation.
+                Defaults to False.
 
         Raises:
             ValueError: If an invalid token_strategy is provided.
         """
-        units = {u for u in relation.units if u.name != self.charm.unit.name}
+        units = relation.units
+        if all_units:
+            units.add(self.charm.unit)
+
         app_databag: ops.RelationDataContent | dict[str, str] = relation.data.get(
             self.charm.model.app, {}
         )

--- a/charms/worker/k8s/templates/cos_roles.yaml
+++ b/charms/worker/k8s/templates/cos_roles.yaml
@@ -1,3 +1,6 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charms/worker/k8s/templates/cos_roles.yaml
+++ b/charms/worker/k8s/templates/cos_roles.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:cos
+rules:
+- apiGroups: [""]
+  resources:
+  - "nodes/metrics"
+  - "pods/metrics"
+  - "services/metrics"
+  - "services"
+  - "services/proxy"
+  - "nodes/proxy"
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cos
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cos
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:cos

--- a/charms/worker/k8s/templates/ksm.yaml
+++ b/charms/worker/k8s/templates/ksm.yaml
@@ -1,0 +1,238 @@
+# Source: https://raw.githubusercontent.com/kubernetes/kube-state-metrics/v2.9.2/examples/standard/cluster-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.9.2
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: kube-system
+---
+# Source: https://raw.githubusercontent.com/kubernetes/kube-state-metrics/v2.9.2/examples/standard/cluster-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.9.2
+  name: kube-state-metrics
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - nodes
+  - pods
+  - services
+  - serviceaccounts
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  - ingressclasses
+  - ingresses
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - list
+  - watch
+---
+# Source: https://raw.githubusercontent.com/kubernetes/kube-state-metrics/v2.9.2/examples/standard/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.9.2
+  name: kube-state-metrics
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/version: 2.9.2
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        name: kube-state-metrics
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 8081
+          name: telemetry
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8081
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: kube-state-metrics
+---
+# Source: https://raw.githubusercontent.com/kubernetes/kube-state-metrics/v2.9.2/examples/standard/service-account.yaml
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.9.2
+  name: kube-state-metrics
+  namespace: kube-system
+---
+# Source: https://raw.githubusercontent.com/kubernetes/kube-state-metrics/v2.9.2/examples/standard/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.9.2
+  name: kube-state-metrics
+  namespace: kube-system
+spec:
+  clusterIP: None
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: http-metrics
+  - name: telemetry
+    port: 8081
+    targetPort: telemetry
+  selector:
+    app.kubernetes.io/name: kube-state-metrics

--- a/charms/worker/k8s/templates/ksm.yaml
+++ b/charms/worker/k8s/templates/ksm.yaml
@@ -1,3 +1,6 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Source: https://raw.githubusercontent.com/kubernetes/kube-state-metrics/v2.9.2/examples/standard/cluster-role-binding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Overview

Implement the `cos-agent` integration for `k8s` and `k8s-worker` charms.

## Rationale

This pull request introduces an implementation for integrating our charms with the Canonical Observability Stack. In this first version, we demonstrate the capabilities of sending scrape jobs to Prometheus over relation data for the following Kubernetes components:
1. **Kubernetes Control Plane (`k8s`):**
   - Kube API Server
   - Kube Controller Manager
   - Kube Proxy
   - Kube Scheduler
   - Kubelet
     - cAdvisor
     - Probes
   - Kube State Metrics
2. **Kubernetes Worker (`k8s-worker`):**
   - Kubelet
     - cAdvisor
     - Probes
   - Kube Proxy

This initial version of the integration relies on manual testing. Integration tests will be introduced in future PRs.

### Module Changes

- Introduced a new `TokenDistributor` module to generalize token distribution for the `cluster` and `cos-tokens` relations.
- Introduced a `COSIntegration` helper class to generate Prometheus scrape jobs for the Kubernetes components.

### Library Changes

- Added `cos-agent` library.
- Added `cosl` package.
