### PR TITLE
Use systemd to reschedule update-status hooks

### DIFF
--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -30,6 +30,7 @@ from urllib.parse import urlparse
 import charms.contextual_status as status
 import charms.operator_libs_linux.v2.snap as snap_lib
 import ops
+import reschedule
 import yaml
 from charms.contextual_status import WaitingStatus, on_error
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
@@ -603,9 +604,12 @@ class K8sCharm(ops.CharmBase):
             status.add(ops.WaitingStatus("Node not Clustered"))
             return
 
+        trigger = reschedule.PeriodicEvent(self)
         if not self._is_node_ready():
             status.add(ops.WaitingStatus("Node not Ready"))
+            trigger.create(reschedule.Period(seconds=30))
             return
+        trigger.cancel()
 
     def _evaluate_removal(self, event: ops.EventBase) -> bool:
         """Determine if my unit is being removed.

--- a/charms/worker/k8s/src/reschedule.py
+++ b/charms/worker/k8s/src/reschedule.py
@@ -1,67 +1,236 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Module used to create scheduled hook events by abusing juju secret expirations."""
+"""EventTimer for scheduling dispatch of juju event on regular intervals."""
 
 import logging
-from dataclasses import dataclass
+import subprocess
 from datetime import timedelta
-from typing import Optional
+from pathlib import Path
+from typing import List, Optional, Tuple, TypedDict
 
 import ops
 
 log = logging.getLogger(__name__)
-PERIODIC_LABEL = "{unit}-{name}-periodic"
 Period = timedelta  # Type aliasing
