### PR TITLE
`runs-on` noble requires at least juju3.3 and beyond

### DIFF
--- a/charms/worker/charmcraft.yaml
+++ b/charms/worker/charmcraft.yaml
@@ -25,7 +25,7 @@ links:
     - https://github.com/canonical/k8s-operator
 
 assumes:
-  - juju >= 3.1
+  - juju >= 3.3
 
 type: charm
 bases:

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -34,7 +34,7 @@ links:
     - https://github.com/canonical/k8s-operator
 
 assumes:
-  - juju >= 3.1
+  - juju >= 3.3
 
 type: charm
 bases:


### PR DESCRIPTION
Resolves https://github.com/canonical/k8s-operator/issues/107

It seems that a bug in juju 3.1 prevents the k8s charm from deploying on any series (jammy or focal) because it mentions an unsupported series (noble)

The message from juju is cryptic (see issue) so to not confuse users, it seems most prudent to just update the minimum version of the charm to 3.3\


Will need to cherry-pick to main on merge