### PR TITLE
Support the external-cloud-provider on bootstrap of k8s

### DIFF
--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -98,3 +98,5 @@ provides:
 requires:
   etcd:
     interface: etcd
+  external-cloud-provider:
+    interface: external_cloud_provider

--- a/charms/worker/k8s/requirements.txt
+++ b/charms/worker/k8s/requirements.txt
@@ -4,3 +4,4 @@ pydantic == 1.*
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@main
 charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status@main
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@main#subdirectory=ops
+charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider@main

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -32,6 +32,7 @@ import ops
 import yaml
 from charms.contextual_status import WaitingStatus, on_error
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
+from charms.interface_external_cloud_provider import ExternalCloudProvider
 from charms.k8s.v0.k8sd_api_manager import (
     BootstrapConfig,
     CreateClusterRequest,
@@ -85,6 +86,8 @@ class K8sCharm(ops.CharmBase):
         super().__init__(*args)
         factory = UnixSocketConnectionFactory(unix_socket=K8SD_SNAP_SOCKET, timeout=320)
         self.api_manager = K8sdAPIManager(factory)
+        xcp_relation = "external-cloud-provider" if self.is_control_plane else ""
+        self.xcp = ExternalCloudProvider(self, xcp_relation)
         self.cos = COSIntegration(self)
         self.reconciler = Reconciler(self, self._reconcile)
         self.distributor = TokenDistributor(self, self.get_node_name(), self.api_manager)
@@ -170,6 +173,8 @@ class K8sCharm(ops.CharmBase):
         Returns:
             the hostname of the machine.
         """
+        if self.xcp.name == "aws":
+            return socket.getfqdn().lower()
         return socket.gethostname().lower()
 
     def get_cloud_name(self) -> str:
@@ -178,8 +183,7 @@ class K8sCharm(ops.CharmBase):
         Returns:
             the cloud hosting the machine.
         """
-        # TODO: adjust to detect the correct cloud
-        return ""
+        return self.xcp.name or ""
 
     @on_error(ops.BlockedStatus("Failed to install k8s snap."), SnapError)
     def _install_k8s_snap(self):
@@ -221,6 +225,7 @@ class K8sCharm(ops.CharmBase):
 
         bootstrap_config = BootstrapConfig()
         self._configure_datastore(bootstrap_config)
+        self._configure_cloud_provider(bootstrap_config)
 
         status.add(ops.MaintenanceStatus("Bootstrapping Cluster"))
 
@@ -283,6 +288,18 @@ class K8sCharm(ops.CharmBase):
             config.datastore_servers = self.etcd.get_connection_string().split(",")
         elif datastore == "dqlite":
             log.info("Using dqlite as datastore")
+
+    def _configure_cloud_provider(self, config: BootstrapConfig):
+        """Configure the cloud-provider for the Kubernetes cluster.
+
+        Args:
+            config (BootstrapConfig): The bootstrap configuration object for
+                the Kubernetes cluster that is being configured. This object
+                will be modified in-place.
+        """
+        if self.xcp.has_xcp:
+            log.info("Using external as cloud-provider")
+            config.cloud_provider = "external"
 
     def _revoke_cluster_tokens(self):
         """Revoke tokens for the units in the cluster and k8s-cluster relations.

--- a/tests/integration/test_etcd.py
+++ b/tests/integration/test_etcd.py
@@ -40,4 +40,4 @@ async def test_etcd_datastore(kubernetes_cluster: model.Model):
     status = json.loads(result.results["stdout"])
     assert status["ready"], "Cluster isn't ready"
     assert status["datastore"]["type"] == "external", "Not bootstrapped against etcd"
-    assert status["datastore"]["external-url"] == f"https://{etcd.public_address}:{etcd_port}"
+    assert status["datastore"]["servers"] == [f"https://{etcd.public_address}:{etcd_port}"]


### PR DESCRIPTION
Satisfies the `external-cloud-provider` relation - the k8s charms can bootstrap using the `external` cloud-provider

While this isn't enough for the other cloud-provider charms to get credentials from the cluster -- this is enough to complete half the relation and indicate that the cloud-provider is externally available. 

--- Note ---
`aws-cloud-provider` requires the nodes to use fqdn rather than the bare hostname in the node names.  It's best in this case to just always use the fqdn when running on aws