### PR TITLE
[COS] Add `COS` substrate fixture

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,14 +8,15 @@ jobs:
   extra-args:
     runs-on: ubuntu-latest
     outputs:
-      args: ${{ steps.set-flags.args }}
+      args: ${{ steps.flags.outputs.args }}
     steps:
       - name: Determine extra args
-        id: set-flags
+        id: flags
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
         run: |
           EXTRA_ARGS="--crash-dump=on-failure"
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          if [[ "$PR_TITLE" == *"[COS]"* ]]; then
+          if [[ "$TITLE" == *"[COS]"* ]]; then
             EXTRA_ARGS="$EXTRA_ARGS --cos"
           fi
           echo "args=$EXTRA_ARGS" >> "$GITHUB_OUTPUT"
@@ -38,7 +39,7 @@ jobs:
     with:
       provider: lxd
       juju-channel: 3.3/stable
-      extra-arguments: ${{ needs.extra-args.outputs.args }}
+      extra-arguments: ${{needs.extra-args.outputs.args}}
       load-test-enabled: false
       zap-enabled: false
       trivy-fs-enabled: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,10 +1,27 @@
+
 name: Integration tests
 
 on:
   pull_request:
 
 jobs:
+  extra-args:
+    runs-on: ubuntu-latest
+    outputs:
+      args: ${{ steps.set-flags.args }}
+    steps:
+      - name: Determine extra args
+        id: set-flags
+        run: |
+          EXTRA_ARGS="--crash-dump=on-failure"
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          if [[ "$PR_TITLE" == *"[COS]"* ]]; then
+            EXTRA_ARGS="$EXTRA_ARGS --cos"
+          fi
+          echo "args=$EXTRA_ARGS" >> "$GITHUB_OUTPUT"
+
   build-all-charms:
+    needs: [extra-args]
     strategy:
       matrix:
         path:
@@ -13,14 +30,15 @@ jobs:
     uses: ./.github/workflows/build-charm.yaml
     with:
       working-directory:  ${{ matrix.path }}
+
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
-    needs: [build-all-charms]
+    needs: [build-all-charms, extra-args]
     secrets: inherit
     with:
       provider: lxd
       juju-channel: 3.3/stable
