### PR TITLE
[COS] Adjustments to integration tests to more reliably test COS relations

### DIFF
--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -448,10 +448,18 @@ class K8sCharm(ops.CharmBase):
 
         log.info("Prepare cos tokens")
         if rel := self.model.get_relation("cos-tokens"):
-            self.distributor.allocate_tokens(relation=rel, token_strategy=TokenStrategy.COS)
+            self.distributor.allocate_tokens(
+                relation=rel,
+                token_strategy=TokenStrategy.COS,
+                token_type=ClusterTokenType.CONTROL_PLANE,
+            )
 
         if rel := self.model.get_relation("cos-worker-tokens"):
-            self.distributor.allocate_tokens(relation=rel, token_strategy=TokenStrategy.COS)
+            self.distributor.allocate_tokens(
+                relation=rel,
+                token_strategy=TokenStrategy.COS,
+                token_type=ClusterTokenType.WORKER,
+            )
 
     @on_error(
         WaitingStatus("Waiting to enable features"),

--- a/tests/integration/grafana.py
+++ b/tests/integration/grafana.py
@@ -17,7 +17,7 @@ class Grafana:
     def __init__(
         self,
         model_name: str,
-        host: Optional[str] = "localhost",
+        base: Optional[str] = "http://localhost",
         username: Optional[str] = "admin",
         password: Optional[str] = "",
     ):
@@ -25,11 +25,11 @@ class Grafana:
 
         Args:
             model_name (str): The name of the model where Grafana is deployed.
-            host (Optional[str]): Host address of Grafana application. Defaults to 'localhost'.
+            base (Optional[str]): Base url of Grafana application. Defaults to 'http://localhost'.
             username (Optional[str]): Username for authentication. Defaults to 'admin'.
             password (Optional [str]): Password for authentication. Defaults to ''.
         """
-        self.base_uri = f"http://{host}/{model_name}-grafana"
+        self.base_uri = f"{base}/{model_name}-grafana"
         self.username = username
         self.password = password
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -6,7 +6,7 @@ import ipaddress
 import json
 import logging
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import yaml
 from juju.model import Model
@@ -47,26 +47,6 @@ async def is_deployed(model: Model, bundle_path: Path) -> bool:
             return False
     await model.wait_for_idle(status="active", timeout=20 * 60, raise_on_error=False)
     return True
-
-
-async def get_address(model: Model, app_name: str, unit_num: Optional[int] = None) -> str:
-    """Find unit address for any application.
-
-    Args:
-        model: juju model
-        app_name: string name of application
-        unit_num: integer number of a juju unit
-
-    Returns:
-        unit address as a string
-    """
-    status = await model.get_status()
-    app = status["applications"][app_name]
-    return (
-        app.public_address
-        if unit_num is None
-        else app["units"][f"{app_name}/{unit_num}"]["address"]
-    )
 
 
 async def get_unit_cidrs(model: Model, app_name: str, unit_num: int) -> List[str]:

--- a/tests/integration/prometheus.py
+++ b/tests/integration/prometheus.py
@@ -4,9 +4,12 @@
 
 
 import json
+import logging
 import urllib.parse
 import urllib.request
 from typing import Optional
+
+log = logging.getLogger(__name__)
 
 
 class Prometheus:
@@ -15,16 +18,16 @@ class Prometheus:
     def __init__(
         self,
         model_name: str,
-        host: Optional[str] = "localhost",
+        base: Optional[str] = "http://localhost",
     ):
         """Initialize Prometheus instance.
 
         Args:
             model_name (str): The name of the model where Prometheus is deployed.
-            host (Optional[str]): Host address of the Prometheus application.
-                Defaults to 'localhost'.
+            base (Optional[str]): Base url of the Prometheus application.
+                Defaults to 'http://localhost'.
         """
-        self.base_uri = f"http://{host}/{model_name}-prometheus-0"
+        self.base_uri = f"{base}/{model_name}-prometheus-0"
 
     def _get_url(self, url):
         """Send GET request to the provided URL.
@@ -35,6 +38,7 @@ class Prometheus:
         Returns:
             str: The response data.
         """
+        log.info("Query: %s", url)
         with urllib.request.urlopen(url) as response:
             data = response.read().decode()
 

--- a/tests/integration/prometheus.py
+++ b/tests/integration/prometheus.py
@@ -7,7 +7,7 @@ import json
 import logging
 import urllib.parse
 import urllib.request
-from typing import Optional
+from typing import List, Optional
 
 log = logging.getLogger(__name__)
 
@@ -68,11 +68,14 @@ class Prometheus:
 
         return data
 
-    async def check_metrics(self, query: str):
+    async def get_metrics(self, query: str) -> List:
         """Query Prometheus for metrics.
 
         Args:
             query (str): The Prometheus query to execute.
+
+        Returns:
+            List: A list of results from the query.
         """
         api_path = "api/v1/query"
         uri = f"{self.base_uri}/{api_path}"
@@ -85,4 +88,4 @@ class Prometheus:
         assert response.code == 200, f"Failed to query '{query}': {data}"
         result = json.loads(data)
         assert result.get("status") == "success", f"Query failed: {result}"
-        assert result.get("data", {}).get("result"), "Data not yet available"
+        return result.get("data", {}).get("result", [])

--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -172,6 +172,6 @@ async def test_prometheus(traefik_url: str, cos_model: model.Model):
         'up{job="kube-proxy"} > 0',
         'up{job="kube-state-metrics"} > 0',
     ]
-    results = asyncio.gather(*[prometheus.get_metrics(query) for query in queries])
+    results = await asyncio.gather(*[prometheus.get_metrics(query) for query in queries])
     failed = [query for query, result in zip(queries, results) if not result]
     assert not failed, f"Failed queries: {failed}"

--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -172,5 +172,6 @@ async def test_prometheus(traefik_url: str, cos_model: model.Model):
         'up{job="kube-proxy"} > 0',
         'up{job="kube-state-metrics"} > 0',
     ]
-    for query in queries:
-        await prometheus.check_metrics(query)
+    results = asyncio.gather(*[prometheus.get_metrics(query) for query in queries])
+    failed = [query for query, result in zip(queries, results) if not result]
+    assert not failed, f"Failed queries: {failed}"


### PR DESCRIPTION
### Overview

* Incorporates testing lessons learned from #141 
* Addresses an issue where the lead control-plane unit was not allocated a cos-token, so it posted no metrics

### Details
* Adds the fixes to the COS tests found in #141 
* Gets the traefik url from an action on that charm rather than using the unit's public address
* Deploy a grafana-agent matching the series+arch of the primaries (k8s-worker and k8s)
* Wait for prometheus to be healthy for only 10 minutes before failing
* Adjust prometheus test to return the metrics for evaluation of which metrics are missing
