### PR TITLE
[Release 1.30] Snap Revision Update

### DIFF
--- a/.github/workflows/update-snap-revision.py
+++ b/.github/workflows/update-snap-revision.py
@@ -11,12 +11,19 @@ from pathlib import Path
 from urllib.request import Request, urlopen
 import yaml
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(format="%(levelname)-8s: %(message)s", level=logging.INFO)
 log = logging.getLogger("update-snap-revision")
-
+TRACK = "1.30-classic"
+RISK = "stable"
 ROOT = Path(__file__).parent / ".." / ".."
 INSTALLATION = ROOT / "charms/worker/k8s/templates/snap_installation.yaml"
 LICENSE = Path(__file__).read_text().splitlines(keepends=True)[1:4]
+
+
+def _multiline_log(logger, message, *args, **kwargs):
+    NEWLINE_INDENT = "\n          * "
+    logger(message.replace("\n", NEWLINE_INDENT), *args, **kwargs)
+
 
 def find_current_revision(arch: str) -> None | str:
     content = yaml.safe_load(INSTALLATION.read_text())
@@ -24,11 +31,11 @@ def find_current_revision(arch: str) -> None | str:
         for value in arch_spec:
             if value.get("name") == "k8s":
                 rev = value.get("revision")
-                log.info("Currently arch=%s revision=%s", arch, rev)
+                log.info("Currently arch='%s' revision='%s'", arch, rev)
                 return rev
 
 
-def find_snapstore_revision(track: str, arch: str, risk: str) -> str:
+def find_snapstore_revision(arch: str, track: str, risk: str) -> str:
     URL = f"https://api.snapcraft.io/v2/snaps/info/k8s?architecture={arch}&fields=revision"
     HEADER = {"Snap-Device-Series": 16}
     req = Request(URL, headers=HEADER)
@@ -42,9 +49,22 @@ def find_snapstore_revision(track: str, arch: str, risk: str) -> str:
             and track in channel.get("track")
         ):
             rev = mapping.get("revision")
-            log.info("SnapStore arch=%s revision=%s track=%s%s", arch, rev, track, f" risk={risk}" if risk else "")
+            log.info(
+                "SnapStore arch='%s' revision='%s' track='%s'%s",
+                arch,
+                rev,
+                track,
+                f" risk='{risk}'" if risk else "",
+            )
             return rev
-    log.warning("SnapStore arch=%s revision=%s track=%s%s", arch, "N/A", track, f" risk={risk}" if risk else "")
+    _multiline_log(
+        log.warning,
+        "Failed to find a revision matching the arch/track/risk\n"
+        "SnapStore arch='%s' track='%s'%s",
+        arch,
+        track,
+        f" risk='{risk}'" if risk else "",
+    )
 
 
 def update_current_revision(arch: str, rev: str):
@@ -59,22 +79,18 @@ def update_current_revision(arch: str, rev: str):
         f.write(yaml.safe_dump(content))
 
 
-def update_github_env(variable:str, value:str):
+def update_github_env(variable: str, value: str):
     if github_output := os.environ.get("GITHUB_OUTPUT", None):
         with Path(github_output).open(mode="a+") as f:
             f.write(f"{variable}={value}")
 
 
 if __name__ == "__main__":
-    arch, track, risk = sys.argv[1:]
+    arch, *_ = sys.argv[1:]
     current_rev = find_current_revision(arch)
-    snapstore_rev = find_snapstore_revision(track, arch, risk)
-    if (
-        snapstore_rev and
-        current_rev and
-        current_rev != snapstore_rev
-    ):
+    snapstore_rev = find_snapstore_revision(arch, TRACK, RISK)
+    if snapstore_rev and current_rev and current_rev != snapstore_rev:
         update_current_revision(arch, snapstore_rev)
         update_github_env("result", snapstore_rev)
     else:
-        log.info("No change arch=%s current=%s snapstore=%s", arch, current_rev, snapstore_rev)        
+        log.info("No change arch=%s current=%s snapstore=%s", arch, current_rev, snapstore_rev)

--- a/.github/workflows/update-snap-revision.py
+++ b/.github/workflows/update-snap-revision.py
@@ -79,7 +79,7 @@ def update_current_revision(arch: str, rev: str):
         f.write(yaml.safe_dump(content))
 
 
-def update_github_env(variable: str, value: str):
+def update_github_output(variable: str, value: str):
     if github_output := os.environ.get("GITHUB_OUTPUT", None):
         with Path(github_output).open(mode="a+") as f:
             f.write(f"{variable}={value}")
@@ -91,6 +91,6 @@ if __name__ == "__main__":
     snapstore_rev = find_snapstore_revision(arch, TRACK, RISK)
     if snapstore_rev and current_rev and current_rev != snapstore_rev:
         update_current_revision(arch, snapstore_rev)
-        update_github_env("result", snapstore_rev)
+        update_github_output("result", snapstore_rev)
     else:
         log.info("No change arch=%s current=%s snapstore=%s", arch, current_rev, snapstore_rev)

--- a/charms/worker/k8s/src/snap.py
+++ b/charms/worker/k8s/src/snap.py
@@ -117,6 +117,7 @@ def management():
             if which.revision != args.revision:
                 log.info("Ensuring %s snap revision=%s", args.name, args.revision)
                 which.ensure(**args.dict(exclude_none=True))
+                which.hold()
         elif isinstance(args, SnapStoreArgument):
             log.info("Ensuring %s snap channel=%s", args.name, args.channel)
             which.ensure(**args.dict(exclude_none=True))

--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,10 +4,8 @@
 amd64:
   - name: k8s
     install-type: store
-    channel: 1.30-classic/stable
     revision: 313
 arm64:
   - name: k8s
     install-type: store
-    channel: 1.30-classic/stable
     revision: 314

--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -5,8 +5,9 @@ amd64:
   - name: k8s
     install-type: store
     channel: 1.30-classic/stable
-    revision: 301
+    revision: 313
 arm64:
   - name: k8s
     install-type: store
-    channel: edge
+    channel: 1.30-classic/stable
+    revision: 314


### PR DESCRIPTION
Release 1.30 Update

Pinning amd64 revision to 313
Pinning arm64 revision to 314
Removes snap channel following
Enforces a snap hold forever


The CI job checks for new versions on `1.30-classic/stable` and updates when new stables are available
* this release branch will publish charms to 1.30/edge but using only 1.30-classic/stable snaps
