### PR TITLE
Expose ports and apps when running in public clouds

### DIFF
--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -25,6 +25,7 @@ from functools import cached_property
 from pathlib import Path
 from time import sleep
 from typing import Dict, Optional
+from urllib.parse import urlparse
 
 import charms.contextual_status as status
 import ops
@@ -444,6 +445,7 @@ class K8sCharm(ops.CharmBase):
         self._apply_node_labels()
         if self.is_control_plane:
             self._copy_internal_kubeconfig()
+            self._expose_ports()
 
     @on_error(
         ops.WaitingStatus("Cluster not yet ready"),
@@ -527,6 +529,13 @@ class K8sCharm(ops.CharmBase):
         status.add(ops.MaintenanceStatus("Generating KubeConfig"))
         KUBECONFIG.parent.mkdir(parents=True, exist_ok=True)
         KUBECONFIG.write_bytes(self._internal_kubeconfig.read_bytes())
+
+    def _expose_ports(self):
+        """Expose ports for public clouds to access api endpoints."""
+        log.info("Exposing api ports")
+        content = yaml.safe_load(KUBECONFIG.read_text())
+        endpoint = urlparse(content["clusters"][0]["cluster"]["server"])
+        self.unit.open_port("tcp", endpoint.port)
 
     def _get_external_kubeconfig(self, event: ops.ActionEvent):
         """Retrieve a public kubeconfig via a charm action.

--- a/charms/worker/k8s/tests/unit/test_base.py
+++ b/charms/worker/k8s/tests/unit/test_base.py
@@ -55,6 +55,7 @@ def mock_reconciler_handlers(harness):
             "_apply_cos_requirements",
             "_copy_internal_kubeconfig",
             "_revoke_cluster_tokens",
+            "_expose_ports",
         }
 
     handlers = [mock.patch(f"charm.K8sCharm.{name}") for name in handler_names]

--- a/tests/integration/test-bundle.yaml
+++ b/tests/integration/test-bundle.yaml
@@ -10,6 +10,7 @@ applications:
     charm: k8s
     channel: latest/edge
     num_units: 3
+    expose: true
   k8s-worker:
     charm: k8s-worker
     channel: latest/edge


### PR DESCRIPTION
Expose ports to the kubernetes api endpoint service on control-plane units, and expose those apps on public clouds during testing

Without this, security groups will prevent using kubernetes clients from accessing the API endpoints outside the cloud