### PR TITLE
unpin pytest operator

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,5 +3,5 @@ pydantic<2
 pylxd
 pytest
 pytest-asyncio
-pytest-operator @ git+https://github.com/charmed-kubernetes/pytest-operator@akd/add-k8s-alpha
+pytest-operator
 tenacity


### PR DESCRIPTION
Unpin github version of pytest-operator with the release of pytest-operator 0.35.0