### PR TITLE
Improve node removal by validating departed|broken relations

### DIFF
--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -631,7 +631,7 @@ class K8sCharm(ops.CharmBase):
         node = node or self.get_node_name()
         cmd = ["nodes", node, '-o=jsonpath={.status.conditions[?(@.type=="Ready")].status}']
         try:
-            return self.kubectl_get(cmd) == "True"
+            return self.kubectl_get(*cmd) == "True"
         except subprocess.CalledProcessError:
             return False
 

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -639,10 +639,10 @@ class K8sCharm(ops.CharmBase):
         """Busy wait on stop event until the unit isn't clustered anymore."""
         busy_wait, reported_down = 30, 0
         status.add(ops.MaintenanceStatus("Ensuring cluster removal"))
-        while busy_wait and reported_down == 3:
+        while busy_wait and reported_down != 3:
             log.info("Waiting for this unit to uncluster")
-            if self._is_node_ready():
-                log.info("Cluster Node is still ready")
+            if self._is_node_ready() or self.api_manager.is_cluster_bootstrapped():
+                log.info("Node is still reportedly clustered")
                 reported_down = 0
             else:
                 reported_down += 1

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -628,8 +628,8 @@ class K8sCharm(ops.CharmBase):
             bool: True when this unit is marked as Ready
         """
         node = node or self.get_node_name()
-        cmd = shlex.split(f"k8s kubectl get nodes {node}")
-        cmd += ['-o=jsonpath={.status.conditions[?(@.type=="Ready")].status}']
+        run = f"{KUBECTL_PATH} --kubeconfig {self._internal_kubeconfig} get nodes {node}"
+        cmd = shlex.split(run) + ['-o=jsonpath={.status.conditions[?(@.type=="Ready")].status}']
         try:
             return subprocess.check_output(cmd) == b"True"
         except subprocess.CalledProcessError:

--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -2,10 +2,10 @@
 # See LICENSE file for licensing details.
 
 amd64:
-- name: k8s
-  install-type: store
-  channel: edge
+  - name: k8s
+    install-type: store
+    channel: edge
 arm64:
-- name: k8s
-  install-type: store
-  channel: edge
+  - name: k8s
+    install-type: store
+    channel: edge


### PR DESCRIPTION
## Summary
Attempts to lengthen the amount of time that a leaving node exists to give time to the lead control-plane charm time to remove the unit

## Changes
* revoke tokens only when `k8s-cluster` and `cluster` relations experience a RelationDepartedEvent
* detect departing unit and elect for removal
* `update_status` event now checks if the node itself is ready with kubectl
* `last_gasp` now requires the node to be reported not in a `Ready` at least 3 times before ending the delay