### PR TITLE
Integrate runtime updates for etcd

### DIFF
--- a/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
+++ b/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
@@ -304,7 +304,7 @@ class UserFacingDatastoreConfig(BaseModel, allow_population_by_field_name=True):
         client_key: client key of the external datastore cluster in PEM format.
     """
 
-    type: Optional[str]] = Field(None)
+    type: Optional[str] = Field(None)
     servers: Optional[List[str]] = Field(None)
     ca_crt: Optional[str] = Field(None, alias="ca-crt")
     client_crt: Optional[str] = Field(None, alias="client-crt")

--- a/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
+++ b/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
@@ -290,6 +290,24 @@ class UserFacingClusterConfig(BaseModel):
     metrics_server: MetricsServerConfig = Field(None, alias="metrics-server")
 
 
+class UserFacingDatastoreConfig(BaseModel):
+    """Aggregated configuration model for the user-facing datastore aspects of a cluster.
+
+    Attributes:
+        type: Type of the datastore. For runtime updates, this needs to be "external".
+        servers: Server addresses of the external datastore.
+        ca_crt: CA certificate of the external datastore cluster in PEM format.
+        client_crt: client certificate of the external datastore cluster in PEM format.
+        client_key: client key of the external datastore cluster in PEM format.
+    """
+
+    type: str = Field(None)
+    servers: List[str] = Field(None)
+    ca_crt: str = Field(None, alias="ca-crt")
+    client_crt: str = Field(None, alias="client-crt")
+    client_key: str = Field(None, alias="client-key")
+
+
 class BootstrapConfig(BaseModel):
     """Configuration model for bootstrapping a Canonical K8s cluster.
 
@@ -341,9 +359,11 @@ class UpdateClusterConfigRequest(BaseModel):
 
     Attributes:
         config (Optional[UserFacingClusterConfig]): The cluster configuration.
+        datastore (Optional[UserFacingDatastoreConfig]): The clusters datastore configuration.
     """
 
-    config: UserFacingClusterConfig
+    config: UserFacingClusterConfig = Field(None)
+    datastore: UserFacingDatastoreConfig = Field(None)
 
 
 class DatastoreStatus(BaseModel):
@@ -351,11 +371,11 @@ class DatastoreStatus(BaseModel):
 
     Attributes:
         datastore_type (str): external or k8s-dqlite datastore
-        external_url: (str): list of external_urls
+        servers: (List(str)): list of server addresses of the external datastore cluster.
     """
 
     datastore_type: str = Field(None, alias="type")
-    external_url: str = Field(None, alias="external-url")
+    servers: List[str] = Field(None, alias="servers")
 
 
 class ClusterStatus(BaseModel):

--- a/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
+++ b/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
@@ -290,7 +290,7 @@ class UserFacingClusterConfig(BaseModel):
     metrics_server: MetricsServerConfig = Field(None, alias="metrics-server")
 
 
-class UserFacingDatastoreConfig(BaseModel, allow_population_by_field_name=True):
+class UserFacingDatastoreConfig(BaseModel, allow_population_by_field_name=True):  # type: ignore[call-arg]
     """Aggregated configuration model for the user-facing datastore aspects of a cluster.
 
     Attributes:

--- a/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
+++ b/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
@@ -304,11 +304,11 @@ class UserFacingDatastoreConfig(BaseModel, allow_population_by_field_name=True):
         client_key: client key of the external datastore cluster in PEM format.
     """
 
-    type: str = Field(None)
-    servers: List[str] = Field(None)
-    ca_crt: str = Field(None, alias="ca-crt")
-    client_crt: str = Field(None, alias="client-crt")
-    client_key: str = Field(None, alias="client-key")
+    type: Optional[str]] = Field(None)
+    servers: Optional[List[str]] = Field(None)
+    ca_crt: Optional[str] = Field(None, alias="ca-crt")
+    client_crt: Optional[str] = Field(None, alias="client-crt")
+    client_key: Optional[str] = Field(None, alias="client-key")
 
 
 class BootstrapConfig(BaseModel):

--- a/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
+++ b/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
@@ -367,8 +367,8 @@ class UpdateClusterConfigRequest(BaseModel):
         datastore (Optional[UserFacingDatastoreConfig]): The clusters datastore configuration.
     """
 
-    config: UserFacingClusterConfig = Field(None)
-    datastore: UserFacingDatastoreConfig = Field(None)
+    config: Optional[UserFacingClusterConfig] = Field(None)
+    datastore: Optional[UserFacingDatastoreConfig] = Field(None)
 
 
 class NodeJoinConfig(BaseModel, allow_population_by_field_name=True):

--- a/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
+++ b/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
@@ -290,7 +290,7 @@ class UserFacingClusterConfig(BaseModel):
     metrics_server: MetricsServerConfig = Field(None, alias="metrics-server")
 
 
-class UserFacingDatastoreConfig(BaseModel):
+class UserFacingDatastoreConfig(BaseModel, allow_population_by_field_name=True):
     """Aggregated configuration model for the user-facing datastore aspects of a cluster.
 
     Attributes:
