### PR TITLE
enable ceph-csi integration

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -36,23 +36,24 @@ jobs:
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     needs: [charmcraft-channel, extra-args]
+    secrets: inherit
     strategy:
       matrix:
         arch:
-        - {id: amd64-k8s,  suite: k8s,  builder-label: ubuntu-22.04, tester-arch: x64}
-        - {id: amd64-etcd, suite: etcd, builder-label: ubuntu-22.04, tester-arch: x64}
-    secrets: inherit
+        - {id: amd64, builder-label: ubuntu-22.04, tester-arch: x64}
+        suite: ["k8s", "etcd", "ceph"]
     with:
-      identifier: ${{ matrix.arch.id }}
+      identifier: ${{ matrix.arch.id }}-${{ matrix.suite }}
+      builder-runner-label: ${{ matrix.arch.builder-label }}
       charmcraft-channel: ${{ needs.charmcraft-channel.outputs.channel }}
-      extra-arguments: ${{needs.extra-args.outputs.args}} -k test_${{ matrix.arch.suite }}
+      extra-arguments: ${{needs.extra-args.outputs.args}} -k test_${{ matrix.suite }}
       juju-channel: 3/stable
       load-test-enabled: false
       provider: lxd
       self-hosted-runner: true
       self-hosted-runner-arch: ${{ matrix.arch.tester-arch }}
       test-timeout: 120
-      test-tox-env: integration-${{ matrix.arch.suite }}
+      test-tox-env: integration-${{ matrix.suite }}
       trivy-fs-enabled: false
       trivy-image-config: "trivy.yaml"
       tmate-debug: true

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -176,6 +176,8 @@ provides:
     interface: cos-k8s-tokens
   containerd:
     interface: containerd
+  ceph-k8s-info:
+    interface: kubernetes-info
 
 requires:
   etcd:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,6 @@
-juju
+# workaround for juju == 3.5.0.0
+# https://github.com/juju/python-libjuju/issues/1052
+juju @ git+https://github.com/juju/python-libjuju.git@53cd33d884f3ca710e1fa026c74f31b02281be69
 pydantic<2
 pylxd
 pytest

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,4 @@
-# workaround for juju == 3.5.0.0
-# https://github.com/juju/python-libjuju/issues/1052
-juju @ git+https://github.com/juju/python-libjuju.git@53cd33d884f3ca710e1fa026c74f31b02281be69
+juju
 pydantic<2
 pylxd
 pytest

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -184,7 +184,7 @@ class Bundle:
     def drop_constraints(self):
         """Remove constraints on applications. Useful for testing on lxd."""
         for app in self.applications.values():
-            app["constraints"] = None
+            app["constraints"] = ""
 
     def add_constraints(self, constraints: Dict[str, str]):
         """Add constraints to applications.
@@ -193,7 +193,10 @@ class Bundle:
             constraints:  Mapping of constraints to add to applications.
         """
         for app in self.applications.values():
-            val: str = app["constraints"]
+            if app.get("num_units", 0) < 1:
+                log.info("Skipping constraints for subordinate charm: %s", app["charm"])
+                continue
+            val: str = app.get("constraints", "")
             existing = dict(kv.split("=", 1) for kv in val.split())
             existing.update(constraints)
             app["constraints"] = " ".join(f"{k}={v}" for k, v in existing.items())

--- a/tests/integration/data/test-bundle-ceph.yaml
+++ b/tests/integration/data/test-bundle-ceph.yaml
@@ -1,0 +1,44 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: integration-test-ceph
+description: |-
+  Used to deploy or refresh within an integration test model
+series: jammy
+applications:
+  k8s:
+    charm: k8s
+    channel: latest/edge
+    constraints: cores=2 mem=8G root-disk=16G
+    num_units: 1
+  k8s-worker:
+    charm: k8s-worker
+    channel: latest/edge
+    constraints: cores=2 mem=8G root-disk=16G
+    num_units: 1
+  ceph-csi:
+    charm: ceph-csi
+    channel: latest/stable
+    options:
+      provisioner-replicas: 1
+  ceph-mon:
+    charm: ceph-mon
+    channel: quincy/stable
+    constraints: cores=2 mem=4G root-disk=16G
+    num_units: 1
+    options:
+      monitor-count: 1
+      expected-osd-count: 1
+  ceph-osd:
+    charm: ceph-osd
+    channel: quincy/stable
+    constraints: cores=2 mem=4G root-disk=16G
+    num_units: 1
+    storage:
+      osd-devices: 1G,2
+      osd-journals: 1G,1
+relations:
+  - [k8s, k8s-worker:cluster]
+  - [ceph-csi, k8s:ceph-k8s-info]
+  - [ceph-csi, ceph-mon:client]
+  - [ceph-mon, ceph-osd:mon]

