### PR TITLE
Configuration for service-cidr and control-plane-taints

### DIFF
--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -67,7 +67,27 @@ config:
       type: string
       description: |
         Labels can be used to organize and to select subsets of nodes in the
-        cluster. Declare node labels in key=value format, separated by spaces.
+        cluster. Declare node labels in key=value format, separated by spaces.      
+    register-with-taints:
+      type: string
+      default: ""
+      description: |
+        Space-separated list of taints to apply to this node at registration time.
+
+        This config is only used at deploy time when Kubelet first registers the
+        node with Kubernetes. To change node taints after deploy time, use kubectl
+        instead.
+
+        For more information, see the upstream Kubernetes documentation about
+        taints:
+        https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+    service-cidr:
+      type: string
+      default: 10.152.183.0/24
+      description: |
+        CIDR to use for Kubernetes services. After deployment it is
+        only possible to increase the size of the IP range. It is not possible to
+        change or shrink the address range after deployment.
 
 actions:
   get-kubeconfig:

--- a/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
+++ b/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
@@ -295,6 +295,7 @@ class BootstrapConfig(BaseModel):
 
     Attributes:
         cluster_config (UserFacingClusterConfig): The cluster configuration settings.
+        control_plane_taints (List[str]): Register with the following control-plane taints
         pod_cidr (str): The IP address range for the cluster's pods.
         service_cidr (str): The IP address range for the cluster services.
         disable_rbac (bool): Flag to disable role-based access control
@@ -309,6 +310,7 @@ class BootstrapConfig(BaseModel):
     """
 
     cluster_config: UserFacingClusterConfig = Field(None, alias="cluster-config")
+    control_plane_taints: List[str] = Field(None, alias="control-plane-taints")
     pod_cidr: str = Field(None, alias="pod-cidr")
     service_cidr: str = Field(None, alias="service-cidr")
     disable_rbac: bool = Field(None, alias="disable-rbac")

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -221,6 +221,8 @@ class K8sCharm(ops.CharmBase):
 
         bootstrap_config = BootstrapConfig()
         self._configure_datastore(bootstrap_config)
+        bootstrap_config.service_cidr = self.config["service-cidr"]
+        bootstrap_config.control_plane_taints = self.config["register-with-taints"].split()
 
         status.add(ops.MaintenanceStatus("Bootstrapping Cluster"))
 

--- a/tests/integration/data/test-bundle.yaml
+++ b/tests/integration/data/test-bundle.yaml
@@ -4,7 +4,7 @@
 name: integration-test
 description: |-
   Used to deploy or refresh within an integration test model
-series: jammy
+series: focal
 applications:
   k8s:
     charm: k8s


### PR DESCRIPTION
Introduces config `service-cidr` and `register-with-taints`.  I considered also introducing `cidr` -- but may wait and leave it default for now in case we later introduce CNI relation

Pairs with snap changes
* https://github.com/canonical/k8s-snap/pull/218