### PR TITLE
pin requests < 2.32

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,3 +5,4 @@ pytest
 pytest-asyncio
 pytest-operator
 tenacity
+requests < 2.32  # https://github.com/canonical/pylxd/issues/579


### PR DESCRIPTION
Workaround for pylxd connections failing in CI due to https://github.com/psf/requests/issues/6707