### PR TITLE
Attempt to use lxd vms rather than containers

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -24,34 +24,36 @@ jobs:
           fi
           echo "args=$EXTRA_ARGS" >> "$GITHUB_OUTPUT"
 
-  build-all-charms:
-    needs: [extra-args]
-    strategy:
-      matrix:
-        path:
-          - "./charms/worker/k8s/"
-          - "./charms/worker/"
-    uses: ./.github/workflows/build-charm.yaml
-    with:
-      working-directory:  ${{ matrix.path }}
+  charmcraft-channel:
+    runs-on: ubuntu-24.04
+    outputs:
+      channel: ${{ steps.charmcraft.outputs.channel }}
+    steps:
+    - uses: actions/checkout@v4
+    - id: charmcraft
+      run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
 
   integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@08c5a65a0bc4696164b4f85a29a9ccbd830d10d8
-    needs: [build-all-charms, extra-args]
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    needs: [charmcraft-channel, extra-args]
     strategy:
       matrix:
-        suite: ["k8s", "etcd"]
+        arch:
+        - {id: amd64-k8s,  suite: k8s,  builder-label: ubuntu-22.04, tester-arch: x64}
+        - {id: amd64-etcd, suite: etcd, builder-label: ubuntu-22.04, tester-arch: x64}
     secrets: inherit
     with:
-      provider: lxd
+      identifier: ${{ matrix.arch.id }}
+      charmcraft-channel: ${{ needs.charmcraft-channel.outputs.channel }}
+      extra-arguments: ${{needs.extra-args.outputs.args}} -k test_${{ matrix.arch.suite }}
       juju-channel: 3/stable
-      extra-arguments: ${{needs.extra-args.outputs.args}} -k test_${{ matrix.suite }}
       load-test-enabled: false
-      zap-enabled: false
+      provider: lxd
       self-hosted-runner: true
-      self-hosted-runner-label: "large"
-      trivy-fs-enabled: true
+      self-hosted-runner-arch: ${{ matrix.arch.tester-arch }}
+      test-timeout: 120
+      test-tox-env: integration-${{ matrix.arch.suite }}
+      trivy-fs-enabled: false
       trivy-image-config: "trivy.yaml"
       tmate-debug: true
-      test-timeout: 120
-      test-tox-env: integration-${{ matrix.suite }}
+      zap-enabled: false

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -186,7 +186,7 @@ class Bundle:
         for app in self.applications.values():
             app["constraints"] = None
 
-    def add_constraints(self, constraints: Dict[str,str]):
+    def add_constraints(self, constraints: Dict[str, str]):
         """Add constraints to applications.
 
         Args:


### PR DESCRIPTION
### Overview

Switches testing of lxd to use VMs rather than nested containers and a difficult to install lxd profile

### Details
* creates a new pytest option which is directed to use lxd-containers rather than lxd vms -- then defaults it off
* updated the conftest.py to instruct juju to start a `virt-type: virtual-machine` and disregard loading a lxd profile.