+BIN_SYSTEMCTL = "/usr/bin/systemctl"
+SYSTEMD_SERVICE = """
+[Unit]
+Description=Dispatch the {event} event on {unit}
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/timeout {timeout} /usr/bin/bash -c '/usr/bin/juju-exec "{unit}" "JUJU_DISPATCH_PATH={event} ./dispatch"'
+
+[Install]
+WantedBy=multi-user.target
+"""
+SYSTEMD_TIMER = """
+[Unit]
+Description=Timer to dispatch {event} event periodically
+Requires={app}.{event}.service
+
+[Timer]
+Unit={app}.{event}.service
+OnUnitInactiveSec={interval}m
+RandomizedDelaySec={random_delay}m
+
+[Install]
+WantedBy=timers.target
+"""
 
 
-def _model(event: ops.EventBase) -> ops.Model:
-    return event.framework.model
+def execute_command(args: List[str], check_exit: bool = True) -> Tuple[str, int]:
+    """Subprocess run wrapper.
+
+    Args:
+        args (List[str]): arguments to subprocess
+        check_exit (bool): True if we raise on errors
+
+    Returns:
+        stdout, int : tuple to handled output.
+    """
+    s = subprocess.run(args, capture_output=True, check=check_exit)
+    return s.stdout.decode(), s.returncode
 
 
-def _secret_find(event: ops.EventBase, **selector) -> Optional[ops.Secret]:
-    model = _model(event)
-    secret = None
-    try:
-        secret = model.get_secret(**selector)
-    except ops.SecretNotFoundError:
-        log.info("No Secret found matching %s", selector)
-    else:
-        log.info("Secret found matching %s: id=%s", selector, secret.id)
-    return secret
+class TimerError(Exception):
+    """Generic timer error as base exception."""
 
 
-def _secret_delete(event: ops.EventBase, **selector):
-    if secret := _secret_find(event, **selector):
-        info = secret.get_info()
-        if info.id:
-            log.info("Removing secret matching %s: id=%d rev=%s", selector, info.id, info.revision)
-            secret.remove_revision(revision=info.revision)
+class TimerEnableError(TimerError):
+    """Raised when unable to enable a event timer."""
 
 
-def _secret_create(event: ops.EventBase, period: Period, **selector) -> ops.Secret:
-    unit = _model(event).unit
-    log.info("Creating Secret matching %s with period %s", selector, period)
-    unit.add_secret(
-        content={"secret": "abuse"},
-        description="Secret used to reschedule hook events on this unit",
-        expire=period,
-        **selector
-    )
+class TimerDisableError(TimerError):
+    """Raised when unable to disable a event timer."""
 
 
-@dataclass
+class TimerStatusError(TimerError):
+    """Raised when unable to check status of a event timer."""
+
+
+class EventConfig(TypedDict):
+    """Configuration used by service and timer templates.
+
+    Attributes:
+        app: Name of the juju application.
+        event: Name of the event.
+        interval: Minutes between the event trigger.
+        random_delay: Minutes of random delay added between event trigger.
+        timeout: Minutes before the event handle is timeout.
+        unit: Name of the juju unit.
+    """
+
+    app: str
+    event: str
+    interval: int
+    random_delay: int
+    timeout: int
+    unit: str
+
+
+class EventTimer:
+    """Manages the timer to emit juju events at regular intervals.
+
+    Attributes:
+        unit_name (str): Name of the juju unit to emit events to.
+    """
+
+    _systemd_path = Path("/etc/systemd/system")
+
+    def __init__(self, unit: ops.Unit):
+        """Construct the timer manager.
+
+        Args:
+            unit: Name of the juju unit to emit events to.
+        """
+        self._unit = unit
+        self.unit_name = unit.name
+        self.app_name = unit.app.name
+
+    def _render_event_template(
+        self, template_type: str, event_name: str, context: EventConfig
+    ) -> None:
+        """Write event configuration files to systemd path.
+
+        Args:
+            template_type: Name of the template type to use. Can be 'service' or 'timer'.
+            event_name: Name of the event to schedule.
+            context: Addition configuration for the event to schedule.
+        """
+        template = SYSTEMD_SERVICE if "service" == template_type else SYSTEMD_TIMER
+        dest = self._systemd_path / f"{self.app_name}.{event_name}.{template_type}"
+        dest.write_text(template.format(**context))
+
+    def is_active(self, event_name: str) -> bool:
+        """Check if the systemd timer is active for the given event.
+
+        Args:
+            event_name: Name of the juju event to check.
+
+        Returns:
+            True if the timer is enabled, False otherwise.
+
+        Raises:
+            TimerStatusError: Timer status cannot be determined.
+        """
+        try:
+            # We choose status over is-active here to provide debug logs that show the output of
+            # the timer.
+            _, ret_code = execute_command(
+                [BIN_SYSTEMCTL, "status", f"{self.app_name}.{event_name}.timer"], check_exit=False
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as ex:
+            raise TimerStatusError from ex
+
+        return ret_code == 0
+
+    def ensure_event_timer(
+        self, event_name: str, interval: int, timeout: Optional[int] = None
+    ) -> None:
+        """Ensure that a systemd service and timer are registered to dispatch the given event.
+
+        The interval is how frequently, in minutes, the event should be dispatched.
+
+        The timeout is the number of seconds before an event is timed out. If not set or 0,
+        it defaults to half the interval period.
+
+        Args:
+            event_name: Name of the juju event to schedule.
+            interval: Number of minutes between emitting each event.
+            timeout: Timeout for each event handle in minutes.
+
+        Raises:
+            TimerEnableError: Timer cannot be started. Events will be not emitted.
+        """
+        if timeout is not None:
+            timeout_in_secs = timeout * 60
+        else:
+            timeout_in_secs = interval * 30
+
+        context: EventConfig = {
+            "event": event_name,
+            "interval": interval,
+            "random_delay": interval // 4,
+            "timeout": timeout_in_secs,
+            "unit": self.unit_name,
+            "app": self.app_name,
+        }
+        self._render_event_template("service", event_name, context)
+        self._render_event_template("timer", event_name, context)
+
+        systemd_timer = f"{self.app_name}.{event_name}.timer"
+        try:
+            execute_command([BIN_SYSTEMCTL, "daemon-reload"])
+            execute_command([BIN_SYSTEMCTL, "enable", systemd_timer])
+            execute_command([BIN_SYSTEMCTL, "start", systemd_timer])
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as ex:
+            raise TimerEnableError(f"Unable to enable systemd timer {systemd_timer}") from ex
+
+    def disable_event_timer(self, event_name: str) -> None:
+        """Disable the systemd timer for the given event.
+
+        Args:
+            event_name: Name of the juju event to disable.
+
+        Raises:
+            TimerDisableError: Timer cannot be stopped. Events will be emitted continuously.
+        """
+        systemd_timer = f"{self.app_name}.{event_name}.timer"
+        try:
+            # Don't check for errors in case the timer wasn't registered.
+            execute_command([BIN_SYSTEMCTL, "stop", systemd_timer], check_exit=False)
+            execute_command([BIN_SYSTEMCTL, "disable", systemd_timer], check_exit=False)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as ex:
+            raise TimerDisableError(f"Unable to disable systemd timer {systemd_timer}") from ex
+
+
 class PeriodicEvent:
-    name: str
+    """Manages the event trigger."""
 
-    def _label(self, event: ops.EventBase):
-        model = _model(event)
-        return PERIODIC_LABEL.format(unit=model.unit.name, name=self.name)
+    def __init__(self, charm: ops.CharmBase, event_name: str = "update_status"):
+        """Crafts a PeriodicEvent.
 
-    def cancel(self, event: ops.EventBase):
-        log.info("Cancelling timer for %s", self.name)
-        _secret_delete(event, label=self._label(event))
+        Args:
+            charm (ops.CharmBase): charm object to retrigger.
+            event_name (str):      name of the juju event to retrigger.
+        """
+        self._name = event_name
+        self._timer = EventTimer(charm.unit)
 
-    def create(self, event: ops.EventBase, period: Period):
-        log.info("Creating timer for %s", self.name)
-        _secret_create(event, period, label=self._label(event))
+    def create(self, period: Period):
+        """Ensure that a periodic timer is active.
+
+        Args:
+            period (Period): timedelta determining how long to wait before trigger
+        """
+        log.info("Creating timer for %s", self._name)
+        if not self._timer.is_active(self._name):
+            self._timer.ensure_event_timer(self._name, period.seconds // 60)
+
+    def cancel(self):
+        """Cancel any active triggers."""
+        log.info("Cancelling timer for %s", self._name)
+        if self._timer.is_active(self._name):
+            self._timer.disable_event_timer(self._name)

--- a/charms/worker/k8s/src/reschedule.py
+++ b/charms/worker/k8s/src/reschedule.py
@@ -1,0 +1,67 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Module used to create scheduled hook events by abusing juju secret expirations."""
+
+import logging
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Optional
+
+import ops
+
+log = logging.getLogger(__name__)
+PERIODIC_LABEL = "{unit}-{name}-periodic"
+Period = timedelta  # Type aliasing
+
+
+def _model(event: ops.EventBase) -> ops.Model:
+    return event.framework.model
+
+
+def _secret_find(event: ops.EventBase, **selector) -> Optional[ops.Secret]:
+    model = _model(event)
+    secret = None
+    try:
+        secret = model.get_secret(**selector)
+    except ops.SecretNotFoundError:
+        log.info("No Secret found matching %s", selector)
+    else:
+        log.info("Secret found matching %s: id=%s", selector, secret.id)
+    return secret
+
+
+def _secret_delete(event: ops.EventBase, **selector):
+    if secret := _secret_find(event, **selector):
+        info = secret.get_info()
+        if info.id:
+            log.info("Removing secret matching %s: id=%d rev=%s", selector, info.id, info.revision)
+            secret.remove_revision(revision=info.revision)
+
+
+def _secret_create(event: ops.EventBase, period: Period, **selector) -> ops.Secret:
+    unit = _model(event).unit
+    log.info("Creating Secret matching %s with period %s", selector, period)
+    unit.add_secret(
+        content={"secret": "abuse"},
+        description="Secret used to reschedule hook events on this unit",
+        expire=period,
+        **selector
+    )
+
+
+@dataclass
+class PeriodicEvent:
+    name: str
+
+    def _label(self, event: ops.EventBase):
+        model = _model(event)
+        return PERIODIC_LABEL.format(unit=model.unit.name, name=self.name)
+
+    def cancel(self, event: ops.EventBase):
+        log.info("Cancelling timer for %s", self.name)
+        _secret_delete(event, label=self._label(event))
+
+    def create(self, event: ops.EventBase, period: Period):
+        log.info("Creating timer for %s", self.name)
+        _secret_create(event, period, label=self._label(event))

--- a/charms/worker/k8s/tests/unit/test_reschedule.py
+++ b/charms/worker/k8s/tests/unit/test_reschedule.py
@@ -1,0 +1,138 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Learn more about testing at: https://juju.is/docs/sdk/testing
+
+"""Unit tests reschedule module."""
+
+import subprocess
+import unittest.mock as mock
+from pathlib import Path
+
+import ops
+import pytest
+import reschedule
+from charm import K8sCharm
+
+
+@pytest.fixture
+def harness():
+    """Craft a ops test harness."""
+    meta = Path(__file__).parent / "../../charmcraft.yaml"
+    harness = ops.testing.Harness(K8sCharm, meta=meta.read_text())
+    harness.begin()
+    yield harness
+    harness.cleanup()
+
+
+@mock.patch("reschedule.subprocess.run")
+def test_execute_command(subprocess_run):
+    """Test no file exists."""
+    subprocess_run.return_value.returncode = 0
+
+    args = ["cat", "/made/up/file"]
+    rc = reschedule._execute_command(args)
+
+    subprocess_run.assert_called_once_with(args, check=True)
+    assert rc == 0
+
+
+def test_event_timer_properties(harness):
+    """Test Event Timer properties."""
+    et = reschedule.EventTimer(harness.charm.unit)
+    assert et.unit_num == 0
+    assert et.app_name == "k8s"
+
+
+@mock.patch("reschedule._execute_command")
+def test_event_timer_is_active(exec, harness):
+    """Test Event Timer is_active."""
+    exec.return_value = 0
+
+    et = reschedule.EventTimer(harness.charm.unit)
+    assert et.is_active("update-status")
+
+    exec.return_value = -1
+    et = reschedule.EventTimer(harness.charm.unit)
+    assert not et.is_active("update-status")
+
+    exec.side_effect = subprocess.CalledProcessError(-1, [])
+    et = reschedule.EventTimer(harness.charm.unit)
+    with pytest.raises(reschedule.TimerStatusError):
+        not et.is_active("update-status")
+
+
+@mock.patch("reschedule.Path.write_text")
+def test_render_event_template(write_text, harness):
+    """Test renders event template."""
+    context = {
+        "app": "k8s",
+        "event": "update-status",
+        "interval": 30,
+        "random_delay": 7,
+        "timeout": 15,
+        "unit_num": 0,
+    }
+    et = reschedule.EventTimer(harness.charm.unit)
+    et._render_event_template("service", "update-status", context)
+    write_text.assert_called_once()
+
+
+@mock.patch("reschedule._execute_command")
+def test_event_timer_ensure(exec, harness):
+    """Test ensure on event timer."""
+    exec.return_value = ("", 0)
+
+    et = reschedule.EventTimer(harness.charm.unit)
+    with mock.patch.object(et, "_render_event_template") as rendered:
+        et.ensure("update-status", 30)
+
+    context = {
+        "app": "k8s",
+        "event": "update-status",
+        "interval": 30,
+        "random_delay": 7,
+        "timeout": 15,
+        "unit_num": 0,
+    }
+    rendered.assert_has_calls(
+        [
+            mock.call("service", "update-status", context),
+            mock.call("timer", "update-status", context),
+        ]
+    )
+
+
+@mock.patch("reschedule._execute_command")
+def test_event_timer_disable(exec, harness):
+    """Test disable on event timer."""
+    exec.return_value = ("", 0)
+
+    et = reschedule.EventTimer(harness.charm.unit)
+    et.disable("update-status")
+    sysctl = reschedule.BIN_SYSTEMCTL
+    calls = [
+        mock.call([sysctl, "stop", "k8s.update-status.timer"], check_exit=False),
+        mock.call([sysctl, "disable", "k8s.update-status.timer"], check_exit=False),
+    ]
+    exec.assert_has_calls(calls)
+
+
+@mock.patch("reschedule.EventTimer.ensure")
+@mock.patch("reschedule.EventTimer.is_active")
+def test_periodic_event_create(is_active, ensure, harness):
+    """Test creating a periodic event."""
+    pe = reschedule.PeriodicEvent(harness.charm)
+    is_active.return_value = False
+    pe.create(reschedule.Period(minutes=10))
+    ensure.assert_called_once_with("update_status", 600)
+
+
+@mock.patch("reschedule.EventTimer.disable")
+@mock.patch("reschedule.EventTimer.is_active")
+def test_periodic_event_cancel(is_active, disable, harness):
+    """Test cancelling a periodic event."""
+    pe = reschedule.PeriodicEvent(harness.charm)
+    is_active.return_value = True
+    pe.cancel()
+    disable.assert_called_once_with("update_status")

--- a/charms/worker/k8s/tox.ini
+++ b/charms/worker/k8s/tox.ini
@@ -32,7 +32,7 @@ deps =
 commands =
     coverage run --source={[vars]src_path},{[vars]lib_path} \
         -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
-    coverage report
+    coverage report --show-missing
 
 [testenv:coverage-report]
 description = Create test coverage report

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -243,7 +243,10 @@ async def deploy_model(
                 status="active",
                 timeout=30 * 60,
             )
-        yield the_model
+        try:
+            yield the_model
+        except GeneratorExit:
+            log.fatal("Failed to determine model: model_name=%s", model_name)
 
 
 @pytest_asyncio.fixture(scope="module")


### PR DESCRIPTION
## Overview
Uses systemd to schedule an update-status hook under certain situations to complete node bootstrapping.

## Details
In some circumstances, the charm doesn't complete deployment by the time the last juju event hook fires.  Rather than using event.defer on the last hook event, this creates a reschedulable systemd call to `update-status` hook until the node is ready.

Resolves issue #90 