### PR TITLE
Handle using a cluster token to join only once

### DIFF
--- a/charms/worker/k8s/src/token_distributor.py
+++ b/charms/worker/k8s/src/token_distributor.py
@@ -3,11 +3,11 @@
 
 """Token Distributor module."""
 
+import contextlib
 from enum import Enum, auto
 
 import ops
 from charms.k8s.v0.k8sd_api_manager import K8sdAPIManager
-from ops import CharmBase
 
 
 class TokenStrategy(Enum):
@@ -36,18 +36,86 @@ class ClusterTokenType(Enum):
     NONE = ""
 
 
+class TokenCollector:
+    """Helper class for collecting tokens for units in a relation."""
+
+    def __init__(self, charm: ops.CharmBase, node_name: str):
+        """Initialize a TokenCollector instance.
+
+        Args:
+            charm (CharmBase): A charm object representing the current charm.
+            node_name (str): current node's name
+        """
+        self.charm = charm
+        self.node_name = node_name
+
+    def joined(self, relation: ops.Relation) -> bool:
+        """Report if this unit has completed token transfer.
+
+        Args:
+            relation (ops.Relation): The relation to check
+
+        Returns:
+            bool: if the local unit is joined on this relation.
+        """
+        data = relation.data[self.charm.unit].get("joined")
+        return data == self.node_name
+
+    def request(self, relation: ops.Relation):
+        """Ensure this unit is requesting a token.
+
+        Args:
+            relation (ops.Relation): The relation on which to request
+        """
+        # the presence of node-name is used to request a token
+        relation.data[self.charm.unit]["node-name"] = self.node_name
+
+    @contextlib.contextmanager
+    def recover_token(self, relation: ops.Relation):
+        """Request, recover token, and acknowledge token once used.
+
+        Args:
+            relation (ops.Relation): The relation to check
+
+        Yields:
+            str: extracted token content
+        """
+        self.request(relation)
+
+        # Read the secret-id from the relation
+        secret_key = f"{self.charm.unit.name}-secret-id"
+        secret_ids = {
+            secret_id
+            for unit in relation.units
+            if (secret_id := relation.data[unit].get(secret_key))
+        }
+
+        assert len(secret_ids) == 1, f"Failed to find 1 {relation.name}:{secret_key}"  # nosec
+        (secret_id,) = secret_ids
+        assert secret_id, f"{relation.name}:{secret_key} is not valid"  # nosec
+        secret = self.charm.model.get_secret(id=secret_id)
+
+        # Get the content from the secret
+        content = secret.get_content(refresh=True)
+        assert content["token"], f"{relation.name}:token not valid"  # nosec
+        yield content["token"]
+
+        # signal that the relation is joined, the token is used
+        relation.data[self.charm.unit]["joined"] = self.node_name
+
+
 class TokenDistributor:
     """Helper class for distributing tokens to units in a relation."""
 
-    def __init__(self, api_manager: K8sdAPIManager, charm: CharmBase):
+    def __init__(self, charm: ops.CharmBase, api_manager: K8sdAPIManager):
         """Initialize a TokenDistributor instance.
 
         Args:
-            api_manager: An K8sdAPIManager object for interacting with k8sd API.
             charm (CharmBase): A charm object representing the current charm.
+            api_manager: An K8sdAPIManager object for interacting with k8sd API.
         """
-        self.api_manager = api_manager
         self.charm = charm
+        self.api_manager = api_manager
         self.token_creation_strategies = {
             TokenStrategy.CLUSTER: self._create_cluster_token,
             TokenStrategy.COS: self._create_cos_token,
@@ -84,7 +152,7 @@ class TokenDistributor:
         relation: ops.Relation,
         token_strategy: TokenStrategy,
         token_type: ClusterTokenType = ClusterTokenType.NONE,
-        all_units: bool = False,
+        invalidate_on_join: bool = False,
     ):
         """Distribute tokens to units in a relation.
 
@@ -93,29 +161,26 @@ class TokenDistributor:
             token_strategy (TokenStrategy): The strategy of token creation.
             token_type (ClusterTokenType, optional): The type of cluster token.
                 Defaults to ClusterTokenType.NONE.
-            all_units (bool, optional): Whether to include all units in the relation.
+            invalidate_on_join (bool, optional): Whether to pop the token once remote is joined
                 Defaults to False.
 
         Raises:
             ValueError: If an invalid token_strategy is provided.
         """
-        units = relation.units
-        if all_units:
-            units.add(self.charm.unit)
-
-        app_databag: ops.RelationDataContent | dict[str, str] = relation.data.get(
-            self.charm.model.app, {}
-        )
-        sec_key_suffix = (
-            "-cluster-secret" if token_strategy == TokenStrategy.CLUSTER else "-cos-secret"
-        )
+        units = relation.units | {self.charm.unit}
+        app = relation.app
+        assert app, f"Remote application doesn't exist on {relation.name}"  # nosec
 
         for unit in units:
-            sec_key = f"{unit.name}{sec_key_suffix}"
-            if app_databag.get(sec_key):
-                continue
+            secret_id = f"{unit.name}-secret-id"
             if not (name := relation.data[unit].get("node-name")):
                 continue  # wait for the joining unit to provide its node-name
+            if relation.data[unit].get("joined") == name:
+                if invalidate_on_join:
+                    relation.data[self.charm.unit].pop(secret_id, None)
+                continue  # unit reports its joined already
+            if relation.data[self.charm.unit].get(secret_id):
+                continue  # unit already assigned a token
 
             # Select the appropriate token creation strategy
             token_creator = self.token_creation_strategies.get(token_strategy)
@@ -124,6 +189,6 @@ class TokenDistributor:
 
             token = token_creator(name, token_type)
             content = {"token": token}
-            secret = self.charm.app.add_secret(content)
+            secret = app.add_secret(content)
             secret.grant(relation, unit=unit)
-            relation.data[self.charm.app][sec_key] = secret.id or ""
+            relation.data[self.charm.unit][secret_id] = secret.id or ""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -194,7 +194,7 @@ async def kubernetes_cluster(request: pytest.FixtureRequest, ops_test: OpsTest):
             application_name=charm.app_name,
             resources=charm.resources,
             series="jammy",
-            num_units=1 if charm.app_name == "k8s-worker" else 2,
+            num_units=2 if charm.app_name == "k8s-worker" else 3,
         )
         for path, charm in zip(charm_files, charms)
     ]


### PR DESCRIPTION
### Overview

* Make the secret-id transfer complete over unit data relation so that workers non-leaders can read the secret-id

### Rationale

k8s-workers that are non leaders couldn't read from the app relation data. Therefore, we must use the unit data for transferring the secret-ids

### Juju Events Changes

None

### Module Changes

Move the token request into token_distrobution.py as well.

### Library Changes

None

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
