### PR TITLE
the snaps set the node-role labels, the charm only now worries about custom labels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ Since the same charm code is executed on the worker and control-plane, in some u
 
 This repo uses `pytest` and `pytest-operator` to execute functional/integration tests against the charm files. The integration tests are defined in `./tests/integration`. Because this repo consists of two charms, the integration tests will build two charm files automatically without you doing anything. If you want to use specific charm files, just make sure the `.charm` files are in the top-level paths and the integration tests will find them if they are named appropriately (eg `./k8s-worker_*.charm` or `k8s_*.charm`). The charms are deployed according to the bundle defined in `./tests/integration/test-bundle.yaml`.
 
-It's required you have a bootstrapped [juju machine controller](https://juju.is/docs/juju/manage-controllers) available. Usually, one prefers to have a controller available from their development machine to a supported cloud like `lxd` or `aws`. You can test if the controller is available by runnning:
+It's required you have a bootstrapped [juju machine controller](https://juju.is/docs/juju/manage-controllers) available. Usually, one prefers to have a controller available from their development machine to a supported cloud like `lxd` or `aws`. You can test if the controller is available by running:
 
 ```shell
 juju status -m controller
@@ -117,6 +117,6 @@ tox run -e integration-tests -- --positional --arguments
 `-k regex-pattern`: run a specific set of matching tests names ignore other passing tests
 Remember that cloud costs could be incurred for every machine -- so be sure to clean up your models on clouds if you instruct pytest-operator to not clean up the models. 
 
-See [pytest-operator](https://github.com/charmed-kubernetes/pytest-operator/blob/main/docs/reference.md) and [pytest](https://docs.pytest.org/en/7.1.x/contents.html) for more documenation on `pytest` arguments
+See [pytest-operator](https://github.com/charmed-kubernetes/pytest-operator/blob/main/docs/reference.md) and [pytest](https://docs.pytest.org/en/7.1.x/contents.html) for more documentation on `pytest` arguments
 
 

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -56,7 +56,7 @@ config:
       type: string
       description: Snap channel of the k8s snap
     labels:
-      default: "node-role.kubernetes.io/control-plane="
+      default: ""
       type: string
       description: |
         Labels can be used to organize and to select subsets of nodes in the

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -79,6 +79,9 @@ class K8sCharm(ops.CharmBase):
         self.reconciler = Reconciler(self, self._reconcile)
         self.distributor = TokenDistributor(self, self.get_node_name(), self.api_manager)
         self.collector = TokenCollector(self, self.get_node_name())
+        self.labeler = LabelMaker(
+            self, kubeconfig_path=self._source_kubeconfig, kubectl=KUBECTL_PATH
+        )
         self._stored.set_default(removing=False)
 
         self.cos_agent = COSAgentProvider(
@@ -438,9 +441,8 @@ class K8sCharm(ops.CharmBase):
         """Apply labels to the node."""
         status.add(ops.MaintenanceStatus("Apply Node Labels"))
         node = self.get_node_name()
-        labeler = LabelMaker(self, kubeconfig_path=self._source_kubeconfig, kubectl=KUBECTL_PATH)
-        if labeler.active_labels() is not None:
-            labeler.apply_node_labels()
+        if self.labeler.active_labels() is not None:
+            self.labeler.apply_node_labels()
             log.info("Node %s labelled successfully", node)
         else:
             log.info("Node %s not yet labelled", node)


### PR DESCRIPTION
### Overview

Resolves an issue where the charm didn't remove labels it had added via config.
Removes unnecessary management of the node role label

### Rationale

in order to use `ops.StoredState`, the `ops.Object` in `LabelMaker` must have a lifetime equal to the `ops.CharmBase` otherwise the framework cannot run it's `on_commit` handler to actually save the state. 

This PR  changes `LabelMaker(...)` to be owned by the Charm itself as an attribute (`self._labeler`) rather than constructing the labeler in the `apply_node_labels` handler
