### PR TITLE
pin operator-workflow to a commit

### DIFF
--- a/.github/workflows/auto-update-libs-k8s-worker.yaml
+++ b/.github/workflows/auto-update-libs-k8s-worker.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   auto-update-libs:
-    uses: canonical/operator-workflows/.github/workflows/auto_update_charm_libs.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/auto_update_charm_libs.yaml@08c5a65a0bc4696164b4f85a29a9ccbd830d10d8
     secrets: inherit
     with:
       working-directory:  ./charms/worker/k8s

--- a/.github/workflows/charm-analysis.yaml
+++ b/.github/workflows/charm-analysis.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   unit-tests:
-    uses: canonical/operator-workflows/.github/workflows/test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/test.yaml@08c5a65a0bc4696164b4f85a29a9ccbd830d10d8
     secrets: inherit
     with:
       charm-directory: charms

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   comment-on-pr:
-    uses: canonical/operator-workflows/.github/workflows/comment.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/comment.yaml@08c5a65a0bc4696164b4f85a29a9ccbd830d10d8
     secrets: inherit

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -36,7 +36,7 @@ jobs:
       working-directory:  ${{ matrix.path }}
 
   integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@08c5a65a0bc4696164b4f85a29a9ccbd830d10d8
     needs: [build-all-charms, extra-args]
     strategy:
       matrix:

--- a/.github/workflows/load_test.yaml
+++ b/.github/workflows/load_test.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   load-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@08c5a65a0bc4696164b4f85a29a9ccbd830d10d8
     with:
       provider: lxd
       juju-channel: 3.3/stable

--- a/.github/workflows/promote-charms.yaml
+++ b/.github/workflows/promote-charms.yaml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         charm-directory: ${{ fromJson(needs.select-charms.outputs.charms) }}
-    uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@08c5a65a0bc4696164b4f85a29a9ccbd830d10d8
     with:
       origin-channel: ${{needs.configure-track.outputs.track}}/${{ github.event.inputs.origin-risk }}
       destination-channel: ${{needs.configure-track.outputs.track}}/${{ github.event.inputs.destination-risk }}

--- a/.github/workflows/publish-charms.yaml
+++ b/.github/workflows/publish-charms.yaml
@@ -32,7 +32,7 @@ jobs:
           fi
   publish-to-edge:
     needs: [configure-channel]
-    uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@08c5a65a0bc4696164b4f85a29a9ccbd830d10d8
     strategy:
       matrix:
         charm: [

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -48,9 +48,6 @@ def pytest_configure(config):
     """
     config.addinivalue_line("markers", "cos: mark COS integration tests.")
     config.addinivalue_line("markers", "bundle_file(name): specify a YAML bundle file for a test.")
-    config.addinivalue_line(
-        "markers", "ignore_blocked: specify if the bundle deploy should ignore BlockedStatus."
-    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -214,7 +211,6 @@ async def deploy_model(
     ops_test: OpsTest,
     model_name: str,
     bundle: Bundle,
-    raise_on_blocked=True,
 ):
     """Add a juju model, deploy apps into it, wait for them to be active.
 
@@ -223,7 +219,6 @@ async def deploy_model(
         ops_test:          Instance of the pytest-operator plugin
         model_name:        name of the model in which to deploy
         bundle:            Bundle object to deploy or redeploy into the model
-        raise_on_blocked:  Raise if any unit in the model is blocked
 
     Yields:
         model object
@@ -246,7 +241,6 @@ async def deploy_model(
             await the_model.wait_for_idle(
                 apps=list(bundle.applications),
                 status="active",
-                raise_on_blocked=raise_on_blocked,
                 timeout=30 * 60,
             )
         yield the_model
@@ -259,11 +253,6 @@ async def kubernetes_cluster(request: pytest.FixtureRequest, ops_test: OpsTest):
     bundle_marker = request.node.get_closest_marker("bundle_file")
     if bundle_marker:
         bundle_file = bundle_marker.args[0]
-
-    raise_on_blocked = True
-    ignore_blocked = request.node.get_closest_marker("ignore_blocked")
-    if ignore_blocked:
-        raise_on_blocked = False
 
     log.info("Deploying cluster using %s bundle.", bundle_file)
 
@@ -278,7 +267,7 @@ async def kubernetes_cluster(request: pytest.FixtureRequest, ops_test: OpsTest):
         bundle.drop_constraints()
     for path, charm in zip(charm_files, charms):
         bundle.switch(charm.app_name, path)
-    async with deploy_model(request, ops_test, model, bundle, raise_on_blocked) as the_model:
+    async with deploy_model(request, ops_test, model, bundle) as the_model:
         yield the_model
 
 

--- a/tests/integration/test_etcd.py
+++ b/tests/integration/test_etcd.py
@@ -16,7 +16,6 @@ from .helpers import ready_nodes
 # bundle with etcd, for all the test within this module.
 pytestmark = [
     pytest.mark.bundle_file("test-bundle-etcd.yaml"),
-    pytest.mark.ignore_blocked,
 ]
 
 


### PR DESCRIPTION
# Summary
Pinning operator-workflows to https://github.com/canonical/operator-workflows/commit/08c5a65a0bc4696164b4f85a29a9ccbd830d10d8

# Overview
Not only does this pin the workflows but it fixes a race condition where sometimes the CI fails when it sees k8s-worker in a blocked state.  That's not necessarily an error -- blocked state is just fine.  It's really error state we should be worried about. 