### PR TITLE
Chore: Crashdump as root with the journalctl from k8s snap

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -89,7 +89,12 @@ deps =
     pytest-operator
     tenacity
 commands =
-    pytest -v --tb native --log-cli-level=INFO -s {toxinidir}/tests/integration {posargs}
+    pytest -v --tb native \
+      --log-cli-level=INFO \
+      -s {toxinidir}/tests/integration \
+      --crash-dump=on-failure \
+      --crash-dump-args='-j snap.k8s.* --as-root' \
+      {posargs}
 
 [testenv:src-docs]
 allowlist_externals=sh


### PR DESCRIPTION
Run integration tests with juju-crashdump so that CI failures can be evaluated