### PR TITLE
Cluster a node only once, block worker units which are asked to recluster with a new control-plane

### DIFF
--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -126,7 +126,7 @@ class K8sCharm(ops.CharmBase):
         self.reconciler = Reconciler(self, self._reconcile)
         self.distributor = TokenDistributor(self, self.get_node_name(), self.api_manager)
         self.collector = TokenCollector(self, self.get_node_name())
-        self.labeler = LabelMaker(
+        self.labeller = LabelMaker(
             self, kubeconfig_path=self._internal_kubeconfig, kubectl=KUBECTL_PATH
         )
         self._stored.set_default(is_dying=False, cluster_name="")
@@ -696,8 +696,8 @@ class K8sCharm(ops.CharmBase):
         """Apply labels to the node."""
         status.add(ops.MaintenanceStatus("Ensuring Kubernetes Node Labels"))
         node = self.get_node_name()
-        if self.labeler.active_labels() is not None:
-            self.labeler.apply_node_labels()
+        if self.labeller.active_labels() is not None:
+            self.labeller.apply_node_labels()
             log.info("Node %s labelled successfully", node)
         else:
             log.info("Node %s not yet labelled", node)

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -217,7 +217,7 @@ class K8sCharm(ops.CharmBase):
                     self._is_node_present(),
                 ]
             ):
-                self._stored.cluster_name = self.collector.joined_cluster_name(relation)
+                self._stored.cluster_name = self.collector.cluster_name(relation, True)
 
         log.info("%s(%s) current cluster-name=%s", unit, node, self._stored.cluster_name)
         return self._stored.cluster_name
@@ -555,10 +555,9 @@ class K8sCharm(ops.CharmBase):
         self._update_status()
         self._last_gasp()
 
+        relation = self.model.get_relation("cluster")
         local_cluster = self.get_cluster_name()
-        remote_cluster = (
-            relation := self.model.get_relation("cluster")
-        ) and self.collector.recover_cluster_name(relation)
+        remote_cluster = self.collector.cluster_name(relation, False) if relation else ""
         if local_cluster and local_cluster != remote_cluster:
             status.add(ops.BlockedStatus("Cannot rejoin new cluster - remove unit"))
 

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -17,14 +17,14 @@ certificate storage.
 
 import logging
 import os
-import re
 import shlex
 import socket
 import subprocess
+import uuid
 from functools import cached_property
 from pathlib import Path
 from time import sleep
-from typing import Dict, Optional, Union
+from typing import Dict, Union
 from urllib.parse import urlparse
 
 import charms.contextual_status as status
@@ -54,6 +54,7 @@ from charms.node_base import LabelMaker
 from charms.reconciler import Reconciler
 from cos_integration import COSIntegration
 from snap import management as snap_management
+from snap import version as snap_version
 from token_distributor import ClusterTokenType, TokenCollector, TokenDistributor, TokenStrategy
 from typing_extensions import Literal
 
@@ -95,6 +96,10 @@ def _cluster_departing_unit(event: ops.EventBase) -> Union[Literal[False], ops.U
     )
 
 
+class NodeRemovedError(Exception):
+    """Raised to prevent reconciliation of dying node."""
+
+
 class K8sCharm(ops.CharmBase):
     """A charm for managing a K8s cluster via the k8s snap.
 
@@ -102,7 +107,6 @@ class K8sCharm(ops.CharmBase):
         is_worker: true if this is a worker unit
         is_control_plane: true if this is a control-plane unit
         lead_control_plane: true if this is a control-plane unit and its the leader
-        is_dying: true if the unit is being removed
     """
 
     _stored = ops.StoredState()
@@ -125,7 +129,7 @@ class K8sCharm(ops.CharmBase):
         self.labeler = LabelMaker(
             self, kubeconfig_path=self._internal_kubeconfig, kubectl=KUBECTL_PATH
         )