-      extra-arguments: --crash-dump=on-failure
+      extra-arguments: ${{ needs.extra-args.outputs.args }}
       load-test-enabled: false
       zap-enabled: false
       trivy-fs-enabled: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,10 @@ Running the integration tests with extra arguments can be accomplished with
 tox run -e integration-tests -- --positional --arguments
 ```
 
+#### COS Integration
+
+The COS integration tests are optional as these are slow/heavy tests. Currently, this suite only runs on LXD. If you are modifying something related to the COS integration, you can validate your changes through integration testing using the flag `--cos`. Also, when submitting a Pull Request with changes related to COS, you must include the `[COS]` tag in your Pull Request description. This will instruct GitHub Actions to execute the respective validation tests against your changes.
+
 #### Useful arguments
 `--keep-models`: Doesn't delete the model once the integration tests are finished
 `--model`: Rerun the test with a given model name -- if it already exist, the integration tests will use it

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,16 +4,26 @@
 """Fixtures for charm tests."""
 import asyncio
 import contextlib
+import json
 import logging
+import shlex
+import tempfile
 from dataclasses import dataclass, field
 from itertools import chain
 from pathlib import Path
-from typing import List, Mapping, Optional
+from typing import List, Mapping, Optional, Tuple
 
 import pytest
 import pytest_asyncio
 import yaml
-from pytest_operator.plugin import OpsTest
+from juju.model import Model
+from juju.tag import untag
+from kubernetes import config as k8s_config
+from kubernetes.client import Configuration
+from pytest_operator.plugin import OpsTest, ops_test
+
+from .cos_substrate import LXDSubstrate
+from .helpers import get_address
 
 log = logging.getLogger(__name__)
 
@@ -191,3 +201,161 @@ async def kubernetes_cluster(request: pytest.FixtureRequest, ops_test: OpsTest):
         bundle.switch(charm.app_name, path)
     async with deploy_model(request, ops_test, model, bundle) as the_model:
         yield the_model
+
+
+@pytest_asyncio.fixture(scope="module")
+async def grafana_agent(ops_test: OpsTest, kubernetes_cluster: Model):
+    """Deploy Grafana Agent."""
+    with ops_test.model_context("main") as model:
+        await model.deploy("grafana-agent", channel="stable")
+        await model.integrate("grafana-agent:cos-agent", "k8s:cos-agent")
+        await model.integrate("grafana-agent:cos-agent", "k8s-worker:cos-agent")
+        await model.integrate("k8s:cos-worker-tokens", "k8s-worker:cos-tokens")
+
+        yield
+
+        await model.remove_application("grafana-agent")
+
+
+@pytest_asyncio.fixture(scope="module")
+async def cos_model(ops_test: OpsTest, kubernetes_cluster: Model, grafana_agent):
+    """Create a COS substrate and a K8s model."""
+    log.info("Creating COS substrate...")
+    container_name = "cos-substrate"
+    network_name = "cos-network"
+    manager = LXDSubstrate(container_name, network_name)
+
+    config = manager.create_substrate()
+    kubeconfig_path = ops_test.tmp_path / "kubeconfig"
+    kubeconfig_path.write_text(config)
+    config = type.__call__(Configuration)
+    k8s_config.load_config(client_configuration=config, config_file=str(kubeconfig_path))
+
+    k8s_cloud = await ops_test.add_k8s(kubeconfig=config, skip_storage=False)
+    k8s_model = await ops_test.track_model(
+        "cos", cloud_name=k8s_cloud, keep=ops_test.ModelKeep.NEVER
+    )
+    with ops_test.model_context("cos"):
+        yield k8s_model
+
+    await ops_test.forget_model("cos", timeout=10 * 60, allow_failure=True)
+
+    manager.teardown_substrate()
+
+
+@pytest_asyncio.fixture(scope="module")
+async def cos_lite_installed(ops_test: OpsTest, cos_model: Model):
+    """Install COS Lite bundle."""
+    log.info("Deploying COS bundle ...")
+    cos_charms = ["alertmanager", "catalogue", "grafana", "loki", "prometheus", "traefik"]
+    overlays = [
+        ops_test.Bundle("cos-lite", "edge"),
+        Path("tests/integration/data/cos-offers-overlay.yaml"),
+    ]
+
+    bundle, *overlays = await ops_test.async_render_bundles(*overlays)
+    cmd = f"juju deploy -m {cos_model.name} {bundle} --trust " + " ".join(
+        f"--overlay={f}" for f in overlays
+    )
+    rc, stdout, stderr = await ops_test.run(*shlex.split(cmd))
+    assert rc == 0, f"COS Lite failed to deploy: {(stderr or stdout).strip()}"
+
+    await cos_model.block_until(
+        lambda: all(app in cos_model.applications for app in cos_charms),
+        timeout=60,
+    )
+    await cos_model.wait_for_idle(status="active", timeout=20 * 60, raise_on_error=False)
+
+    yield
+
+    log.info("Removing COS Lite charms...")
+    for charm in cos_charms:
+        log.info(f"Removing {charm}...")
+        cmd = f"remove-application {charm} --destroy-storage --force --no-prompt"
+        rc, stdout, stderr = await ops_test.juju(*shlex.split(cmd))
+        log.info(f"{(stdout or stderr)})")
+        assert rc == 0
+        await cos_model.block_until(lambda: charm not in cos_model.applications, timeout=60 * 10)
+
+
+@pytest_asyncio.fixture(scope="module")
+async def traefik_address(ops_test: OpsTest, cos_lite_installed):
+    """Fixture to get Traefik address."""
+    address = await get_address(ops_test=ops_test, app_name="traefik")
+    yield address
+
+
+@pytest_asyncio.fixture(scope="module")
+async def expected_dashboard_titles():
+    """Fixture to get expected Grafana dashboard titles."""
+    grafana_dir = Path("charms/worker/k8s/src/grafana_dashboards")
+    grafana_files = [p for p in grafana_dir.iterdir() if p.is_file() and p.name.endswith(".json")]
+    titles = []
+    for path in grafana_files:
+        dashboard = json.loads(path.read_text())
+        titles.append(dashboard["title"])
+    return set(titles)
+
+
+@pytest_asyncio.fixture(scope="module")
+async def related_grafana(ops_test: OpsTest, cos_model: Model, cos_lite_installed):
+    """Fixture to integrate with Grafana."""
+    model_owner = untag("user-", cos_model.info.owner_tag)
+    cos_model_name = cos_model.name
+
+    with ops_test.model_context("main") as model:
+        log.info("Integrating with Grafana")
+        await ops_test.model.integrate(
+            "grafana-agent",
+            f"{model_owner}/{cos_model_name}.grafana-dashboards",
+        )
+        with ops_test.model_context("cos") as k8s_model:
+            await k8s_model.wait_for_idle(status="active")
+        await ops_test.model.wait_for_idle(status="active")
+
+    yield
+
+    with ops_test.model_context("main") as model:
+        log.info("Removing Grafana SAAS ...")
+        await ops_test.model.remove_saas("grafana-dashboards")
+    with ops_test.model_context("cos") as model:
+        log.info("Removing Grafana Offer...")
+        await model.remove_offer(f"{model.name}.grafana-dashboards", force=True)
+
+
+@pytest_asyncio.fixture(scope="module")
+async def grafana_password(ops_test, cos_model: Model, related_grafana):
+    """Fixture to get Grafana password."""
+    with ops_test.model_context("cos"):
+        action = (
+            await ops_test.model.applications["grafana"].units[0].run_action("get-admin-password")
+        )
+        action = await action.wait()
+        yield action.results["admin-password"]
+
+
+@pytest_asyncio.fixture(scope="module")
+async def related_prometheus(ops_test: OpsTest, cos_model, cos_lite_installed):
+    """Fixture to integrate with Prometheus."""
+    model_owner = untag("user-", cos_model.info.owner_tag)
+    cos_model_name = cos_model.name
+
+    with ops_test.model_context("main") as model:
+        log.info("Integrating with Prometheus")
+        relation = await ops_test.model.integrate(
+            "grafana-agent",
+            f"{model_owner}/{cos_model_name}.prometheus-receive-remote-write",
+        )
+        await ops_test.model.wait_for_idle(status="active")
+        with ops_test.model_context("cos") as model:
+            await model.wait_for_idle(status="active")
+
+    yield
+
+    with ops_test.model_context("main") as model:
+        log.info("Removing Prometheus Remote Write SAAS ...")
+        await ops_test.model.remove_saas("prometheus-receive-remote-write")
+
+    with ops_test.model_context("cos") as model:
+        log.info("Removing Prometheus Offer...")
+        await model.remove_offer(f"{model.name}.prometheus-receive-remote-write", force=True)

--- a/tests/integration/cos_substrate.py
+++ b/tests/integration/cos_substrate.py
@@ -95,7 +95,7 @@ class LXDSubstrate(COSSubstrate):
             container = self.client.instances.create(config, wait=True)
             log.info("Starting Container")
             container.start(wait=True)
-            time.sleep(10)
+            time.sleep(60)
             return container
 
         except Exception as e:

--- a/tests/integration/cos_substrate.py
+++ b/tests/integration/cos_substrate.py
@@ -1,3 +1,6 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 import ipaddress
 import logging
 import time

--- a/tests/integration/cos_substrate.py
+++ b/tests/integration/cos_substrate.py
@@ -1,0 +1,258 @@
+import ipaddress
+import logging
+import time
+from pathlib import Path
+from typing import Protocol
+
+import yaml
+from pylxd import Client
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
+
+
+class COSSubstrate(Protocol):
+    """Interface for managing a COS substrate."""
+    def create_substrate(self) -> str:
+        """Create a COS substrate.
+
+        Returns:
+            str: The generated kubeconfig.
+        """
+        ...
+
+    def teardown_substrate(self): 
+        """Teardown the COS substrate."""
+        ...
+
+
+class LXDSubstrate(COSSubstrate):
+    """A COS substrate implemented using LXD."""
+
+    def __init__(self, container_name: str, network_name: str) -> None:
+        """Initialize LXDSubstrate instance.
+
+        Args:
+            container_name (str): Name of the container.
+            network_name (str): Name of the network.
+        """
+        self.client = Client()
+        self.container_name = container_name
+        self.network_name = network_name
+
+    def apply_profile(self, profile_name="microk8s.profile", target_profile_name="cos-profile"):
+        """Apply LXD profile.
+
+        Args:
+            profile_name (Optional[str]): Name of the profile to apply.
+            target_profile_name (Optional[str]): Name of the target profile. Defaults to 'cos-profile'.
+        """
+        profile_path = Path("tests/integration/data") / profile_name
+        with open(profile_path) as file:
+            try:
+                raw_profile = yaml.safe_load(file)
+                config = raw_profile.get("config", {})
+                devices = raw_profile.get("devices", {})
+                self.client.profiles.create(target_profile_name, config=config, devices=devices)
+                log.info(f"Profile {target_profile_name} applied successfully.")
+            except (yaml.YAMLError, Exception) as e:
+                log.error(f"Failed to read or apply LXD profile: {e}")
+
+    def create_container(self, name: str):
+        """Create a container.
+
+        Args:
+            name (str): Name of the container.
+
+        Returns:
+            container: The created container instance, or None if creation fails.
+        """
+        log.info("Creating container")
+        config = {
+            "name": name,
+            "source": {
+                "type": "image",
+                "mode": "pull",
+                "server": "https://cloud-images.ubuntu.com/releases",
+                "protocol": "simplestreams",
+                "alias": "22.04",
+            },
+            "type": "container",
+            "devices": {},
+            "profiles": ["default", "cos-profile"],
+        }
+        if self.network_name:
+            config["devices"]["eth0"] = {
+                "name": "eth0",
+                "nictype": "bridged",
+                "parent": self.network_name,
+                "type": "nic",
+            }
+        try:
+            container = self.client.instances.create(config, wait=True)
+            log.info("Starting Container")
+            container.start(wait=True)
+            time.sleep(10)
+            return container
+
+        except Exception as e:
+            log.error(f"Failed to create or start container: {e}")
+            return None
+
+    def create_network(
+        self, network_name, subnet_cidr="10.10.0.0/24", reserved_addresses: int = 5
+    ):
+        """Create a network.
+
+        Args:
+            network_name (str): Name of the network.
+            subnet_cidr (Optional[str]): CIDR of the subnet. Defaults to '10.10.0.0/24'.
+            reserved_addresses (Optional[int]): Number of reserved IP addresses. Defaults to 5.
+        """
+        existing_networks = self.client.networks.all()
+        if any(net.name == network_name for net in existing_networks):
+            log.info("Network already exists. Skipping creation.")
+            return
+
+        subnet = ipaddress.ip_network(subnet_cidr)
+        total_addresses = subnet.num_addresses - 2
+
+        if reserved_addresses >= total_addresses:
+            raise ValueError(
+                "Reserved Addresses must be less than the total number of usable addresses."
+            )
+
+        gateway_ip = subnet.network_address + 1
+        ipv4_address = f"{gateway_ip}/{subnet.prefixlen}"
+        dhcp_range_start = subnet.network_address + 2
+        dhcp_range_stop = subnet.network_address + total_addresses - reserved_addresses
+
+        reserved_stop = subnet.broadcast_address - 1
+
+        network_config = {
+            "name": network_name,
+            "description": "Custom LXD network for COS integration",
+            "config": {
+                "ipv4.address": ipv4_address,
+                "ipv4.nat": "true",
+                "ipv4.dhcp": "true",
+                "ipv4.dhcp.ranges": f"{dhcp_range_start}-{dhcp_range_stop}",
+                "ipv6.address": "none",
+            },
+            "type": "bridge",
+        }
+
+        try:
+            log.info(
+                f"Creating network '{network_name}' with {reserved_addresses} reserved addresses."
+            )
+            self.client.networks.create(**network_config)
+            log.info("Network created successfully.")
+            reserved_start = dhcp_range_stop + 1
+            return (reserved_start, reserved_stop)
+        except Exception as e:
+            log.error(f"Failed to create network: {e}")
+
+    def create_substrate(self) -> str:
+        """Create a COS substrate.
+
+        Returns:
+            str: The generated kubeconfig.
+        """
+        self.apply_profile()
+        reserved_start, reserved_stop = self.create_network(self.network_name)
+        container = self.create_container(self.container_name)
+        self.install_k8s(container)
+        self.enable_microk8s_addons(container, f"{reserved_start}-{reserved_stop}")
+        return self.get_kubeconfig(container)
+
+    def delete_container(self, container):
+        """Delete a container.
+
+        Args:
+            container: Container instance to be deleted.
+        """
+        try:
+            container.stop(wait=True)
+            container.delete(wait=True)
+            log.info("Container deleted successfully.")
+        except Exception as e:
+            log.error(f"Failed to delete container: {e}")
+
+    def delete_network(self, network_name: str):
+        """Delete a network.
+
+        Args:
+            network_name (str): Name of the network.
+        """
+        network = self.client.networks.get(network_name)
+        network.delete(wait=True)
+
+    def enable_microk8s_addons(self, container, ranges):
+        """Enable MicroK8s addons.
+
+        Args:
+            container: Container instance.
+            ranges (str): MetalLB IP ranges.
+        """
+        addons = ["dns", "hostpath-storage", f"metallb:{ranges}"]
+        for addon in addons:
+            self.execute_command(container, ["sudo", "microk8s", "enable", addon])
+
+    def execute_command(self, container, command):
+        """Execute a command inside a container.
+
+        Args:
+            container: Container instance.
+            command (list): Command to execute.
+        """
+        log.info("Running command")
+        try:
+            rc, stdout, stderr = container.execute(command)
+            log.info(f"Command executed with return code {rc}. stdout: {stdout}, stderr: {stderr}")
+            return stdout
+        except Exception as e:
+            log.error(f"Failed to execute command: {e}")
+
+    def get_kubeconfig(self, container) -> str:
+        """Get kubeconfig from a container.
+
+        Args:
+            container: Container instance.
+
+        Returns:
+            str: The kubeconfig.
+        """
+        return self.execute_command(container, ["microk8s", "config"])
+
+    def install_k8s(self, container):
+        """Install Kubernetes inside a container.
+
+        Args:
+            container: Container instance.
+        """
+
+        return self.execute_command(
+            container,
+            ["sudo", "snap", "install", "microk8s", "--channel=1.28/stable", "--classic"],
+        )
+
+    def remove_profile(self, profile_name="cos-profile"):
+        """Remove an LXD profile.
+
+        Args:
+            profile_name (Optional[str]): Name of the profile to remove. Defaults to 'cos-profile'.
+        """
+        try:
+            profile = self.client.profiles.get(profile_name)
+            profile.delete()
+            log.info(f"Profile {profile_name} removed successfully.")
+        except Exception as e:
+            log.error(f"Failed to remove profile {profile_name}: {e}")
+
+    def teardown_substrate(self):
+        """Teardown the COS substrate."""
+        container = self.client.instances.get(self.container_name)
+        self.delete_container(container)
+        self.delete_network(self.network_name)
+        self.remove_profile()

--- a/tests/integration/data/cos-offers-overlay.yaml
+++ b/tests/integration/data/cos-offers-overlay.yaml
@@ -1,0 +1,24 @@
+applications:
+  alertmanager:
+    offers:
+      alertmanager-karma-dashboard:
+        endpoints:
+          - karma-dashboard
+  grafana:
+    offers:
+      grafana-dashboards:
+        endpoints:
+          - grafana-dashboard
+  loki:
+    offers:
+      loki-logging:
+        endpoints:
+        - logging
+  prometheus:
+    offers:
+      prometheus-scrape:
+        endpoints:
+        - metrics-endpoint
+      prometheus-receive-remote-write:
+        endpoints:
+        - receive-remote-write

--- a/tests/integration/data/cos-offers-overlay.yaml
+++ b/tests/integration/data/cos-offers-overlay.yaml
@@ -1,3 +1,6 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 applications:
   alertmanager:
     offers:

--- a/tests/integration/data/microk8s.profile
+++ b/tests/integration/data/microk8s.profile
@@ -1,0 +1,33 @@
+name: microk8s
+config:
+  boot.autostart: "true"
+  linux.kernel_modules: ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh,ip_tables,ip6_tables,netlink_diag,nf_nat,overlay,br_netfilter
+  raw.lxc: |
+    lxc.apparmor.profile=unconfined
+    lxc.mount.auto=proc:rw sys:rw cgroup:rw
+    lxc.cgroup.devices.allow=a
+    lxc.cap.drop=
+  security.nesting: "true"
+  security.privileged: "true"
+description: ""
+devices:
+  aadisable:
+    path: /sys/module/nf_conntrack/parameters/hashsize
+    source: /sys/module/nf_conntrack/parameters/hashsize
+    type: disk
+  aadisable2:
+    path: /dev/zfs
+    source: /dev/zfs
+    type: disk
+  aadisable3:
+    path: /dev/kmsg
+    source: /dev/kmsg
+    type: unix-char
+  aadisable4:
+    path: /sys/fs/bpf
+    source: /sys/fs/bpf
+    type: disk
+  aadisable5:
+    path: /proc/sys/net/netfilter/nf_conntrack_max
+    source: /proc/sys/net/netfilter/nf_conntrack_max
+    type: disk

--- a/tests/integration/data/microk8s.profile
+++ b/tests/integration/data/microk8s.profile
@@ -1,3 +1,6 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 name: microk8s
 config:
   boot.autostart: "true"

--- a/tests/integration/grafana.py
+++ b/tests/integration/grafana.py
@@ -1,0 +1,89 @@
+import base64
+import json
+import logging
+import urllib.request
+from typing import Dict, List, Optional
+
+log = logging.getLogger(__name__)
+
+
+class Grafana:
+    """A class to manage interactions with a running instance of Grafana."""
+
+    def __init__(
+        self,
+        model_name: str,
+        host: Optional[str] = "localhost",
+        username: Optional[str] = "admin",
+        password: Optional[str] = "",
+    ):
+        """Initialize Grafana instance.
+
+        Args:
+            model_name (str): The name of the model where Grafana is deployed.
+            host (Optional[str]): Host address of Grafana application. Defaults to 'localhost'.
+            username (Optional[str]): Username for authentication. Defaults to 'admin'.
+            password (Optional [str]): Password for authentication. Defaults to ''.
+        """
+        self.base_uri = f"http://{host}/{model_name}-grafana"
+        self.username = username
+        self.password = password
+
+    def _get_with_auth(self, url: str) -> str:
+        """Send GET request with basic authentication.
+
+        Args:
+            url (str): The URL to send the request to.
+
+        Returns:
+            str: The response data.
+
+        Raises:
+            AssertionError: If the response status code is not 200.
+        """
+        log.info(f"Query: {url}")
+        credentials = f"{self.username}:{self.password}"
+        encoded_creds = base64.b64encode(credentials.encode("ascii"))
+        request = urllib.request.Request(url)
+        request.add_header("Authorization", f"Basic {encoded_creds.decode('ascii')}")
+
+        response = urllib.request.urlopen(request)
+
+        assert response.code == 200, f"Failed to get endpoint {url}"
+        data = response.read().decode()
+        return data
+
+    async def is_ready(self) -> bool:
+        """Check if Grafana is ready.
+
+        Returns:
+            bool: True if Grafana is ready, False otherwise.
+        """
+        res = await self.health()
+        return res.get("database", "") == "ok" or False
+
+    async def health(self) -> Dict:
+        """Query the API to check Grafana's health.
+
+        Returns:
+            dict: A dictionary containing basic API health information.
+        """
+        api_path = "api/health"
+        uri = "{}/{}".format(self.base_uri, api_path)
+
+        data = self._get_with_auth(uri)
+
+        return json.loads(data)
+
+    async def dashboards_all(self) -> List:
+        """Retrieve all dashboards.
+
+        Returns:
+            list: Found dashboards, if any.
+        """
+        api_path = "api/search"
+        uri = "{}/{}?starred=false".format(self.base_uri, api_path)
+
+        data = self._get_with_auth(uri)
+
+        return json.loads(data)

--- a/tests/integration/grafana.py
+++ b/tests/integration/grafana.py
@@ -1,3 +1,6 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 import base64
 import json
 import logging

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,29 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from typing import Optional
+
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+async def get_address(ops_test: OpsTest, app_name: str, unit_num: Optional[int] = None) -> str:
+    """Find unit address for any application.
+
+    Args:
+        ops_test: pytest-operator plugin
+        app_name: string name of application
+        unit_num: integer number of a juju unit
+
+    Returns:
+        unit address as a string
+    """
+    status = await ops_test.model.get_status()
+    app = status["applications"][app_name]
+    return (
+        app.public_address
+        if unit_num is None
+        else app["units"][f"{app_name}/{unit_num}"]["address"]
+    )

--- a/tests/integration/prometheus.py
+++ b/tests/integration/prometheus.py
@@ -1,0 +1,84 @@
+import json
+import urllib.parse
+import urllib.request
+from typing import Optional
+
+
+
+class Prometheus:
+    """A class for managing interactions with a running instance of Prometheus."""
+
+    def __init__(
+        self,
+        model_name: str,
+        host: Optional[str] = "localhost",
+    ):
+        """Initialize Prometheus instance.
+
+        Args:
+            model_name (str): The name of the model where Prometheus is deployed.
+            host (Optional[str]): Host address of the Prometheus application. Defaults to 'localhost'.
+        """
+        self.base_uri = f"http://{host}/{model_name}-prometheus-0"
+
+    def _get_url(self, url):
+        """Send GET request to the provided URL.
+
+        Args:
+            url (str): The URL to send the request to.
+
+        Returns:
+            str: The response data.
+
+        Raises:
+            AssertionError: If the response status code is not 200.
+        """
+        response = urllib.request.urlopen(url)
+        data = response.read().decode()
+
+        assert response.code == 200, f"Failed to get endpoint {url}: {data}"
+        return data
+
+    async def is_ready(self) -> bool:
+        """Check if Prometheus is ready.
+
+        Returns:
+            bool: True if Prometheus is ready, False otherwise.
+        """
+        res = await self.health()
+        return "Prometheus Server is Ready." in res
+
+    async def health(self) -> str:
+        """Check Prometheus readiness using the MGMT API.
+
+        Returns:
+            str: A string containing "Prometheus is Ready" if it is ready; otherwise, an empty string.
+        """
+        api_path = "-/ready"
+        uri = f"{self.base_uri}/{api_path}"
+
+        data = self._get_url(uri)
+
+        return data
+
+    async def check_metrics(self, query: str):
+        """Query Prometheus for metrics.
+
+        Args:
+            query (str): The Prometheus query to execute.
+
+        Raises:
+            AssertionError: If the query fails or if data is not yet available.
+        """
+        api_path = "api/v1/query"
+        uri = f"{self.base_uri}/{api_path}"
+
+        encoded_query = urllib.parse.urlencode({"query": query}).encode("ascii")
+        request = urllib.request.Request(uri, data=encoded_query)
+        response = urllib.request.urlopen(request)
+        data = response.read().decode()
+
+        assert response.code == 200, f"Failed to query '{query}': {data}"
+        result = json.loads(data)
+        assert result.get("status") == "success", f"Query failed: {result}"
+        assert result.get("data", {}).get("result"), f"Data not yet available"

--- a/tests/integration/prometheus.py
+++ b/tests/integration/prometheus.py
@@ -7,7 +7,6 @@ import urllib.request
 from typing import Optional
 
 
-
 class Prometheus:
     """A class for managing interactions with a running instance of Prometheus."""
 

--- a/tests/integration/prometheus.py
+++ b/tests/integration/prometheus.py
@@ -1,3 +1,6 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 import json
 import urllib.parse
 import urllib.request

--- a/tests/integration/test-bundle.yaml
+++ b/tests/integration/test-bundle.yaml
@@ -10,11 +10,9 @@ applications:
     charm: k8s
     channel: latest/edge
     num_units: 3
-    constraints: "cores=2 mem=4G root-disk=50G"
   k8s-worker:
     charm: k8s-worker
     channel: latest/edge
     num_units: 2
-    constraints: "cores=2 mem=4G root-disk=50G"
 relations:
   - [k8s, k8s-worker:cluster]

--- a/tests/integration/test-bundle.yaml
+++ b/tests/integration/test-bundle.yaml
@@ -10,9 +10,11 @@ applications:
     charm: k8s
     channel: latest/edge
     num_units: 3
+    constraints: "cores=2 mem=4G root-disk=50G"
   k8s-worker:
     charm: k8s-worker
     channel: latest/edge
     num_units: 2
+    constraints: "cores=2 mem=4G root-disk=50G"
 relations:
   - [k8s, k8s-worker:cluster]

--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -86,48 +86,6 @@ async def test_nodes_ready(kubernetes_cluster: model.Model):
     await ready_nodes(k8s.units[0], expected_nodes)
 
 
-@pytest.mark.cos
-@retry(reraise=True, stop=stop_after_attempt(12), wait=wait_fixed(60))
-async def test_grafana(
-    traefik_address: str,
-    grafana_password: str,
-    expected_dashboard_titles: set,
-    cos_model: model.Model,
-):
-    """Test integration with Grafana."""
-    grafana = Grafana(model_name=cos_model.name, host=traefik_address, password=grafana_password)
-    await asyncio.wait_for(grafana.is_ready(), timeout=5 * 60)
-    dashboards = await grafana.dashboards_all()
-    actual_dashboard_titles = set()
-
-    for dashboard in dashboards:
-        actual_dashboard_titles.add(dashboard.get("title"))
-
-    assert expected_dashboard_titles.issubset(actual_dashboard_titles)
-
-
-@pytest.mark.cos
-@retry(reraise=True, stop=stop_after_attempt(12), wait=wait_fixed(60))
-async def test_prometheus(traefik_address: str, cos_model: model.Model, related_prometheus):
-    """Test integration with Prometheus."""
-    prometheus = Prometheus(model_name=cos_model.name, host=traefik_address)
-    while not await prometheus.is_ready():
-        log.info("Waiting for Prometheus to be ready.")
-        await asyncio.sleep(5)
-    queries = [
-        'up{job="kubelet", metrics_path="/metrics"} > 0',
-        'up{job="kubelet", metrics_path="/metrics/cadvisor"} > 0',
-        'up{job="kubelet", metrics_path="/metrics/probes"} > 0',
-        'up{job="apiserver"} > 0',
-        'up{job="kube-controller-manager"} > 0',
-        'up{job="kube-scheduler"} > 0',
-        'up{job="kube-proxy"} > 0',
-        'up{job="kube-state-metrics"} > 0',
-    ]
-    for query in queries:
-        await prometheus.check_metrics(query)
-
-
 async def test_nodes_labelled(request, kubernetes_cluster: model.Model):
     """Test the charms label the nodes appropriately."""
     testname: str = request.node.name
@@ -217,3 +175,45 @@ async def test_remove_leader_control_plane(kubernetes_cluster: model.Model):
     await k8s.add_unit()
     await kubernetes_cluster.wait_for_idle(status="active", timeout=5 * 60)
     await ready_nodes(follower, expected_nodes)
+
+
+@pytest.mark.cos
+@retry(reraise=True, stop=stop_after_attempt(12), wait=wait_fixed(60))
+async def test_grafana(
+    traefik_address: str,
+    grafana_password: str,
+    expected_dashboard_titles: set,
+    cos_model: model.Model,
+):
+    """Test integration with Grafana."""
+    grafana = Grafana(model_name=cos_model.name, host=traefik_address, password=grafana_password)
+    await asyncio.wait_for(grafana.is_ready(), timeout=5 * 60)
+    dashboards = await grafana.dashboards_all()
+    actual_dashboard_titles = set()
+
+    for dashboard in dashboards:
+        actual_dashboard_titles.add(dashboard.get("title"))
+
+    assert expected_dashboard_titles.issubset(actual_dashboard_titles)
+
+
+@pytest.mark.cos
+@retry(reraise=True, stop=stop_after_attempt(12), wait=wait_fixed(60))
+async def test_prometheus(traefik_address: str, cos_model: model.Model, related_prometheus):
+    """Test integration with Prometheus."""
+    prometheus = Prometheus(model_name=cos_model.name, host=traefik_address)
+    while not await prometheus.is_ready():
+        log.info("Waiting for Prometheus to be ready.")
+        await asyncio.sleep(5)
+    queries = [
+        'up{job="kubelet", metrics_path="/metrics"} > 0',
+        'up{job="kubelet", metrics_path="/metrics/cadvisor"} > 0',
+        'up{job="kubelet", metrics_path="/metrics/probes"} > 0',
+        'up{job="apiserver"} > 0',
+        'up{job="kube-controller-manager"} > 0',
+        'up{job="kube-scheduler"} > 0',
+        'up{job="kube-proxy"} > 0',
+        'up{job="kube-state-metrics"} > 0',
+    ]
+    for query in queries:
+        await prometheus.check_metrics(query)

--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -86,6 +86,7 @@ async def test_nodes_ready(kubernetes_cluster: model.Model):
     await ready_nodes(k8s.units[0], expected_nodes)
 
 
+@pytest.mark.cos
 @retry(reraise=True, stop=stop_after_attempt(12), wait=wait_fixed(60))
 async def test_grafana(
     traefik_address: str,
@@ -95,9 +96,7 @@ async def test_grafana(
 ):
     """Test integration with Grafana."""
     grafana = Grafana(model_name=cos_model.name, host=traefik_address, password=grafana_password)
-    while not await grafana.is_ready():
-        log.info("Waiting for Grafana to be ready.")
-        await asyncio.sleep(5)
+    await asyncio.wait_for(grafana.is_ready(), timeout=5 * 60)
     dashboards = await grafana.dashboards_all()
     actual_dashboard_titles = set()
 
@@ -107,6 +106,7 @@ async def test_grafana(
     assert expected_dashboard_titles.issubset(actual_dashboard_titles)
 
 
+@pytest.mark.cos
 @retry(reraise=True, stop=stop_after_attempt(12), wait=wait_fixed(60))
 async def test_prometheus(traefik_address: str, cos_model: model.Model, related_prometheus):
     """Test integration with Prometheus."""

--- a/tox.ini
+++ b/tox.ini
@@ -84,9 +84,10 @@ commands =
 description = Run integration tests
 deps =
     juju
+    pylxd
     pytest
     pytest-asyncio
-    pytest-operator
+    pytest-operator @ git+https://github.com/charmed-kubernetes/pytest-operator@akd/add-k8s-alpha
     tenacity
 commands =
     pytest -v --tb native \


### PR DESCRIPTION
## Overview
Add a `COS` substrate fixture to ease COS integration.

### Rationale
We usually test COS integration using the same K8s as the substrate for the COS stack. However, we would want to mimic the real-world environment. This pull request replicates a COS instance related to the K8s cluster using Cross-Model Integration.

### Module Changes
- Added a Grafana module to verify the Grafana integration.
- Added a Prometheus module which verifies the Prometheus integration, querying the cluster for the known metrics jobs.
- Added a COS substrate module implementation using LXD. It creates a separate network and instance, completely independent from the cluster itself (the cluster is using MicroK8s as the K8s substrate).
- Added tests for Grafana and Prometheus.
