### PR TITLE
Include `UserFacingClusterConfig`

### DIFF
--- a/charms/worker/k8s/tests/unit/test_base.py
+++ b/charms/worker/k8s/tests/unit/test_base.py
@@ -49,7 +49,7 @@ def mock_reconciler_handlers(harness):
     if harness.charm.is_control_plane:
         handler_names |= {
             "_bootstrap_k8s_snap",
-            "_enable_components",
+            "_enable_functionalities",
             "_create_cluster_tokens",
             "_create_cos_tokens",
             "_apply_cos_requirements",

--- a/charms/worker/k8s/tests/unit/test_k8sd_api_manager.py
+++ b/charms/worker/k8s/tests/unit/test_k8sd_api_manager.py
@@ -13,12 +13,15 @@ from lib.charms.k8s.v0.k8sd_api_manager import (
     AuthTokenResponse,
     BaseRequestModel,
     CreateJoinTokenResponse,
+    DNSConfig,
     EmptyResponse,
     InvalidResponseError,
     K8sdAPIManager,
     K8sdConnectionError,
     TokenMetadata,
     UnixSocketHTTPConnection,
+    UpdateClusterConfigRequest,
+    UserFacingClusterConfig,
 )
 
 
@@ -208,24 +211,18 @@ class TestK8sdAPIManager(unittest.TestCase):
         )
 
     @patch("lib.charms.k8s.v0.k8sd_api_manager.K8sdAPIManager._send_request")
-    def test_enable_component__enable(self, mock_send_request):
+    def test_update_cluster_config(self, mock_send_request):
         mock_send_request.return_value = EmptyResponse(status_code=200, type="test", error_code=0)
 
-        self.api_manager.enable_component("foo", True)
+        dns_config = DNSConfig(enabled=True)
+        user_config = UserFacingClusterConfig(dns=dns_config)
+        request = UpdateClusterConfigRequest(config=user_config)
+        self.api_manager.update_cluster_config(request)
         mock_send_request.assert_called_once_with(
-            "/1.0/k8sd/components/foo",
+            "/1.0/k8sd/cluster/config",
             "PUT",
             EmptyResponse,
-            {"status": "enabled"},
-        )
-
-    @patch("lib.charms.k8s.v0.k8sd_api_manager.K8sdAPIManager._send_request")
-    def test_enable_component__disable(self, mock_send_request):
-        mock_send_request.return_value = EmptyResponse(status_code=200, type="test", error_code=0)
-
-        self.api_manager.enable_component("foo", False)
-        mock_send_request.assert_called_once_with(
-            "/1.0/k8sd/components/foo", "PUT", EmptyResponse, {"status": "disabled"}
+            {"config": {"dns": {"enabled": True}}},
         )
 
     @patch("lib.charms.k8s.v0.k8sd_api_manager.K8sdAPIManager._send_request")

--- a/tox.ini
+++ b/tox.ini
@@ -84,9 +84,10 @@ commands =
 description = Run integration tests
 deps =
     juju
+    pylxd
     pytest
     pytest-asyncio
-    pytest-operator
+    pytest-operator @ git+https://github.com/charmed-kubernetes/pytest-operator@akd/add-k8s-alpha
     tenacity
 commands =
     pytest -v --tb native \

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ deps =
     pylxd
     pytest
     pytest-asyncio
-    pytest-operator @ git+https://github.com/charmed-kubernetes/pytest-operator@akd/add-k8s-alpha
+    pytest-operator
     tenacity
 commands =
     pytest -v --tb native \

--- a/tox.ini
+++ b/tox.ini
@@ -84,7 +84,6 @@ commands =
 description = Run integration tests
 deps =
     juju
-    pylxd
     pytest
     pytest-asyncio
     pytest-operator


### PR DESCRIPTION
## Overview
Include UserFacingClusterConfig
### Rationale
The UserFacingClusterConfig response DTO was included in a recent `k8s-snap` PR https://github.com/canonical/k8s-snap/pull/184. This pull request synchronize the API payloads.