### PR TITLE
include license check on k8s charm library but ignore downloaded library

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -16,8 +16,9 @@ header:
         See LICENSE file for licensing details.
     paths:
       - '**'
+      - 'charms/worker/k8s/lib/charms/k8s/**'
     paths-ignore:
-      - '**/lib/charms/operator_libs_linux/**'
+      - 'charms/worker/k8s/lib/charms/**'
       - '.github/**'
       - '**/.gitkeep'
       - '**/*.cfg'


### PR DESCRIPTION
This charm maintains the `k8s` charm library under `charm/worker/k8s/lib/charms/k8s` so we should license check those files.  But we want to ignore any other charm license headers bc we can't do anything about them