### PR TITLE
Add Joining Certificates for non-leader Control Planes and Workers

### DIFF
--- a/charms/worker/charmcraft.yaml
+++ b/charms/worker/charmcraft.yaml
@@ -45,6 +45,14 @@ bases:
       architectures: [amd64]
 config:
   options:
+    certificates:
+      default: self-signed
+      type: string
+      description: |
+        The certificates generation strategy to use in Canonical Kubernetes.
+        This cannot be changed after deployment. Allowed values are "self-signed"
+        and "external". If "external" is chosen, the charm should be integrated
+        with the an external certificates authority charm.
     labels:
       default: ""
       type: string

--- a/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
+++ b/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
@@ -444,7 +444,7 @@ class ControlPlaneNodeJoinConfig(NodeJoinConfig, allow_population_by_field_name=
     Attributes:
         extra_sans (List[str]): List of extra sans for the self-signed certificates
         apiserver_crt (str): apiserver certificate
-        apiserver_client_key (str): apiserver certificate key
+        apiserver_key (str): apiserver certificate key
         front_proxy_client_crt (str): front-proxy certificate
         front_proxy_client_key (str): front-proxy certificate key
     """
@@ -452,7 +452,7 @@ class ControlPlaneNodeJoinConfig(NodeJoinConfig, allow_population_by_field_name=
     extra_sans: Optional[List[str]] = Field(None, alias="extra-sans")
 
     apiserver_crt: Optional[str] = Field(None, alias="apiserver-crt")
-    apiserver_client_key: Optional[str] = Field(None, alias="apiserver-key")
+    apiserver_key: Optional[str] = Field(None, alias="apiserver-key")
     front_proxy_client_crt: Optional[str] = Field(None, alias="front-proxy-client-crt")
     front_proxy_client_key: Optional[str] = Field(None, alias="front-proxy-client-key")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,5 +82,6 @@ max-complexity = 10
 
 [tool.codespell]
 skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
+ignore-words-list = "assertIn"
 [tool.pyright]
 extraPaths = ["./charms/worker/k8s/lib"]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,3 +5,4 @@ pytest
 pytest-asyncio
 pytest-operator
 tenacity
+requests < 2.32  # https://github.com/canonical/pylxd/issues/579

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -167,13 +167,9 @@ class Bundle:
             name (str):  Which application
             path (Path): Path to local charm
         """
-        # FIXME: Omit non present charms
-        try:
-            app = self.applications[name]
-            app["charm"] = str(path.resolve())
-            app["channel"] = None
-        except KeyError:
-            log.warning("Application %s not found in bundle", name)
+        app = self.applications[name]
+        app["charm"] = str(path.resolve())
+        app["channel"] = None
 
     def drop_constraints(self):
         """Remove constraints on applications. Useful for testing on lxd."""

--- a/tests/integration/data/test-bundle-certificates.yaml
+++ b/tests/integration/data/test-bundle-certificates.yaml
@@ -15,10 +15,17 @@ applications:
   k8s:
     charm: k8s
     channel: latest/edge
+    num_units: 2
+    constraints: cores=2 mem=8G root-disk=16G
+    options:
+      certificates: external
+  k8s-worker:
+    charm: k8s-worker
+    channel: latest/edge
     num_units: 1
     constraints: cores=2 mem=8G root-disk=16G
     options:
       certificates: external
 relations:
-- - k8s:certificates
-  - self-signed-certificates:certificates
+  - [k8s, self-signed-certificates:certificates]
+  - [k8s, k8s-worker:cluster]

--- a/tests/integration/data/test-bundle-certificates.yaml
+++ b/tests/integration/data/test-bundle-certificates.yaml
@@ -28,4 +28,5 @@ applications:
       certificates: external
 relations:
   - [k8s, self-signed-certificates:certificates]
+  - [k8s-worker, self-signed-certificates:certificates]
   - [k8s, k8s-worker:cluster]

--- a/tests/integration/test_certificates.py
+++ b/tests/integration/test_certificates.py
@@ -23,5 +23,6 @@ pytestmark = [
 async def test_nodes_ready(kubernetes_cluster: model.Model):
     """Deploy the charm and wait for active/idle status."""
     k8s = kubernetes_cluster.applications["k8s"]
-    expected_nodes = len(k8s.units)
+    worker = kubernetes_cluster.applications["k8s-worker"]
+    expected_nodes = len(k8s.units) + len(worker.units)
     await ready_nodes(k8s.units[0], expected_nodes)


### PR DESCRIPTION
### Overview
This pull request adds support for external certificates for non-leader control planes and worker units.

### Rationale
A mechanism is required to allow the joining units to request their own certificates and pass them to the joining configuration object. In this pull request, joining units can request their required certificates over the TLSCertificatesv3 interface, which can be used with charms that implement this interface (e.g., new Vault or self-signed-certificates).

