### PR TITLE
Improve the juju unit status

### DIFF
--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -341,14 +341,14 @@ class K8sCharm(ops.CharmBase):
             self.distributor.allocate_tokens(relation=rel, token_strategy=TokenStrategy.COS)
 
     @on_error(
-        WaitingStatus("Waiting to enable Functionalities"),
+        WaitingStatus("Waiting to enable features"),
         InvalidResponseError,
         K8sdConnectionError,
     )
     def _enable_functionalities(self):
         """Enable necessary components for the Kubernetes cluster."""
-        status.add(ops.MaintenanceStatus("Updating K8s Functionalities"))
-        log.info("Enabling K8s Functionalities")
+        status.add(ops.MaintenanceStatus("Updating K8s features"))
+        log.info("Enabling K8s features")
         dns_config = DNSConfig(enabled=True)
         network_config = NetworkConfig(enabled=True)
         user_cluster_config = UserFacingClusterConfig(dns=dns_config, network=network_config)

--- a/charms/worker/k8s/tests/unit/test_base.py
+++ b/charms/worker/k8s/tests/unit/test_base.py
@@ -86,7 +86,10 @@ def test_update_status(harness):
     """
     harness.charm.reconciler.stored.reconciled = True  # Pretended to be reconciled
     harness.charm.on.update_status.emit()
-    assert harness.model.unit.status == ops.WaitingStatus("Cluster not yet ready")
+    if harness.charm.is_worker:
+        assert harness.model.unit.status == ops.BlockedStatus("Missing cluster integration")
+    else:
+        assert harness.model.unit.status == ops.WaitingStatus("Cluster not yet ready")
 
 
 def test_set_leader(harness):

--- a/tests/integration/test_etcd.py
+++ b/tests/integration/test_etcd.py
@@ -40,4 +40,4 @@ async def test_etcd_datastore(kubernetes_cluster: model.Model):
     status = json.loads(result.results["stdout"])
     assert status["ready"], "Cluster isn't ready"
     assert status["datastore"]["type"] == "external", "Not bootstrapped against etcd"
-    assert status["datastore"]["external-url"] == f"https://{etcd.public_address}:{etcd_port}"
+    assert status["datastore"]["servers"] == [f"https://{etcd.public_address}:{etcd_port}"]


### PR DESCRIPTION
# Summary
Since the charm reconcile loops runs the same execution steps over and over, providing meaning descriptions of those stages is important.  These changes better describe the stages the charm is stepping through -- not just the early stages

# Details
* Many of the MaintenanceStatus messages were update to show that they are repeating the same stage of configuration, which may already be applied
* Improved the worker's status when it's blocked by not being related to the k8s control-plane application