@@ -647,7 +647,7 @@ class K8sdAPIManager:
             config (UpdateClusterConfigRequest): The cluster configuration.
         """
         endpoint = "/1.0/k8sd/cluster/config"
-        body = config.dict(exclude_none=True)
+        body = config.dict(exclude_none=True, by_alias=True)
         self._send_request(endpoint, "PUT", EmptyResponse, body)
 
     def get_cluster_status(self) -> GetClusterStatusResponse:

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -368,7 +368,7 @@ class K8sCharm(ops.CharmBase):
         K8sdConnectionError,
     )
     def _ensure_cluster_config(self):
-        """Ensure that the cluster configuration is up-to-date
+        """Ensure that the cluster configuration is up-to-date.
 
         The snap will detect any changes and only perform necessary steps.
         There is no need to track changes in the charm.

--- a/charms/worker/k8s/tests/unit/test_base.py
+++ b/charms/worker/k8s/tests/unit/test_base.py
@@ -59,6 +59,7 @@ def mock_reconciler_handlers(harness):
             "_apply_cos_requirements",
             "_copy_internal_kubeconfig",
             "_revoke_cluster_tokens",
+            "_ensure_cluster_config",
             "_expose_ports",
         }
 

--- a/charms/worker/k8s/tests/unit/test_k8sd_api_manager.py
+++ b/charms/worker/k8s/tests/unit/test_k8sd_api_manager.py
@@ -25,6 +25,7 @@ from lib.charms.k8s.v0.k8sd_api_manager import (
     UnixSocketHTTPConnection,
     UpdateClusterConfigRequest,
     UserFacingClusterConfig,
+    UserFacingDatastoreConfig,
 )
 
 
@@ -262,13 +263,29 @@ class TestK8sdAPIManager(unittest.TestCase):
 
         dns_config = DNSConfig(enabled=True)
         user_config = UserFacingClusterConfig(dns=dns_config)
-        request = UpdateClusterConfigRequest(config=user_config)
+        datastore = UserFacingDatastoreConfig(
+            type="external",
+            servers=["localhost:123"],
+            ca_crt="ca-crt",
+            client_crt="client-crt",
+            client_key="client-key",
+        )
+        request = UpdateClusterConfigRequest(config=user_config, datastore=datastore)
         self.api_manager.update_cluster_config(request)
         mock_send_request.assert_called_once_with(
             "/1.0/k8sd/cluster/config",
             "PUT",
             EmptyResponse,
-            {"config": {"dns": {"enabled": True}}},
+            {
+                "config": {"dns": {"enabled": True}},
+                "datastore": {
+                    "type": "external",
+                    "servers": ["localhost:123"],
+                    "ca-crt": "ca-crt",
+                    "client-crt": "client-crt",
+                    "client-key": "client-key",
+                },
+            },
         )
 
     @patch("lib.charms.k8s.v0.k8sd_api_manager.K8sdAPIManager._send_request")

--- a/tests/integration/test_etcd.py
+++ b/tests/integration/test_etcd.py
@@ -51,7 +51,7 @@ async def test_update_etcd_cluster(kubernetes_cluster: model.Model):
     count = 3 - len(etcd.units)
     if count > 0:
         await etcd.add_unit(count=count)
-    await kubernetes_cluster.wait_for_idle(status="active", timeout=20*60)
+    await kubernetes_cluster.wait_for_idle(status="active", timeout=20 * 60)
 
     expected_servers = []
     for u in etcd.units:

--- a/tests/integration/test_etcd.py
+++ b/tests/integration/test_etcd.py
@@ -48,9 +48,10 @@ async def test_update_etcd_cluster(kubernetes_cluster: model.Model):
     """Test that adding etcd clusters are propagated to the k8s cluster."""
     k8s: unit.Unit = kubernetes_cluster.applications["k8s"].units[0]
     etcd = kubernetes_cluster.applications["etcd"]
-
-    await etcd.add_unit()
-    await etcd.add_unit()
+    count = 3 - len(etcd.units)
+    if count > 0:
+        await etcd.add_unit(count=count)
+    await kubernetes_cluster.wait_for_idle(status="active", timeout=20*60)
 
     expected_servers = []
     for u in etcd.units:

--- a/tests/integration/test_etcd.py
+++ b/tests/integration/test_etcd.py
@@ -40,4 +40,6 @@ async def test_etcd_datastore(kubernetes_cluster: model.Model):
     status = json.loads(result.results["stdout"])
     assert status["ready"], "Cluster isn't ready"
     assert status["datastore"]["type"] == "external", "Not bootstrapped against etcd"
-    assert status["datastore"]["external-url"] == f"https://{etcd.public_address}:{etcd_port}"
+    assert status["datastore"]["servers"] == [
+        f"https://{etcd.public_address}:{etcd_port}"
+    ]


### PR DESCRIPTION
## Overview

With https://github.com/canonical/k8s-snap/pull/334 the snap allows to configure the external datastore on runtime. This allows for changes of the etcd configuration after the cluster is bootstrapped. 
The snap only performs steps (restarting services etc.) if a configuration changed. Hence, we can just send the current datastore configuration of the charm to the endpoint on every event. If there is no change, nothing happens.

## Changes

* Add `UserFacingDatastoreConfig` type as defined in the `k8s-snap` API
* Update `Datastore` status type
* Add `datastore` to the `UpdateClusterConfigRequest`
* Add new reconcile step `ensure_cluster_config`
