### PR TITLE
Prefer the cluster relation for bootstrap address rather than juju-info

### DIFF
--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -286,7 +286,7 @@ class K8sCharm(ops.CharmBase):
 
         status.add(ops.MaintenanceStatus("Bootstrapping Cluster"))
 
-        binding = self.model.get_binding("juju-info")
+        binding = self.model.get_binding("cluster")
         address = binding and binding.network.ingress_address
         node_name = self.get_node_name()
         payload = CreateClusterRequest(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -243,7 +243,10 @@ async def deploy_model(
                 status="active",
                 timeout=30 * 60,
             )
-        yield the_model
+        try:
+            yield the_model
+        except GeneratorExit:
+            log.fatal("Failed to determine model: model_name=%s", model_name)
 
 
 @pytest_asyncio.fixture(scope="module")


### PR DESCRIPTION
Swap from `juju-info` relation to `cluster` relation when determining which address to bind for bootstrapping