--- a/tests/integration/data/test-bundle-ceph.yaml
+++ b/tests/integration/data/test-bundle-ceph.yaml
@@ -35,8 +35,8 @@ applications:
     constraints: cores=2 mem=4G root-disk=16G
     num_units: 1
     storage:
-      osd-devices: 1G,2
-      osd-journals: 1G,1
+      osd-devices: 'lxd,1G,2'
+      osd-journals: 'lxd,1G,1'
 relations:
   - [k8s, k8s-worker:cluster]
   - [ceph-csi, k8s:ceph-k8s-info]

--- a/tests/integration/data/test-bundle-ceph.yaml
+++ b/tests/integration/data/test-bundle-ceph.yaml
@@ -35,8 +35,8 @@ applications:
     constraints: cores=2 mem=4G root-disk=16G
     num_units: 1
     storage:
-      osd-devices: 'lxd,1G,2'
-      osd-journals: 'lxd,1G,1'
+      osd-devices: 1G,2
+      osd-journals: 1G,1
 relations:
   - [k8s, k8s-worker:cluster]
   - [ceph-csi, k8s:ceph-k8s-info]

--- a/tests/integration/test_ceph.py
+++ b/tests/integration/test_ceph.py
@@ -9,23 +9,12 @@
 import pytest
 from juju import model, unit
 
-from .helpers import ready_nodes
-
 # This pytest mark configures the test environment to use the Canonical Kubernetes
 # bundle with ceph, for all the test within this module.
 pytestmark = [
     pytest.mark.bundle_file("test-bundle-ceph.yaml"),
     pytest.mark.ignore_blocked,
 ]
-
-
-@pytest.mark.abort_on_fail
-async def test_nodes_ready(kubernetes_cluster: model.Model):
-    """Deploy the charm and wait for active/idle status."""
-    k8s = kubernetes_cluster.applications["k8s"]
-    worker = kubernetes_cluster.applications["k8s-worker"]
-    expected_nodes = len(k8s.units) + len(worker.units)
-    await ready_nodes(k8s.units[0], expected_nodes)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_ceph.py
+++ b/tests/integration/test_ceph.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# pylint: disable=duplicate-code
+"""Integration tests."""
+
+import pytest
+from juju import model, unit
+
+from .helpers import ready_nodes
+
+# This pytest mark configures the test environment to use the Canonical Kubernetes
+# bundle with ceph, for all the test within this module.
+pytestmark = [
+    pytest.mark.bundle_file("test-bundle-ceph.yaml"),
+    pytest.mark.ignore_blocked,
+]
+
+
+@pytest.mark.abort_on_fail
+async def test_nodes_ready(kubernetes_cluster: model.Model):
+    """Deploy the charm and wait for active/idle status."""
+    k8s = kubernetes_cluster.applications["k8s"]
+    worker = kubernetes_cluster.applications["k8s-worker"]
+    expected_nodes = len(k8s.units) + len(worker.units)
+    await ready_nodes(k8s.units[0], expected_nodes)
+
+
+@pytest.mark.abort_on_fail
+async def test_ceph_sc(kubernetes_cluster: model.Model):
+    """Test that a ceph storage class is available."""
+    k8s: unit.Unit = kubernetes_cluster.applications["k8s"].units[0]
+    event = await k8s.run("k8s kubectl get sc -o=jsonpath='{.items[*].provisioner}'")
+    result = await event.wait()
+    stdout = result.results["stdout"]
+    assert "rbd.csi.ceph.com" in stdout, f"No ceph provisioner found in: {stdout}"

--- a/tox.ini
+++ b/tox.ini
@@ -84,7 +84,7 @@ deps =
 commands =
     bandit -c {toxinidir}/pyproject.toml -r {[vars]all_path}
 
-[testenv:{integration,integration-k8s,integration-etcd}]
+[testenv:{integration,integration-k8s,integration-etcd,integration-ceph}]
 description = Run integration tests
 deps = -r test_requirements.txt
 commands =


### PR DESCRIPTION
### Overview

Enable Ceph CSI integration.

### Rationale

We're recommending ceph as the storage solution when using Canonical K8s as the backing cloud for `juju add-k8s`. This PR provides the integration needed by the `ceph-csi` subordinate charm.

### Juju Events Changes

Adds a new relation-changed observation for `ceph-k8s-info`.