-        self._stored.set_default(removing=False)
+        self._stored.set_default(is_dying=False, cluster_name="")
 
         self.cos_agent = COSAgentProvider(
             self,
@@ -180,11 +184,6 @@ class K8sCharm(ops.CharmBase):
         """Returns true if the unit is a worker."""
         return self.meta.name == "k8s-worker"
 
-    @property
-    def is_dying(self) -> bool:
-        """Returns true if the unit is being removed."""
-        return bool(self._stored.removing)
-
     def _apply_proxy_environment(self):
         """Apply the proxy settings from environment variables."""
         proxy_settings = self._get_proxy_env()
@@ -196,6 +195,32 @@ class K8sCharm(ops.CharmBase):
             current_env.update(proxy_settings)
             with open("/etc/environment", mode="w", encoding="utf-8") as file:
                 file.write("\n".join([f"{k}={v}" for k, v in current_env.items()]))
+
+    def get_cluster_name(self) -> str:
+        """Craft a unique name for the cluster once joined or bootstrapped.
+
+        Note: It won't change for the lifetime of the unit.
+
+        Returns:
+            the cluster name.
+        """
+        unit, node = self.unit.name, self.get_node_name()
+        if not self._stored.cluster_name:
+            if self.lead_control_plane and self.api_manager.is_cluster_bootstrapped():
+                # TODO: replace with API call once available from the snap
+                self._stored.cluster_name = str(uuid.uuid4())
+            elif not (relation := self.model.get_relation("cluster")):
+                pass
+            elif any(
+                [
+                    self.is_control_plane and self.api_manager.is_cluster_bootstrapped(),
+                    self._is_node_present(),
+                ]
+            ):
+                self._stored.cluster_name = self.collector.joined_cluster_name(relation)
+
+        log.info("%s(%s) current cluster-name=%s", unit, node, self._stored.cluster_name)
+        return self._stored.cluster_name
 
     def get_node_name(self) -> str:
         """Return the lowercase hostname.
@@ -352,7 +377,7 @@ class K8sCharm(ops.CharmBase):
         """
         log.info("Garbage collect cluster tokens")
         to_remove = None
-        if self.is_dying:
+        if self._stored.is_dying:
             to_remove = self.unit
         elif unit := _cluster_departing_unit(event):
             to_remove = unit
@@ -377,10 +402,6 @@ class K8sCharm(ops.CharmBase):
         """Create tokens for the units in the cluster and k8s-cluster relations."""
         log.info("Prepare clustering")
         if peer := self.model.get_relation("cluster"):
-            node_name = self.get_node_name()
-            peer.data[self.unit]["node-name"] = node_name
-            peer.data[self.unit]["joined"] = node_name
-
             self.distributor.allocate_tokens(
                 relation=peer,
                 token_strategy=TokenStrategy.CLUSTER,
@@ -489,24 +510,6 @@ class K8sCharm(ops.CharmBase):
                 proxy_settings[env_key.lower()] = env_value
         return proxy_settings
 
-    def _get_snap_version(self) -> Optional[str]:
-        """Retrieve the version of the installed Kubernetes snap package.
-
-        Returns:
-            Optional[str]: The version of the installed k8s snap package, or None if
-            not available.
-        """
-        cmd = "snap list k8s"
-        result = subprocess.check_output(shlex.split(cmd))
-        output = result.decode().strip()
-        match = re.search(r"(\d+\.\d+(?:\.\d+)?)", output)
-
-        if match:
-            return match.group()
-
-        log.info("Snap k8s not found or no version available.")
-        return None
-
     @on_error(
         WaitingStatus("Waiting for Cluster token"),
         AssertionError,
@@ -519,11 +522,7 @@ class K8sCharm(ops.CharmBase):
             status.add(ops.BlockedStatus("Missing cluster integration"))
             assert False, "Missing cluster integration"  # nosec
 
-        if self.is_control_plane and self.api_manager.is_cluster_bootstrapped():
-            relation.data[self.unit]["joined"] = self.get_node_name()
-            return
-
-        if self.collector.joined(relation):
+        if self.get_cluster_name():
             return
 
         status.add(ops.MaintenanceStatus("Joining cluster"))
@@ -541,6 +540,30 @@ class K8sCharm(ops.CharmBase):
             self.api_manager.join_cluster(request)
             log.info("Joined %s(%s)", self.unit, node_name)
 
+    @on_error(WaitingStatus("Awaiting cluster removal"))
+    def _death_handler(self, event: ops.EventBase):
+        """Reconcile end of unit's position in the cluster.
+
+        Args:
+            event: ops.EventBase - events triggered after notification of removal
+
+        Raises:
+            NodeRemovedError: at the end of every loop to prevent the unit from ever reconciling
+        """
+        if self.lead_control_plane:
+            self._revoke_cluster_tokens(event)
+        self._update_status()
+        self._last_gasp()
+
+        local_cluster = self.get_cluster_name()
+        remote_cluster = (
+            relation := self.model.get_relation("cluster")
+        ) and self.collector.recover_cluster_name(relation)
+        if local_cluster and local_cluster != remote_cluster:
+            status.add(ops.BlockedStatus("Cannot rejoin new cluster - remove unit"))
+
+        raise NodeRemovedError()
+
     def _reconcile(self, event: ops.EventBase):
         """Reconcile state change events.
 
@@ -549,13 +572,8 @@ class K8sCharm(ops.CharmBase):
         """
         log.info("Reconcile event=%s", event)
 
-        self._evaluate_removal(event)
-        if self.is_dying and self.lead_control_plane:
-            self._revoke_cluster_tokens(event)
-        if self.is_dying:
-            self._update_status()
-            self._last_gasp()
-            return
+        if self._evaluate_removal(event):
+            self._death_handler(event)
 
         self._apply_proxy_environment()
         self._install_snaps()
@@ -577,50 +595,75 @@ class K8sCharm(ops.CharmBase):
             self._copy_internal_kubeconfig()
             self._expose_ports()
 
-    @on_error(
-        ops.WaitingStatus("Cluster not yet ready"),
-        AssertionError,
-        subprocess.CalledProcessError,
-        InvalidResponseError,
-        K8sdConnectionError,
-    )
     def _update_status(self):
         """Check k8s snap status."""
-        if self.is_dying:
-            status.add(ops.WaitingStatus("Preparing to leave cluster"))
-            return
-        if self.is_control_plane:
-            assert self.api_manager.is_cluster_ready(), "control-plane not yet ready"  # nosec
-
-        if version := self._get_snap_version():
+        if version := snap_version("k8s"):
             self.unit.set_workload_version(version)
 
-        if not self._is_node_ready():
-            status.add(ops.WaitingStatus("Node not yet Ready"))
+        if not self.get_cluster_name():
+            status.add(ops.WaitingStatus("Node not Clustered"))
             return
 
-    def _evaluate_removal(self, event: ops.EventBase):
+        if not self._is_node_ready():
+            status.add(ops.WaitingStatus("Node not Ready"))
+            return
+
+    def _evaluate_removal(self, event: ops.EventBase) -> bool:
         """Determine if my unit is being removed.
 
         Args:
             event: ops.EventBase - event that triggered charm hook
+
+        Returns:
+            True if being removed, otherwise False
         """
-        if self.is_dying:
-            return
-        if unit := _cluster_departing_unit(event):
+        if self._stored.is_dying:
+            pass
+        elif (unit := _cluster_departing_unit(event)) and unit == self.unit:
             # Juju says I am being removed
-            self._stored.removing = unit == self.unit
-        elif isinstance(event, ops.RelationBrokenEvent) and event.relation.name == "cluster":
+            self._stored.is_dying = True
+        elif (
+            isinstance(event, ops.RelationBrokenEvent)
+            and event.relation.name == "cluster"
+            and self.is_worker
+        ):
             # Control-plane never experience RelationBroken on "cluster", it's a peer relation
             # Worker units experience RelationBroken on "cluster" when the relation is removed
             # or this unit is being removed.
-            self._stored.removing = self.is_worker
+            self._stored.is_dying = True
+        elif (
+            self.is_worker
+            and self.get_cluster_name()
+            and (relation := self.model.get_relation("cluster"))
+            and not relation.units
+        ):
+            # If a worker unit has been clustered,
+            # but there are no more control-plane units on the relation
+            # this unit cannot be re-clustered
+            self._stored.is_dying = True
         elif isinstance(event, (ops.RemoveEvent, ops.StopEvent)):
             # If I myself am dying, its me!
-            self._stored.removing = True
+            self._stored.is_dying = True
+        return self._stored.is_dying
+
+    def _is_node_present(self, node: str = "") -> bool:
+        """Determine if node is in the kubernetes cluster.
+
+        Args:
+            node (str): name of node
+
+        Returns:
+            bool: True when this unit appears in the node list
+        """
+        node = node or self.get_node_name()
+        cmd = ["nodes", node, "-o=jsonpath={.metadata.name}"]
+        try:
+            return self.kubectl_get(*cmd) == node
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return False
 
     def _is_node_ready(self, node: str = "") -> bool:
-        """Determine if node is in the kubernetes cluster.
+        """Determine if node is Ready in the kubernetes cluster.
 
         Args:
             node (str): name of node
@@ -632,7 +675,7 @@ class K8sCharm(ops.CharmBase):
         cmd = ["nodes", node, '-o=jsonpath={.status.conditions[?(@.type=="Ready")].status}']
         try:
             return self.kubectl_get(*cmd) == "True"
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             return False
 
     def _last_gasp(self):
@@ -664,6 +707,7 @@ class K8sCharm(ops.CharmBase):
         """Handle update-status event."""
         if not self.reconciler.stored.reconciled:
             return
+
         try:
             with status.context(self.unit):
                 self._update_status()

--- a/charms/worker/k8s/src/snap.py
+++ b/charms/worker/k8s/src/snap.py
@@ -9,6 +9,7 @@
 
 
 import logging
+import re
 import subprocess
 from pathlib import Path
 from typing import List, Literal, Optional, Union
@@ -115,3 +116,27 @@ def management():
         elif isinstance(args, SnapStoreArgument):
             log.info("Ensuring %s snap version", args.name)
             which.ensure(**args.dict(exclude_none=True))
+
+
+def version(snap: str) -> Optional[str]:
+    """Retrieve the version of the installed snap package.
+
+    Arguments:
+        snap: (str): Name of the snap
+
+    Returns:
+        Optional[str]: The version of the installed snap package, or None if
+        not available.
+    """
+    try:
+        result = subprocess.check_output(["/usr/bin/snap", "list", snap])
+    except subprocess.CalledProcessError:
+        return None
+
+    output = result.decode().strip()
+    match = re.search(r"(\d+\.\d+(?:\.\d+)?)", output)
+    if match:
+        return match.group()
+
+    log.info("Snap k8s not found or no version available.")
+    return None

--- a/charms/worker/k8s/src/token_distributor.py
+++ b/charms/worker/k8s/src/token_distributor.py
@@ -11,6 +11,7 @@ from typing import Optional
 import charms.contextual_status as status
 import ops
 from charms.k8s.v0.k8sd_api_manager import (
+    ErrorCodes,
     InvalidResponseError,
     K8sdAPIManager,
     K8sdConnectionError,
@@ -60,17 +61,16 @@ class TokenCollector:
         self.charm = charm
         self.node_name = node_name
 
-    def joined(self, relation: ops.Relation) -> bool:
+    def joined(self, relation: ops.Relation) -> str:
         """Report if this unit has completed token transfer.
 
         Args:
             relation (ops.Relation): The relation to check
 
         Returns:
-            bool: if the local unit is joined on this relation.
+            str: if the local unit is joined on this relation.
         """
-        data = relation.data[self.charm.unit].get("joined")
-        return data == self.node_name
+        return relation.data[self.charm.unit].get("joined")
 
     def request(self, relation: ops.Relation):
         """Ensure this unit is requesting a token.
@@ -80,6 +80,41 @@ class TokenCollector:
         """
         # the presence of node-name is used to request a token
         relation.data[self.charm.unit]["node-name"] = self.node_name
+
+    def recover_cluster_name(self, relation: ops.Relation) -> str:
+        """Recover cluster name from the lead unit on the relation.
+
+        Args:
+            relation (ops.Relation): The relation to check
+
+        Returns:
+            the recovered cluster name from existing relations
+        """
+        values = {
+            value for unit in relation.units if (value := relation.data[unit].get("cluster-name"))
+        }
+        if values:
+            assert len(values) == 1, f"Failed to find 1 {relation.name}:cluster-name"  # nosec
+            (value,) = values
+            return value
+
+        return ""
+
+    def joined_cluster_name(self, relation: ops.Relation) -> str:
+        """Return the current cluster this unit is joined with.
+
+        Args:
+            relation (ops.Relation): The relation to check
+
+        Returns:
+            either the current joined, or the recovered cluster name
+        """
+        if cluster_name := relation.data[self.charm.unit].get("joined"):
+            return cluster_name
+        cluster_name = relation.data[self.charm.unit]["joined"] = self.recover_cluster_name(
+            relation
+        )
+        return cluster_name
 
     @contextlib.contextmanager
     def recover_token(self, relation: ops.Relation):
@@ -112,7 +147,7 @@ class TokenCollector:
         yield content["token"]
 
         # signal that the relation is joined, the token is used
-        relation.data[self.charm.unit]["joined"] = self.node_name
+        self.recover_cluster_name(relation)
 
 
 class TokenDistributor:
@@ -177,10 +212,11 @@ class TokenDistributor:
         try:
             self.api_manager.remove_node(name)
         except (K8sdConnectionError, InvalidResponseError) as e:
-            if ignore_errors:
+            if ignore_errors or e.code == ErrorCodes.StatusNodeUnavailable:
                 # Let's just ignore some of these expected errors:
                 # "Remote end closed connection without response"
                 # "Failed to check if node is control-plane"
+                # Removing a node that doesn't exist
                 log.warning("Remove_Node %s: but with an expected error: %s", name, e)
             else:
                 raise
@@ -217,6 +253,39 @@ class TokenDistributor:
             secret = self.charm.model.get_secret(id=juju_secret)
             secret.remove_all_revisions()
 
+    def active_nodes(self, relation: ops.Relation):
+        """Get nodes from application databag for given relation.
+
+        Args:
+            relation (ops.Relation): Which relation (cluster or k8s-cluster)
+
+        Returns:
+            dict[Unit, str] each unit's node state
+        """
+        return {
+            self.charm.model.get_unit(str(u)): data
+            for u, data in relation.data[self.charm.app].items()
+        }
+
+    def drop_node(self, relation: ops.Relation, unit: ops.Unit):
+        """Remove nodes from application databag for given units.
+
+        Args:
+            relation (ops.Relation): Which relation (cluster or k8s-cluster)
+            unit (ops.Unit):         Which unit to drop from the application databag
+        """
+        relation.data[self.charm.app].pop(unit.name, None)
+
+    def update_node(self, relation: ops.Relation, unit: ops.Unit, state: str):
+        """Update node within application databag for given units.
+
+        Args:
+            relation (ops.Relation): Which relation (cluster or k8s-cluster)
+            unit (ops.Unit):         Which unit to update in the application databag
+            state (str):             State of joining the cluster
+        """
+        relation.data[self.charm.app][unit.name] = state
+
     def allocate_tokens(
         self,
         relation: ops.Relation,
@@ -240,17 +309,23 @@ class TokenDistributor:
             # include self in peer relations
             units |= {self.charm.unit}
         assert relation.app, f"Remote application doesn't exist on {relation.name}"  # nosec
-        app_databag = relation.data[self.charm.app]
 
         # Select the appropriate token creation strategy
         token_strat = self.token_creation_strategies.get(token_strategy)
         if not token_strat:
             raise ValueError(f"Invalid token_strategy: {token_strategy}")
 
+        log.info("Allocating %s tokens", token_type.value)
         status.add(ops.MaintenanceStatus(f"Allocating {token_type.value} tokens"))
+        local_cluster = self.charm.get_cluster_name()
+        relation.data[self.charm.unit]["node-name"] = self.node_name
+        relation.data[self.charm.unit]["joined"] = local_cluster
+        relation.data[self.charm.unit]["cluster-name"] = local_cluster
         for unit in units:
             secret_id = SECRET_ID.format(unit.name)
-            if not (name := relation.data[unit].get("node-name")):
+            remote_cluster = relation.data[unit].get("joined")
+            node = relation.data[unit].get("node-name")
+            if not node:
                 log.info(
                     "Wait for node-name of %s unit=%s:%s",
                     token_type.value,
@@ -258,18 +333,29 @@ class TokenDistributor:
                     unit.name,
                 )
                 continue  # wait for the joining unit to provide its node-name
-            if relation.data[unit].get("joined") == name:
-                # when a unit state it's joined, it's accepted it took
-                # ownership of a token.  We need to revoke this token
-                # if the unit leaves. Let's create a cache in
-                # our app's session of this data.
+            if remote_cluster and remote_cluster != local_cluster:
+                # ignore this unit, it's not in our cluster
                 log.info(
-                    "Completed token allocation of %s unit=%s:%s",
+                    "Ignoring token allocation of %s with unit=%s:%s (%s)",
                     token_type.value,
                     relation.name,
                     unit.name,
+                    node,
                 )
-                app_databag[unit.name] = f"joined-{name}"
+                continue  # unit reports it's joined to another cluster
+            if remote_cluster == local_cluster:
+                # when a unit state it's joined, it accepts
+                # ownership of a token. We need to revoke this token
+                # if the unit leaves. Let's create a cache in
+                # our app's session of this data.
+                log.info(
+                    "Completed token allocation of %s with unit=%s:%s (%s)",
+                    token_type.value,
+                    relation.name,
+                    unit.name,
+                    node,
+                )
+                self.update_node(relation, unit, f"joined-{node}")
                 if revoke_on_join:
                     self._revoke_juju_secret(relation, unit)
 
@@ -277,22 +363,21 @@ class TokenDistributor:
             if relation.data[self.charm.unit].get(secret_id):
                 # unit already assigned a token
                 log.info(
-                    "Waiting for token to be recovered %s unit=%s:%s",
+                    "Waiting for token to be recovered %s unit=%s:%s (%s)",
                     token_type.value,
                     relation.name,
                     unit.name,
+                    node,
                 )
                 continue
 
-            log.info(
-                "Creating token for %s unit=%s hostname=%s", token_type.value, unit.name, name
-            )
-            token = token_strat(name, token_type)
+            log.info("Creating token for %s unit=%s node=%s", token_type.value, unit.name, node)
+            token = token_strat(node, token_type)
             content = {"token": token.get_secret_value()}
             secret = relation.app.add_secret(content)
             secret.grant(relation, unit=unit)
             relation.data[self.charm.unit][secret_id] = secret.id or ""
-            app_databag[unit.name] = f"pending-{name}"
+            self.update_node(relation, unit, f"pending-{node}")
 
     def revoke_tokens(
         self,
@@ -320,8 +405,8 @@ class TokenDistributor:
             all_units |= {self.charm.unit}
 
         # any unit in the app_databag, which successfully recovered its token
-        app_databag = relation.data[self.charm.app]
-        joined = {self.charm.model.get_unit(str(u)) for u in app_databag}
+        app_databag = self.active_nodes(relation)
+        joined = set(app_databag.keys())
 
         # establish the remaining units
         remove = {to_remove} if to_remove else (joined - all_units)
@@ -343,9 +428,11 @@ class TokenDistributor:
             raise ValueError(f"Invalid token_strategy: {token_strategy}")
 
         status.add(ops.MaintenanceStatus(f"Revoking {token_type.value} tokens"))
+        local_cluster = self.charm.get_cluster_name()
         for unit in remove:
-            if node_state := app_databag.get(unit.name):
+            if node_state := app_databag.get(unit):
                 state, node = node_state.split("-", 1)
+                remote_cluster = (data := relation.data.get(unit)) and data.get("joined")
                 log.info(
                     "Revoking token for %s unit=%s:%s %s node=%s",
                     token_type.value,
@@ -354,10 +441,11 @@ class TokenDistributor:
                     state,
                     node,
                 )
-                # ignore pending state, because we can't confirm
-                # if the other node ever used the token to join
-                # ignore self revocation
-                ignore_errors = self.node_name == node or state == "pending"
+                ignore_errors = self.node_name == node  # ignore errors removing myself
+                ignore_errors |= state == "pending"  # ignore errors on pending tokens
+                ignore_errors |= (
+                    local_cluster != remote_cluster
+                )  # ignore errors if cluster doesn't match
                 token_strat(node, ignore_errors)
-                del app_databag[unit.name]
+                self.drop_node(relation, unit)
                 self._revoke_juju_secret(relation, unit)

--- a/charms/worker/k8s/src/token_distributor.py
+++ b/charms/worker/k8s/src/token_distributor.py
@@ -424,11 +424,9 @@ class TokenDistributor:
                     state,
                     node,
                 )
-                ignore_errors = self.node_name == node  # ignore errors removing myself
-                ignore_errors |= state == "pending"  # ignore errors on pending tokens
-                ignore_errors |= (
-                    local_cluster != remote_cluster
-                )  # ignore errors if cluster doesn't match
+                ignore_errors = self.node_name == node  # removing myself
+                ignore_errors |= state == "pending"  # on pending tokens
+                ignore_errors |= local_cluster != remote_cluster  # if cluster doesn't match
                 token_strat(node, ignore_errors)
                 self.drop_node(relation, unit)
                 self._revoke_juju_secret(relation, unit)

--- a/charms/worker/k8s/tests/unit/test_base.py
+++ b/charms/worker/k8s/tests/unit/test_base.py
@@ -91,8 +91,9 @@ def test_update_status(harness):
         harness: the harness under test
     """
     harness.charm.reconciler.stored.reconciled = True  # Pretended to be reconciled
+    harness.model.unit.status = ops.WaitingStatus("Unchanged")
     harness.charm.on.update_status.emit()
-    assert harness.model.unit.status == ops.WaitingStatus("Cluster not yet ready")
+    assert harness.model.unit.status == ops.WaitingStatus("Node not Clustered")
 
 
 def test_set_leader(harness):
@@ -103,6 +104,7 @@ def test_set_leader(harness):
     """
     harness.charm.reconciler.stored.reconciled = False  # Pretended to not be reconciled
     with mock_reconciler_handlers(harness) as handlers:
+        handlers["_evaluate_removal"].return_value = False
         harness.set_leader(True)
     assert harness.model.unit.status == ops.ActiveStatus("Ready")
     assert harness.charm.reconciler.stored.reconciled

--- a/charms/worker/k8s/tests/unit/test_snap.py
+++ b/charms/worker/k8s/tests/unit/test_snap.py
@@ -7,6 +7,7 @@
 """Unit tests snap module."""
 
 import io
+import subprocess
 import unittest.mock as mock
 from pathlib import Path
 
@@ -120,3 +121,19 @@ def test_management_installs_store(cache, install_local, args):
     cache()["k8s"].ensure.assert_called_once_with(
         state=snap.snap_lib.SnapState.Present, channel="edge"
     )
+
+
+@mock.patch("subprocess.check_output")
+def test_version(check_output):
+    """Test snap list returns the correct version."""
+    check_output.return_value = b""
+    assert snap.version(snap="k8s") is None
+
+    check_output.return_value = """
+Name  Version    Rev    Tracking       Publisher   Notes
+k8s   1.30.0     1234   latest/stable  canonical✓
+""".encode()
+    assert snap.version(snap="k8s") == "1.30.0"
+
+    check_output.side_effect = subprocess.CalledProcessError(-1, [], None, None)
+    assert snap.version(snap="k8s") is None

--- a/charms/worker/k8s/tests/unit/test_token_distributor.py
+++ b/charms/worker/k8s/tests/unit/test_token_distributor.py
@@ -1,0 +1,74 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Learn more about testing at: https://juju.is/docs/sdk/testing
+
+# pylint: disable=duplicate-code,missing-function-docstring
+"""Unit tests token_distributor module."""
+
+from pathlib import Path
+
+import ops
+import ops.testing
+import pytest
+import token_distributor
+from charm import K8sCharm
+
+
+@pytest.fixture(params=["worker", "control-plane"])
+def harness(request):
+    """Craft a ops test harness.
+
+    Args:
+        request: pytest request object
+    """
+    meta = Path(__file__).parent / "../../charmcraft.yaml"
+    if request.param == "worker":
+        meta = Path(__file__).parent / "../../../charmcraft.yaml"
+    harness = ops.testing.Harness(K8sCharm, meta=meta.read_text())
+    harness.begin()
+    harness.charm.is_worker = request.param == "worker"
+    yield harness
+    harness.cleanup()
+
+
+def test_request(harness):
+    """Test request adds node-name."""
+    harness.disable_hooks()
+    collector = token_distributor.TokenCollector(harness.charm, "my-node")
+    relation_id = harness.add_relation("cluster", "remote")
+    collector.request(harness.charm.model.get_relation("cluster"))
+    data = harness.get_relation_data(relation_id, harness.charm.unit.name)
+    assert data["node-name"] == "my-node"
+
+
+def test_cluster_name_not_joined(harness):
+    """Test cluster name while not bootstrapped."""
+    harness.disable_hooks()
+    collector = token_distributor.TokenCollector(harness.charm, "my-node")
+    relation_id = harness.add_relation("cluster", "remote")
+    remote = collector.cluster_name(harness.charm.model.get_relation("cluster"), False)
+    local = collector.cluster_name(harness.charm.model.get_relation("cluster"), True)
+    assert remote == local == ""
+    data = harness.get_relation_data(relation_id, harness.charm.unit.name)
+    assert not data.get("joined")
+
+
+def test_cluster_name_joined(harness):
+    """Test cluster name while not bootstrapped."""
+    harness.disable_hooks()
+    collector = token_distributor.TokenCollector(harness.charm, "my-node")
+    relation_id = harness.add_relation(
+        "cluster", "remote", unit_data={"cluster-name": "my-cluster"}
+    )
+    # Fetching the remote doesn't update joined field
+    remote = collector.cluster_name(harness.charm.model.get_relation("cluster"), False)
+    assert remote == "my-cluster"
+    data = harness.get_relation_data(relation_id, harness.charm.unit.name)
+    assert not data.get("joined")
+
+    # Fetching the local does update joined field
+    local = collector.cluster_name(harness.charm.model.get_relation("cluster"), True)
+    assert remote == local == "my-cluster"
+    data = harness.get_relation_data(relation_id, harness.charm.unit.name)
+    assert data["joined"] == "my-cluster"

--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -58,10 +58,10 @@ async def test_nodes_labelled(request, kubernetes_cluster: model.Model):
         juju_nodes = [n for n in nodes if "juju-charm" in n["metadata"]["labels"]]
         assert len(k8s.units + worker.units) == len(
             labelled
-        ), "Not all nodes labeled with custom-label"
+        ), "Not all nodes labelled with custom-label"
         assert len(k8s.units + worker.units) == len(
             juju_nodes
-        ), "Not all nodes labeled as juju-charms"
+        ), "Not all nodes labelled as juju-charms"
     finally:
         await asyncio.gather(
             k8s.reset_config(list(label_config)), worker.reset_config(list(label_config))
@@ -71,7 +71,7 @@ async def test_nodes_labelled(request, kubernetes_cluster: model.Model):
     nodes = await get_nodes(k8s.units[0])
     labelled = [n for n in nodes if testname in n["metadata"]["labels"]]
     juju_nodes = [n for n in nodes if "juju-charm" in n["metadata"]["labels"]]
-    assert 0 == len(labelled), "Not all nodes labeled with custom-label"
+    assert 0 == len(labelled), "Not all nodes labelled with custom-label"
 
 
 @pytest.mark.abort_on_fail


### PR DESCRIPTION
Address #74 and  #75 

## Overview
Prevent reclustering errors after removing all control-plane units without destroying the control-plane application itself.

## Details
* If all control-plane units are removed  --  a new one would constitute a new cluster
  Therefore existing workers should not try to cluster with the new control-plane units.
* on API join and the node is already clustered, ignore error response
* on API remove and the node is not joined, ignore error response
* dying nodes never reconcile (any juju event will be handled with reconciler)
* synchronize cluster relation using a unique `cluster-name` from the leader control-plane
* synchronize cluster relation using a response from units on the  `joined` field
* ignore errors while removing tokens when:
   1) node is removing itself
   2) token may not have been used (it was a pending token)
   3) local `cluster-name` doesn't match remote `cluster-name`