### PR TITLE
Add Annotations to Charm Configuration

### DIFF
--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -56,9 +56,9 @@ config:
   options:
     annotations:
       type: string
-      default: "{}"
+      default: ""
       description: |
-        Annotations is a JSON dictionary (key/value pairs) object that can be
+        Annotations is a space separated list of (key/value) pairs)  that can be
         used to add arbitrary metadata configuration to the Canonical
         Kubernetes cluster. For more information, see the upstream Canonical
         Kubernetes documentation about annotations:
@@ -66,7 +66,7 @@ config:
         https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/reference/annotations/
 
         The value for this config must be a JSON object, like this:
-          e.g.: {"key1": "value1", "key2": "value2"}
+          e.g.: key1=value1 key2=value2
     containerd_custom_registries:
       type: string
       default: "[]"

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -65,7 +65,7 @@ config:
 
         https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/reference/annotations/
 
-        The value for this config must be a JSON object, like this:
+        Example:
           e.g.: key1=value1 key2=value2
     containerd_custom_registries:
       type: string

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -54,6 +54,19 @@ bases:
       architectures: [amd64]
 config:
   options:
+    annotations:
+      type: string
+      default: "{}"
+      description: |
+        Annotations is a JSON dictionary (key/value pairs) object that can be
+        used to add arbitrary metadata configuration to the Canonical
+        Kubernetes cluster. For more information, see the upstream Canonical
+        Kubernetes documentation about annotations:
+
+        https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/reference/annotations/
+
+        The value for this config must be a JSON object, like this:
+          e.g.: {"key1": "value1", "key2": "value2"}
     containerd_custom_registries:
       type: string
       default: "[]"

--- a/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
+++ b/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
@@ -308,6 +308,7 @@ class UserFacingClusterConfig(BaseModel):
         gateway: Gateway configuration for the cluster.
         metrics_server: Metrics server configuration for the cluster.
         cloud_provider: The cloud provider for the cluster.
+        annotations: Dictionary that can be used to store arbitrary metadata configuration.
     """
 
     network: Optional[NetworkConfig] = Field(None)
@@ -318,6 +319,7 @@ class UserFacingClusterConfig(BaseModel):
     gateway: Optional[GatewayConfig] = Field(None)
     metrics_server: Optional[MetricsServerConfig] = Field(None, alias="metrics-server")
     cloud_provider: Optional[str] = Field(None, alias="cloud-provider")
+    annotations: Optional[Dict[str, str]] = Field(None)
 
 
 class UserFacingDatastoreConfig(BaseModel, allow_population_by_field_name=True):

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -339,7 +339,7 @@ class K8sCharm(ops.CharmBase):
             dict: The parsed annotations if valid, otherwise None.
 
         Raises:
-            AssertionError: If the any of the annotations are invalid.
+            AssertionError: If any annotation is invalid.
         """
         raw_annotations = self.config.get("annotations")
         if not raw_annotations:
@@ -374,6 +374,10 @@ class K8sCharm(ops.CharmBase):
         else:
             config.cluster_config.annotations = annotations
 
+    @status.on_error(
+        ops.BlockedStatus("Invalid Annotations"),
+        AssertionError,
+    )
     def _update_annotations(self):
         """Update the annotations for the Canonical Kubernetes cluster."""
         annotations = self._get_valid_annotations()

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -15,7 +15,6 @@ optional cloud-providers, optional schedulers, external backing stores, and exte
 certificate storage.
 """
 
-import json
 import logging
 import os
 import shlex
@@ -338,20 +337,27 @@ class K8sCharm(ops.CharmBase):
 
         Returns:
             dict: The parsed annotations if valid, otherwise None.
+
+        Raises:
+            AssertionError: If the any of the annotations are invalid.
         """
         raw_annotations = self.config.get("annotations")
         if not raw_annotations:
             return None
 
+        raw_annotations = str(raw_annotations)
+
         annotations = {}
         try:
             for key, value in [pair.split("=", 1) for pair in raw_annotations.split()]:
-                assert key and value, "Invalid annotation"  # nosec
+                assert key and value, "Invalid Annotation"  # nosec
                 annotations[key] = value
         except AssertionError:
             log.exception("Invalid annotations: %s", raw_annotations)
             status.add(ops.BlockedStatus("Invalid Annotations"))
             raise
+
+        return annotations
 
     def _configure_annotations(self, config: BootstrapConfig):
         """Configure the annotations for the Canonical Kubernetes cluster.


### PR DESCRIPTION
## Overview
Add a charm configuration option to enable the fine grained configuration of clusters using annotations.
## Rationale
The `k8s` snap allows the use of annotations as a mechanism to configure features built into the snap. For example, to configure VLAN BPF bypass in Cilium (as requested in #112), we can use the annotation `k8sd/v1alpha1/cilium/vlan-bpf-bypass` which passes the VLAN IDs to Cilium's configuration.
## Related Issues
closes #112
