### PR TITLE
Address fan-network disabling on aws

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -229,10 +229,7 @@ async def cloud_profile(ops_test: OpsTest):
         lxd.remove_profile(profile_name)
         lxd.apply_profile("k8s.profile", profile_name)
     elif _type == "ec2" and ops_test.model:
-        await ops_test.model.set_config({
-            "container-networking-method": "local",
-            "fan-config": ""
-        })
+        await ops_test.model.set_config({"container-networking-method": "local", "fan-config": ""})
 
 
 @contextlib.asynccontextmanager

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -216,16 +216,23 @@ async def cloud_proxied(ops_test: OpsTest):
 
 
 async def cloud_profile(ops_test: OpsTest):
-    """Apply lxd-profile to the model if the juju cloud is lxd.
+    """Apply Cloud Specific Settings to the model
 
     Args:
         ops_test (OpsTest): ops_test plugin
     """
-    if await cloud_type(ops_test) == "lxd" and ops_test.model:
+    _type = await cloud_type(ops_test)
+    if _type == "lxd" and ops_test.model:
+        # lxd-profile to the model if the juju cloud is lxd.
         lxd = LXDSubstrate("", "")
         profile_name = f"juju-{ops_test.model.name}"
         lxd.remove_profile(profile_name)
         lxd.apply_profile("k8s.profile", profile_name)
+    elif _type == "ec2" and ops_test.model:
+        await ops_test.model.set_config({
+            "container-networking-method": "local",
+            "fan-config": ""
+        })
 
 
 @contextlib.asynccontextmanager


### PR DESCRIPTION
### Overview

Applies workaround for testing cilium on AWS from [LP#2016905](https://bugs.launchpad.net/charm-cilium/+bug/2016905/comments/1)

### Details

Integration test attempts to determine which cloud the controller is on, in order to apply correct model configuration