### PR TITLE
Publish charms with a specific revision of charmcraft

### DIFF
--- a/.github/workflows/build-charm.yaml
+++ b/.github/workflows/build-charm.yaml
@@ -51,7 +51,7 @@ jobs:
         if: ${{ env.CHARM_NAME != 'UNKNOWN' && !cancelled() && steps.cache-charm.outputs.cache-hit != 'true' }}
         working-directory: ${{ inputs.working-directory }}/${{ matrix.path }}
         run: |
-          sudo snap install charmcraft --classic --channel ${{steps.charmcraft.outputs.channel}}
+          sudo snap install charmcraft --classic --channel ${{ steps.charmcraft.outputs.channel }}
           charmcraft pack -v
           mkdir -p packed
           mv *.charm packed/

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -44,7 +44,7 @@ jobs:
     secrets: inherit
     with:
       provider: lxd
-      juju-channel: 3.3/stable
+      juju-channel: 3/stable
       extra-arguments: ${{needs.extra-args.outputs.args}} -k test_${{ matrix.suite }}
       load-test-enabled: false
       zap-enabled: false

--- a/.github/workflows/publish-charms.yaml
+++ b/.github/workflows/publish-charms.yaml
@@ -30,8 +30,17 @@ jobs:
             echo "::error Failed to determine track/risk from branch ${BRANCH}"
             exit 1
           fi
+  charmcraft-channel:
+    runs-on: ubuntu-latest
+    outputs:
+      channel: ${{ steps.charmcraft.outputs.channel }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read charmcraft version file
+        id: charmcraft
+        run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
   publish-to-edge:
-    needs: [configure-channel]
+    needs: [configure-channel, charmcraft-channel]
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@08c5a65a0bc4696164b4f85a29a9ccbd830d10d8
     strategy:
       matrix:
@@ -43,4 +52,5 @@ jobs:
     with:
       channel: ${{needs.configure-channel.outputs.track}}/${{needs.configure-channel.outputs.risk}}
       working-directory: ${{ matrix.charm.path }}
+      charmcraft-channel: ${{needs.charmcraft-channel.outputs.channel}}
       tag-prefix: ${{ matrix.charm.tagPrefix }}

--- a/.github/workflows/publish-charms.yaml
+++ b/.github/workflows/publish-charms.yaml
@@ -52,5 +52,5 @@ jobs:
     with:
       channel: ${{needs.configure-channel.outputs.track}}/${{needs.configure-channel.outputs.risk}}
       working-directory: ${{ matrix.charm.path }}
-      charmcraft-channel: ${{needs.charmcraft-channel.outputs.channel}}
+      charmcraft-channel: ${{ needs.charmcraft-channel.outputs.channel }}
       tag-prefix: ${{ matrix.charm.tagPrefix }}


### PR DESCRIPTION
## Overview

The publishing charm action fails due to not being able to read a charmcraft yaml tuned for charmcraft 2.x.  This updates the publish-charm action to read the charmcraft channel version from a file in repo. 

## Details
a previous [action](https://github.com/canonical/k8s-operator/actions/runs/10291869467) no longer operates due to charmcraft promoting the snap 3.1.1 to its latest/stable channel.  
#137 fixed this by pinning the BUILD channel to 2.x/stable, but couldn't publish the built charm.

* juju has asked us to no longer use juju `3.3/stable` -- but rather `3/stable` snap