### PR TITLE
Handle various microcluster ready endpoints

### DIFF
--- a/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
+++ b/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
@@ -782,15 +782,17 @@ class K8sdAPIManager:
             K8sdConnectionError: If the response is Not Found on all endpoints.
         """
         ready_endpoints = ["/core/1.0/ready", "/cluster/1.0/ready"]
-        for endpoint in ready_endpoints:
+        for i, endpoint in enumerate(ready_endpoints):
             try:
                 self._send_request(endpoint, "GET", EmptyResponse)
                 break
             except InvalidResponseError as ex:
                 if ex.code == 404:
                     logger.warning(
-                        "Encountered 404 while checking if micro-cluster is ready @ %s: %s",
+                        "micro-cluster unavailable @ %s (%s of %s): %s",
                         endpoint,
+                        i + 1,
+                        len(ready_endpoints),
                         ex,
                     )
                     # Try the next endpoint if the current one is not found

--- a/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
+++ b/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
@@ -776,9 +776,30 @@ class K8sdAPIManager:
         return status.metadata and status.metadata.status.ready
 
     def check_k8sd_ready(self):
-        """Check if k8sd is ready."""
-        endpoint = "/cluster/1.0/ready"
-        self._send_request(endpoint, "GET", EmptyResponse)
+        """Check if k8sd is ready using various microcluster endpoints.
+
+        Raises:
+            K8sdConnectionError: If the response is Not Found on all endpoints.
+        """
+        ready_endpoints = ["/core/1.0/ready", "/cluster/1.0/ready"]
+        for endpoint in ready_endpoints:
+            try:
+                self._send_request(endpoint, "GET", EmptyResponse)
+                break
+            except InvalidResponseError as ex:
+                if ex.code == 404:
+                    logger.warning(
+                        "Encountered 404 while checking if micro-cluster is ready @ %s: %s",
+                        endpoint,
+                        ex,
+                    )
+                    # Try the next endpoint if the current one is not found
+                    continue
+                raise
+        else:
+            raise K8sdConnectionError(
+                "Exhausted all endpoints while checking if micro-cluster is ready"
+            )
 
     def bootstrap_k8s_snap(self, request: CreateClusterRequest) -> None:
         """Bootstrap the k8s cluster.

--- a/charms/worker/k8s/tests/unit/test_k8sd_api_manager.py
+++ b/charms/worker/k8s/tests/unit/test_k8sd_api_manager.py
@@ -168,6 +168,7 @@ class TestK8sdAPIManager(unittest.TestCase):
 
         with self.assertRaises(K8sdConnectionError):
             self.api_manager.check_k8sd_ready()
+
         mock_send_request.assert_has_calls(
             [
                 call("/core/1.0/ready", "GET", EmptyResponse),
@@ -183,6 +184,7 @@ class TestK8sdAPIManager(unittest.TestCase):
         mock_send_request.side_effect = [not_found, success]
 
         self.api_manager.check_k8sd_ready()
+
         mock_send_request.assert_has_calls(
             [
                 call("/core/1.0/ready", "GET", EmptyResponse),


### PR DESCRIPTION
### Overview
With the advent of v2 microcluster, the ready endpoint moved from `/cluster/1.0/ready` to `/core/1.0/ready` because changing endpoints is a totally natural thing to do for run

### Details
* loop through available endpoints til we find one that doesn't `404`.  
* reraise any non-404 excptions
* raise a `K8sdConnectionError` if we run out of endpoints to try