### PR TITLE
Chore/reusable kubernetes fixture

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -167,8 +167,6 @@ async def deploy_model(
         )
     with ops_test.model_context(model_name) as the_model:
         async with ops_test.fast_forward():
-            # if not all(a in the_model.applications for a in bundle.applications):
-            #     await the_model.deploy(bundle.render)
             await the_model.deploy(bundle.render)
             await the_model.wait_for_idle(
                 apps=list(bundle.applications),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -124,8 +124,8 @@ class Bundle:
         yaml.safe_dump(self.content, target.open("w"))
         return target
 
-    def swap_application(self, name: str, path: Path):
-        """Replace existing application with a local charm path.
+    def switch(self, name: str, path: Path):
+        """Replace charmhub application with a local charm path.
 
         Args:
             name (str):  Which application
@@ -188,6 +188,6 @@ async def kubernetes_cluster(request: pytest.FixtureRequest, ops_test: OpsTest):
     )
     bundle = Bundle(ops_test, Path(__file__).parent / "test-bundle.yaml")
     for path, charm in zip(charm_files, charms):
-        bundle.swap_application(charm.app_name, path)
+        bundle.switch(charm.app_name, path)
     async with deploy_model(request, ops_test, model, bundle) as the_model:
         yield the_model

--- a/tests/integration/test-bundle.yaml
+++ b/tests/integration/test-bundle.yaml
@@ -1,0 +1,15 @@
+name: integration-test
+description: |-
+  Used to deploy or refresh within an integration test model
+series: focal
+applications:
+  k8s:
+    charm: k8s
+    channel: latest/edge
+    num_units: 3
+  k8s-worker:
+    charm: k8s-worker
+    channel: latest/edge
+    num_units: 2
+relations:
+  - [k8s, k8s-worker:cluster]

--- a/tests/integration/test-bundle.yaml
+++ b/tests/integration/test-bundle.yaml
@@ -1,3 +1,6 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 name: integration-test
 description: |-
   Used to deploy or refresh within an integration test model

--- a/tests/integration/test-bundle.yaml
+++ b/tests/integration/test-bundle.yaml
@@ -1,7 +1,7 @@
 name: integration-test
 description: |-
   Used to deploy or refresh within an integration test model
-series: focal
+series: jammy
 applications:
   k8s:
     charm: k8s


### PR DESCRIPTION
Improves the `kubernetes_cluster` fixture to make it more reusable

Key improvements:
* if a user runs without `--model=whatever`, a new model is generated -- a fresh deployment occurs
* if a user runs with `--model=whatever` and that model doesn't exist -- a fresh deployment occurs
* if a user runs with `--model=whatever` and that model exists, but has no apps -- a fresh deployment occurs
* if a user runs with `--model=whatever` and that model exists, with apps -- an upgraded deployment occurs
* It uses an honest-to-gosh bundle file to reason about the charms deployed and relations.

