### PR TITLE
Integrate with cloud-provider and test with AWS

### DIFF
--- a/charms/worker/charmcraft.yaml
+++ b/charms/worker/charmcraft.yaml
@@ -98,6 +98,10 @@ provides:
   cos-agent:
     interface: cos_agent
 requires:
+  aws:
+    interface: aws-integration
+  azure:
+    interface: azure-integration
   cluster:
     interface: k8s-cluster
     # interface to connect with the k8s charm to provide
@@ -108,3 +112,5 @@ requires:
     interface: cos-k8s-tokens
   containerd:
     interface: containerd
+  gcp:
+    interface: gcp-integration

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -189,17 +189,25 @@ peers:
 provides:
   cos-agent:
     interface: cos_agent
-  k8s-cluster:
-    interface: k8s-cluster
   cos-worker-tokens:
     interface: cos-k8s-tokens
   containerd:
     interface: containerd
   ceph-k8s-info:
     interface: kubernetes-info
+  k8s-cluster:
+    interface: k8s-cluster
+  kube-control:
+    interface: kube-control
 
 requires:
+  aws:
+    interface: aws-integration
+  azure:
+    interface: azure-integration
   etcd:
     interface: etcd
   external-cloud-provider:
     interface: external_cloud_provider
+  gcp:
+    interface: gcp-integration

--- a/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
+++ b/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
@@ -834,6 +834,16 @@ class K8sdAPIManager:
         auth_response = self._send_request(endpoint, "POST", AuthTokenResponse, body)
         return auth_response.metadata.token
 
+    def revoke_auth_token(self, token: str) -> None:
+        """Revoke a Kubernetes authentication token.
+
+        Args:
+            token (str): The authentication token.
+        """
+        endpoint = "/1.0/kubernetes/auth/tokens"
+        body = {"token": token}
+        self._send_request(endpoint, "DELETE", EmptyResponse, body)
+
     def get_kubeconfig(self, server: Optional[str]) -> str:
         """Request a Kubernetes admin config.
 

--- a/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
+++ b/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
@@ -45,7 +45,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 
@@ -190,8 +190,8 @@ class ClusterMember(BaseModel):
 
     name: str
     address: str
-    cluster_role: Optional[str] = Field(None, alias="cluster-role")
-    datastore_role: Optional[str] = Field(None, alias="datastore-role")
+    cluster_role: Optional[str] = Field(default=None, alias="cluster-role")
+    datastore_role: Optional[str] = Field(default=None, alias="datastore-role")
 
 
 class DNSConfig(BaseModel):
@@ -204,10 +204,10 @@ class DNSConfig(BaseModel):
         upstream_nameservers: List of upstream nameservers for DNS resolution.
     """
 
-    enabled: Optional[bool] = Field(None)
-    cluster_domain: Optional[str] = Field(None, alias="cluster-domain")
-    service_ip: Optional[str] = Field(None, alias="service-ip")
-    upstream_nameservers: Optional[List[str]] = Field(None, alias="upstream-nameservers")
+    enabled: Optional[bool] = Field(default=None)
+    cluster_domain: Optional[str] = Field(default=None, alias="cluster-domain")
+    service_ip: Optional[str] = Field(default=None, alias="service-ip")
+    upstream_nameservers: Optional[List[str]] = Field(default=None, alias="upstream-nameservers")
 
 
 class IngressConfig(BaseModel):
@@ -219,9 +219,9 @@ class IngressConfig(BaseModel):
         enable_proxy_protocol: Optional flag to enable or disable proxy protocol.
     """
 
-    enabled: Optional[bool] = Field(None)
-    default_tls_secret: Optional[str] = Field(None, alias="default-tls-secret")
-    enable_proxy_protocol: Optional[bool] = Field(None, alias="enable-proxy-protocol")
+    enabled: Optional[bool] = Field(default=None)
+    default_tls_secret: Optional[str] = Field(default=None, alias="default-tls-secret")
+    enable_proxy_protocol: Optional[bool] = Field(default=None, alias="enable-proxy-protocol")
 
 
 class LoadBalancerConfig(BaseModel):
@@ -239,15 +239,15 @@ class LoadBalancerConfig(BaseModel):
         bgp_peer_port: The port for BGP peering.
     """
 
-    enabled: Optional[bool] = Field(None)
-    cidrs: Optional[List[str]] = Field(None)
-    l2_enabled: Optional[bool] = Field(None, alias="l2-enabled")
-    l2_interfaces: Optional[List[str]] = Field(None, alias="l2-interfaces")
-    bgp_enabled: Optional[bool] = Field(None, alias="bgp-enabled")
-    bgp_local_asn: Optional[int] = Field(None, alias="bgp-local-asn")
-    bgp_peer_address: Optional[str] = Field(None, alias="bgp-peer-address")
-    bgp_peer_asn: Optional[int] = Field(None, alias="bgp-peer-asn")
-    bgp_peer_port: Optional[int] = Field(None, alias="bgp-peer-port")
+    enabled: Optional[bool] = Field(default=None)
+    cidrs: Optional[List[str]] = Field(default=None)
+    l2_enabled: Optional[bool] = Field(default=None, alias="l2-enabled")
+    l2_interfaces: Optional[List[str]] = Field(default=None, alias="l2-interfaces")
+    bgp_enabled: Optional[bool] = Field(default=None, alias="bgp-enabled")
+    bgp_local_asn: Optional[int] = Field(default=None, alias="bgp-local-asn")
+    bgp_peer_address: Optional[str] = Field(default=None, alias="bgp-peer-address")
+    bgp_peer_asn: Optional[int] = Field(default=None, alias="bgp-peer-asn")
+    bgp_peer_port: Optional[int] = Field(default=None, alias="bgp-peer-port")
 
 
 class LocalStorageConfig(BaseModel):
@@ -260,10 +260,10 @@ class LocalStorageConfig(BaseModel):
         set_default: Optional flag to set this as the default storage option.
     """
 
-    enabled: Optional[bool] = Field(None)
-    local_path: Optional[str] = Field(None, alias="local-path")
-    reclaim_policy: Optional[str] = Field(None, alias="reclaim-policy")
-    set_default: Optional[bool] = Field(None, alias="set-default")
+    enabled: Optional[bool] = Field(default=None)
+    local_path: Optional[str] = Field(default=None, alias="local-path")
+    reclaim_policy: Optional[str] = Field(default=None, alias="reclaim-policy")
+    set_default: Optional[bool] = Field(default=None, alias="set-default")
 
 
 class NetworkConfig(BaseModel):
@@ -273,7 +273,7 @@ class NetworkConfig(BaseModel):
         enabled: Optional flag which represents the status of Network.
     """
 
-    enabled: Optional[bool] = Field(None)
+    enabled: Optional[bool] = Field(default=None)
 
 
 class GatewayConfig(BaseModel):
@@ -283,7 +283,7 @@ class GatewayConfig(BaseModel):
         enabled: Optional flag which represents the status of Gateway.
     """
 
-    enabled: Optional[bool] = Field(None)
+    enabled: Optional[bool] = Field(default=None)
 
 
 class MetricsServerConfig(BaseModel):
@@ -293,7 +293,7 @@ class MetricsServerConfig(BaseModel):
         enabled: Optional flag which represents the status of MetricsServer.
     """
 
-    enabled: Optional[bool] = Field(None)
+    enabled: Optional[bool] = Field(default=None)
 
 
 class UserFacingClusterConfig(BaseModel, allow_population_by_field_name=True):
@@ -311,15 +311,15 @@ class UserFacingClusterConfig(BaseModel, allow_population_by_field_name=True):
         annotations: Dictionary that can be used to store arbitrary metadata configuration.
     """
 
-    network: Optional[NetworkConfig] = Field(None)
-    dns: Optional[DNSConfig] = Field(None)
-    ingress: Optional[IngressConfig] = Field(None)
-    load_balancer: Optional[LoadBalancerConfig] = Field(None, alias="load-balancer")
-    local_storage: Optional[LocalStorageConfig] = Field(None, alias="local-storage")
-    gateway: Optional[GatewayConfig] = Field(None)
-    metrics_server: Optional[MetricsServerConfig] = Field(None, alias="metrics-server")
-    cloud_provider: Optional[str] = Field(None, alias="cloud-provider")
-    annotations: Optional[Dict[str, str]] = Field(None)
+    network: Optional[NetworkConfig] = Field(default=None)
+    dns: Optional[DNSConfig] = Field(default=None)
+    ingress: Optional[IngressConfig] = Field(default=None)
+    load_balancer: Optional[LoadBalancerConfig] = Field(default=None, alias="load-balancer")
+    local_storage: Optional[LocalStorageConfig] = Field(default=None, alias="local-storage")
+    gateway: Optional[GatewayConfig] = Field(default=None)
+    metrics_server: Optional[MetricsServerConfig] = Field(default=None, alias="metrics-server")
+    cloud_provider: Optional[str] = Field(default=None, alias="cloud-provider")
+    annotations: Optional[Dict[str, str]] = Field(default=None)
 
 
 class UserFacingDatastoreConfig(BaseModel, allow_population_by_field_name=True):
@@ -333,11 +333,11 @@ class UserFacingDatastoreConfig(BaseModel, allow_population_by_field_name=True):
         client_key: client key of the external datastore cluster in PEM format.
     """
 
-    type: Optional[str] = Field(None)
-    servers: Optional[List[str]] = Field(None)
-    ca_crt: Optional[str] = Field(None, alias="ca-crt")
-    client_crt: Optional[str] = Field(None, alias="client-crt")
-    client_key: Optional[str] = Field(None, alias="client-key")
+    type: Optional[str] = Field(default=None)
+    servers: Optional[List[str]] = Field(default=None)
+    ca_crt: Optional[str] = Field(default=None, alias="ca-crt")
+    client_crt: Optional[str] = Field(default=None, alias="client-crt")
+    client_key: Optional[str] = Field(default=None, alias="client-key")
 
 
 class BootstrapConfig(BaseModel):
@@ -357,21 +357,25 @@ class BootstrapConfig(BaseModel):
         datastore_client_cert (str): The client certificate for accessing the datastore.
         datastore_client_key (str): The client key for accessing the datastore.
         extra_sans (List[str]): List of extra sans for the self-signed certificates
+        extra_node_kube_controller_manager_args ([Dict[str,str]]): key-value service args
     """
 
-    cluster_config: Optional[UserFacingClusterConfig] = Field(None, alias="cluster-config")
-    control_plane_taints: Optional[List[str]] = Field(None, alias="control-plane-taints")
-    pod_cidr: Optional[str] = Field(None, alias="pod-cidr")
-    service_cidr: Optional[str] = Field(None, alias="service-cidr")
-    disable_rbac: Optional[bool] = Field(None, alias="disable-rbac")
-    secure_port: Optional[int] = Field(None, alias="secure-port")
-    k8s_dqlite_port: Optional[int] = Field(None, alias="k8s-dqlite-port")
-    datastore_type: Optional[str] = Field(None, alias="datastore-type")
-    datastore_servers: Optional[List[AnyHttpUrl]] = Field(None, alias="datastore-servers")
-    datastore_ca_cert: Optional[str] = Field(None, alias="datastore-ca-crt")
-    datastore_client_cert: Optional[str] = Field(None, alias="datastore-client-crt")
-    datastore_client_key: Optional[str] = Field(None, alias="datastore-client-key")
-    extra_sans: Optional[List[str]] = Field(None, alias="extra-sans")
+    cluster_config: Optional[UserFacingClusterConfig] = Field(default=None, alias="cluster-config")
+    control_plane_taints: Optional[List[str]] = Field(default=None, alias="control-plane-taints")
+    pod_cidr: Optional[str] = Field(default=None, alias="pod-cidr")
+    service_cidr: Optional[str] = Field(default=None, alias="service-cidr")
+    disable_rbac: Optional[bool] = Field(default=None, alias="disable-rbac")
+    secure_port: Optional[int] = Field(default=None, alias="secure-port")
+    k8s_dqlite_port: Optional[int] = Field(default=None, alias="k8s-dqlite-port")
+    datastore_type: Optional[str] = Field(default=None, alias="datastore-type")
+    datastore_servers: Optional[List[AnyHttpUrl]] = Field(default=None, alias="datastore-servers")
+    datastore_ca_cert: Optional[str] = Field(default=None, alias="datastore-ca-crt")
+    datastore_client_cert: Optional[str] = Field(default=None, alias="datastore-client-crt")
+    datastore_client_key: Optional[str] = Field(default=None, alias="datastore-client-key")
+    extra_sans: Optional[List[str]] = Field(default=None, alias="extra-sans")
+    extra_node_kube_controller_manager_args: Optional[Dict[str, str]] = Field(
+        default=None, alias="extra-node-kube-controller-manager-args"
+    )
 
 
 class CreateClusterRequest(BaseModel):
@@ -396,8 +400,8 @@ class UpdateClusterConfigRequest(BaseModel):
         datastore (Optional[UserFacingDatastoreConfig]): The clusters datastore configuration.
     """
 
-    config: Optional[UserFacingClusterConfig] = Field(None)
-    datastore: Optional[UserFacingDatastoreConfig] = Field(None)
+    config: Optional[UserFacingClusterConfig] = Field(default=None)
+    datastore: Optional[UserFacingDatastoreConfig] = Field(default=None)
 
 
 class NodeJoinConfig(BaseModel, allow_population_by_field_name=True):
@@ -408,8 +412,8 @@ class NodeJoinConfig(BaseModel, allow_population_by_field_name=True):
         kubelet_key (str): node's certificate key
     """
 
-    kubelet_crt: Optional[str] = Field(None, alias="kubelet-crt")
-    kubelet_key: Optional[str] = Field(None, alias="kubelet-key")
+    kubelet_crt: Optional[str] = Field(default=None, alias="kubelet-crt")
+    kubelet_key: Optional[str] = Field(default=None, alias="kubelet-key")
 
 
 class ControlPlaneNodeJoinConfig(NodeJoinConfig, allow_population_by_field_name=True):
@@ -423,12 +427,12 @@ class ControlPlaneNodeJoinConfig(NodeJoinConfig, allow_population_by_field_name=
         front_proxy_client_key (str): front-proxy certificate key
     """
 
-    extra_sans: Optional[List[str]] = Field(None, alias="extra-sans")
+    extra_sans: Optional[List[str]] = Field(default=None, alias="extra-sans")
 
-    apiserver_crt: Optional[str] = Field(None, alias="apiserver-crt")
-    apiserver_client_key: Optional[str] = Field(None, alias="apiserver-key")
-    front_proxy_client_crt: Optional[str] = Field(None, alias="front-proxy-client-crt")
-    front_proxy_client_key: Optional[str] = Field(None, alias="front-proxy-client-key")
+    apiserver_crt: Optional[str] = Field(default=None, alias="apiserver-crt")
+    apiserver_client_key: Optional[str] = Field(default=None, alias="apiserver-key")
+    front_proxy_client_crt: Optional[str] = Field(default=None, alias="front-proxy-client-crt")
+    front_proxy_client_key: Optional[str] = Field(default=None, alias="front-proxy-client-key")
 
 
 class JoinClusterRequest(BaseModel, allow_population_by_field_name=True):
@@ -444,7 +448,7 @@ class JoinClusterRequest(BaseModel, allow_population_by_field_name=True):
     name: str
     address: str
     token: SecretStr
-    config: Optional[NodeJoinConfig] = Field(None)
+    config: Optional[NodeJoinConfig] = Field(default=None)
 
     def dict(self, **kwds) -> Dict[Any, Any]:
         """Render object into a dict.
@@ -470,8 +474,8 @@ class DatastoreStatus(BaseModel):
         servers: (List(str)): list of server addresses of the external datastore cluster.
     """
 
-    datastore_type: Optional[str] = Field(None, alias="type")
-    servers: Optional[List[str]] = Field(None, alias="servers")
+    datastore_type: Optional[str] = Field(default=None, alias="type")
+    servers: Optional[List[str]] = Field(default=None, alias="servers")
 
 
 class ClusterStatus(BaseModel):
@@ -485,9 +489,9 @@ class ClusterStatus(BaseModel):
     """
 
     ready: bool = Field(False)
-    members: Optional[List[ClusterMember]] = Field(None)
-    config: Optional[UserFacingClusterConfig] = Field(None)
-    datastore: Optional[DatastoreStatus] = Field(None)
+    members: Optional[List[ClusterMember]] = Field(default=None)
+    config: Optional[UserFacingClusterConfig] = Field(default=None)
+    datastore: Optional[DatastoreStatus] = Field(default=None)
 
 
 class ClusterMetadata(BaseModel):
@@ -508,7 +512,7 @@ class GetClusterStatusResponse(BaseRequestModel):
                                     Can be None if the status is not available.
     """
 
-    metadata: Optional[ClusterMetadata] = Field(None)
+    metadata: Optional[ClusterMetadata] = Field(default=None)
 
 
 class KubeConfigMetadata(BaseModel):

--- a/charms/worker/k8s/requirements.txt
+++ b/charms/worker/k8s/requirements.txt
@@ -2,7 +2,7 @@ charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-li
 charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider@e1c5fc69e98100a7d43c0ad5a7969bba1ecbcd40
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@9b212854e768f13c26cc907bed51444e97e51b50#subdirectory=ops
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@f818cc30d1a22be43ffdfecf7fbd9c3fd2967502
-ops-interface-kube-control @ git+https://github.com/charmed-kubernetes/interface-kube-control.git@KU-1998/use-secrets#subdirectory=ops
+ops-interface-kube-control @ git+https://github.com/charmed-kubernetes/interface-kube-control.git@main#subdirectory=ops
 ops.interface_aws @ git+https://github.com/charmed-kubernetes/interface-aws-integration@main#subdirectory=ops
 ops.interface_gcp @ git+https://github.com/charmed-kubernetes/interface-gcp-integration@main#subdirectory=ops
 ops.interface_azure @ git+https://github.com/charmed-kubernetes/interface-azure-integration@main#subdirectory=ops

--- a/charms/worker/k8s/requirements.txt
+++ b/charms/worker/k8s/requirements.txt
@@ -2,6 +2,10 @@ charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-li
 charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider@e1c5fc69e98100a7d43c0ad5a7969bba1ecbcd40
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@9b212854e768f13c26cc907bed51444e97e51b50#subdirectory=ops
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@f818cc30d1a22be43ffdfecf7fbd9c3fd2967502
+ops-interface-kube-control @ git+https://github.com/charmed-kubernetes/interface-kube-control.git@KU-1998/use-secrets#subdirectory=ops
+ops.interface_aws @ git+https://github.com/charmed-kubernetes/interface-aws-integration@main#subdirectory=ops
+ops.interface_gcp @ git+https://github.com/charmed-kubernetes/interface-gcp-integration@main#subdirectory=ops
+ops.interface_azure @ git+https://github.com/charmed-kubernetes/interface-azure-integration@main#subdirectory=ops
 cosl==0.0.42
 ops==2.17.0
 pydantic==1.10.19

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -986,4 +986,4 @@ class K8sCharm(ops.CharmBase):
 
 
 if __name__ == "__main__":  # pragma: nocover
-    ops.main.main(K8sCharm)
+    ops.main(K8sCharm)

--- a/charms/worker/k8s/src/cloud_integration.py
+++ b/charms/worker/k8s/src/cloud_integration.py
@@ -1,0 +1,131 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Cloud Integration for Charmed Kubernetes Control Plane."""
+
+import logging
+from typing import Optional, Union
+
+import charms.contextual_status as status
+import ops
+from ops.interface_aws.requires import AWSIntegrationRequires
+from ops.interface_azure.requires import AzureIntegrationRequires
+from ops.interface_gcp.requires import GCPIntegrationRequires
+from protocols import K8sCharmProtocol
+
+log = logging.getLogger(__name__)
+
+CloudSpecificIntegration = Union[
+    AWSIntegrationRequires, AzureIntegrationRequires, GCPIntegrationRequires
+]
+
+
+class CloudIntegration:
+    """Utility class that handles the integration with clouds for Charmed Kubernetes.
+
+    This class provides methods to configure instance tags and roles for control-plane
+    units
+
+    Attributes:
+        charm (K8sCharm): Reference to the base charm instance.
+        cloud (CloudSpecificIntegration): Reference to the cloud-specific integration.
+    """
+
+    def __init__(self, charm: K8sCharmProtocol, is_control_plane: bool) -> None:
+        """Integrate with all possible clouds.
+
+        Args:
+            charm (K8sCharm): Reference to the base charm instance.
+            is_control_plane (bool): Flag to determine if the unit is a control-plane node.
+        """
+        self.charm = charm
+        self.is_control_plane = is_control_plane
+
+    @property
+    def cloud(self) -> Optional[CloudSpecificIntegration]:
+        """Determine if we're integrated with a known cloud."""
+        cloud_name = self.charm.get_cloud_name()
+        cloud: CloudSpecificIntegration
+        if cloud_name == "aws":
+            cloud = AWSIntegrationRequires(self.charm)
+        elif cloud_name == "gcp":
+            cloud = GCPIntegrationRequires(self.charm)
+        elif cloud_name == "azure":
+            cloud = AzureIntegrationRequires(self.charm)
+        else:
+            log.warning("Skipping direct cloud integration: cloud %s", cloud_name)
+            return None
+
+        if not cloud.relation:
+            log.info(
+                "Skipping Cloud integration: Needs an active %s relation to integrate.", cloud_name
+            )
+            return None
+        return cloud
+
+    @status.on_error(ops.WaitingStatus("Waiting for cloud-integration"))
+    def integrate(self, event: ops.EventBase):
+        """Request tags and permissions for a control-plane node.
+
+        Args:
+            event (ops.EventBase): Event that triggered the integration
+
+        Raises:
+            ValueError: If the cloud integration evaluation fails
+        """
+        if not (cloud := self.cloud):
+            return
+
+        cloud_name = self.charm.get_cloud_name()
+        cluster_tag = self.charm.get_cluster_name()
+
+        status.add(ops.MaintenanceStatus(f"Integrate with {cloud_name}"))
+        if isinstance(cloud, AWSIntegrationRequires):
+            aws_cluster_tag = {f"kubernetes.io/cluster/{cluster_tag}": "owned"}
+            if self.is_control_plane:
+                # wokeignore:rule=master
+                cloud.tag_instance({**aws_cluster_tag, "k8s.io/role/master": "true"})
+                cloud.tag_instance_security_group(aws_cluster_tag)
+                cloud.tag_instance_subnet(aws_cluster_tag)
+                cloud.enable_object_storage_management(["kubernetes-*"])
+                cloud.enable_load_balancer_management()
+
+                # Necessary for cloud-provider-aws
+                cloud.enable_autoscaling_readonly()
+                cloud.enable_instance_modification()
+                cloud.enable_region_readonly()
+            else:
+                cloud.tag_instance(aws_cluster_tag)
+                cloud.tag_instance_security_group(aws_cluster_tag)
+                cloud.tag_instance_subnet(aws_cluster_tag)
+                cloud.enable_object_storage_management(["kubernetes-*"])
+        elif isinstance(cloud, GCPIntegrationRequires):
+            gcp_cluster_tag = {"k8s-io-cluster-name": cluster_tag}
+            if self.is_control_plane:
+                # wokeignore:rule=master
+                cloud.tag_instance({**gcp_cluster_tag, "k8s-io-role-master": "master"})
+                cloud.enable_object_storage_management()
+                cloud.enable_security_management()
+            else:
+                cloud.tag_instance(gcp_cluster_tag)
+                cloud.enable_object_storage_management()
+        elif isinstance(cloud, AzureIntegrationRequires):
+            azure_cluster_tag = {"k8s-io-cluster-name": cluster_tag}
+            if self.is_control_plane:
+                # wokeignore:rule=master
+                cloud.tag_instance({**azure_cluster_tag, "k8s-io-role-master": "master"})
+                cloud.enable_object_storage_management()
+                cloud.enable_security_management()
+                cloud.enable_loadbalancer_management()
+            else:
+                cloud.tag_instance(azure_cluster_tag)
+                cloud.enable_object_storage_management()
+        cloud.enable_instance_inspection()
+        cloud.enable_dns_management()
+        if self.is_control_plane:
+            cloud.enable_network_management()
+            cloud.enable_block_storage_management()
+        evaluation = cloud.evaluate_relation(event)
+        if not evaluation:
+            log.error("Failed to evaluate cloud integration: %s", evaluation)
+            raise ValueError("Failed to evaluate cloud integration")

--- a/charms/worker/k8s/src/cloud_integration.py
+++ b/charms/worker/k8s/src/cloud_integration.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Cloud Integration for Charmed Kubernetes Control Plane."""
+"""Cloud Integration for Canonical k8s Operator."""
 
 import logging
 from typing import Mapping, Optional, Union
@@ -21,7 +21,7 @@ CloudSpecificIntegration = Union[
 
 
 class CloudIntegration:
-    """Utility class that handles the integration with clouds for Charmed Kubernetes.
+    """Utility class that handles the integration with clouds for Canonical k8s.
 
     This class provides methods to configure instance tags and roles for control-plane
     units
@@ -61,11 +61,73 @@ class CloudIntegration:
             return None
         return cloud
 
+    def _integrate_aws(self, cloud: AWSIntegrationRequires, cluster_tag: str):
+        """Integrate with AWS cloud.
+
+        Args:
+            cloud (AWSIntegrationRequires): AWS cloud integration.
+            cluster_tag (str): Tag to identify the cluster.
+        """
+        aws_cluster_tag = {f"kubernetes.io/cluster/{cluster_tag}": "owned"}
+        if self.is_control_plane:
+            # wokeignore:rule=master
+            cloud.tag_instance({**aws_cluster_tag, "k8s.io/role/master": "true"})
+            cloud.tag_instance_security_group(aws_cluster_tag)
+            cloud.tag_instance_subnet(aws_cluster_tag)
+            cloud.enable_object_storage_management(["kubernetes-*"])
+            cloud.enable_load_balancer_management()
+
+            # Necessary for cloud-provider-aws
+            cloud.enable_autoscaling_readonly()
+            cloud.enable_instance_modification()
+            cloud.enable_region_readonly()
+        else:
+            cloud.tag_instance(aws_cluster_tag)
+            cloud.tag_instance_security_group(aws_cluster_tag)
+            cloud.tag_instance_subnet(aws_cluster_tag)
+            cloud.enable_object_storage_management(["kubernetes-*"])
+
+    def _integrate_gcp(self, cloud: GCPIntegrationRequires, cluster_tag: str):
+        """Integrate with GCP cloud.
+
+        Args:
+            cloud (GCPIntegrationRequires): GCP cloud integration.
+            cluster_tag (str): Tag to identify the cluster.
+        """
+        gcp_cluster_tag = {"k8s-io-cluster-name": cluster_tag}
+        if self.is_control_plane:
+            # wokeignore:rule=master
+            cloud.tag_instance({**gcp_cluster_tag, "k8s-io-role-master": "master"})
+            cloud.enable_object_storage_management()
+            cloud.enable_security_management()
+        else:
+            cloud.tag_instance(gcp_cluster_tag)
+            cloud.enable_object_storage_management()
+
+    def _integrate_azure(self, cloud: AzureIntegrationRequires, cluster_tag: str):
+        """Integrate with Azure cloud.
+
+        Args:
+            cloud (AzureIntegrationRequires): Azure cloud integration.
+            cluster_tag (str): Tag to identify the cluster.
+        """
+        azure_cluster_tag = {"k8s-io-cluster-name": cluster_tag}
+        if self.is_control_plane:
+            # wokeignore:rule=master
+            cloud.tag_instance({**azure_cluster_tag, "k8s-io-role-master": "master"})
+            cloud.enable_object_storage_management()
+            cloud.enable_security_management()
+            cloud.enable_loadbalancer_management()
+        else:
+            cloud.tag_instance(azure_cluster_tag)
+            cloud.enable_object_storage_management()
+
     @status.on_error(ops.WaitingStatus("Waiting for cloud-integration"))
-    def integrate(self, event: ops.EventBase):
+    def integrate(self, cluster_tag: str, event: ops.EventBase):
         """Request tags and permissions for a control-plane node.
 
         Args:
+            cluster_tag (str):     Tag to identify the integrating cluster.
             event (ops.EventBase): Event that triggered the integration
 
         Raises:
@@ -74,50 +136,18 @@ class CloudIntegration:
         if not (cloud := self.cloud):
             return
 
+        if not cluster_tag:
+            raise ValueError("Cluster-tag is required for cloud integration")
+
         cloud_name = self.charm.get_cloud_name()
-        cluster_tag = self.charm.get_cluster_name()
 
         status.add(ops.MaintenanceStatus(f"Integrate with {cloud_name}"))
         if isinstance(cloud, AWSIntegrationRequires):
-            aws_cluster_tag = {f"kubernetes.io/cluster/{cluster_tag}": "owned"}
-            if self.is_control_plane:
-                # wokeignore:rule=master
-                cloud.tag_instance({**aws_cluster_tag, "k8s.io/role/master": "true"})
-                cloud.tag_instance_security_group(aws_cluster_tag)
-                cloud.tag_instance_subnet(aws_cluster_tag)
-                cloud.enable_object_storage_management(["kubernetes-*"])
-                cloud.enable_load_balancer_management()
-
-                # Necessary for cloud-provider-aws
-                cloud.enable_autoscaling_readonly()
-                cloud.enable_instance_modification()
-                cloud.enable_region_readonly()
-            else:
-                cloud.tag_instance(aws_cluster_tag)
-                cloud.tag_instance_security_group(aws_cluster_tag)
-                cloud.tag_instance_subnet(aws_cluster_tag)
-                cloud.enable_object_storage_management(["kubernetes-*"])
+            self._integrate_aws(cloud, cluster_tag)
         elif isinstance(cloud, GCPIntegrationRequires):
-            gcp_cluster_tag = {"k8s-io-cluster-name": cluster_tag}
-            if self.is_control_plane:
-                # wokeignore:rule=master
-                cloud.tag_instance({**gcp_cluster_tag, "k8s-io-role-master": "master"})
-                cloud.enable_object_storage_management()
-                cloud.enable_security_management()
-            else:
-                cloud.tag_instance(gcp_cluster_tag)
-                cloud.enable_object_storage_management()
+            self._integrate_gcp(cloud, cluster_tag)
         elif isinstance(cloud, AzureIntegrationRequires):
-            azure_cluster_tag = {"k8s-io-cluster-name": cluster_tag}
-            if self.is_control_plane:
-                # wokeignore:rule=master
-                cloud.tag_instance({**azure_cluster_tag, "k8s-io-role-master": "master"})
-                cloud.enable_object_storage_management()
-                cloud.enable_security_management()
-                cloud.enable_loadbalancer_management()
-            else:
-                cloud.tag_instance(azure_cluster_tag)
-                cloud.enable_object_storage_management()
+            self._integrate_azure(cloud, cluster_tag)
         cloud.enable_instance_inspection()
         cloud.enable_dns_management()
         if self.is_control_plane:

--- a/charms/worker/k8s/src/kube_control.py
+++ b/charms/worker/k8s/src/kube_control.py
@@ -1,0 +1,68 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Relation kube-control module."""
+import logging
+from base64 import b64decode
+
+import charms.contextual_status as status
+import ops
+import yaml
+from protocols import K8sCharmProtocol
+
+# Log messages can be retrieved using juju debug-log
+log = logging.getLogger(__name__)
+
+
+def configure(charm: K8sCharmProtocol):
+    """Configure kube-control for the Kubernetes cluster.
+
+    Args:
+        charm (K8sCharmProtocol): The charm instance.
+    """
+    if not (binding := charm.model.get_binding("kube-control")):
+        return
+
+    status.add(ops.MaintenanceStatus("Configuring Kube Control"))
+    ca_cert, endpoints = "", [f"https://{binding.network.bind_address}:6443"]
+    labels = str(charm.model.config["labels"])
+    taints = str(charm.model.config["register-with-taints"])
+    if charm._internal_kubeconfig.exists():
+        kubeconfig = yaml.safe_load(charm._internal_kubeconfig.read_text())
+        cluster = kubeconfig["clusters"][0]["cluster"]
+        ca_cert_b64 = cluster["certificate-authority-data"]
+        ca_cert = b64decode(ca_cert_b64).decode("utf-8")
+
+    charm.kube_control.set_api_endpoints(endpoints)
+    charm.kube_control.set_ca_certificate(ca_cert)
+
+    if (
+        (cluster_status := charm.api_manager.get_cluster_status())
+        and cluster_status.metadata
+        and cluster_status.metadata.status.config
+        and (dns := cluster_status.metadata.status.config.dns)
+    ):
+        charm.kube_control.set_dns_address(dns.service_ip or "")
+        charm.kube_control.set_dns_domain(dns.cluster_domain or "")
+        charm.kube_control.set_dns_enabled(dns.enabled)
+        charm.kube_control.set_dns_port(53)
+
+    charm.kube_control.set_default_cni("")
+    charm.kube_control.set_image_registry("rocks.canonical.com")
+
+    charm.kube_control.set_cluster_name(charm.get_cluster_name())
+    charm.kube_control.set_has_external_cloud_provider(charm.xcp.has_xcp)
+    charm.kube_control.set_labels(labels.split())
+    charm.kube_control.set_taints(taints.split())
+
+    for request in charm.kube_control.auth_requests:
+        log.info("Signing kube-control request for '%s 'in '%s'", request.user, request.group)
+        client_token = charm.api_manager.request_auth_token(
+            username=request.user, groups=[request.group]
+        )
+        charm.kube_control.sign_auth_request(
+            request,
+            client_token=client_token.get_secret_value(),
+            kubelet_token=str(),
+            proxy_token=str(),
+        )

--- a/charms/worker/k8s/src/kube_control.py
+++ b/charms/worker/k8s/src/kube_control.py
@@ -67,6 +67,6 @@ def configure(charm: K8sCharmProtocol):
             proxy_token=str(),
         )
 
-    for user, _ in charm.kube_control.closed_auth_creds():
-        log.info("TODO: Revoke auth-token for '%s'", user)
-        # charm.api_manager.remove_auth_token(cred.client_token.get_secret_value())
+    for user, cred in charm.kube_control.closed_auth_creds():
+        log.info("Revoke auth-token for '%s'", user)
+        charm.api_manager.revoke_auth_token(cred.load_client_token(charm.model, user))

--- a/charms/worker/k8s/src/kube_control.py
+++ b/charms/worker/k8s/src/kube_control.py
@@ -66,3 +66,7 @@ def configure(charm: K8sCharmProtocol):
             kubelet_token=str(),
             proxy_token=str(),
         )
+
+    for user, _ in charm.kube_control.closed_auth_creds():
+        log.info("TODO: Revoke auth-token for '%s'", user)
+        # charm.api_manager.remove_auth_token(cred.client_token.get_secret_value())

--- a/charms/worker/k8s/src/protocols.py
+++ b/charms/worker/k8s/src/protocols.py
@@ -4,10 +4,23 @@
 """Protocol definitions module."""
 
 import ops
+from charms.interface_external_cloud_provider import ExternalCloudProvider
+from charms.k8s.v0.k8sd_api_manager import K8sdAPIManager
+from ops.interface_kube_control import KubeControlProvides
 
 
 class K8sCharmProtocol(ops.CharmBase):
-    """Typing for the K8sCharm."""
+    """Typing for the K8sCharm.
+
+    Attributes:
+        api_manager (K8sdAPIManager): The API manager for the charm.
+        kube_control (KubeControlProvides): The kube-control interface.
+        xcp (ExternalCloudProvider): The external cloud provider interface.
+    """
+
+    api_manager: K8sdAPIManager
+    kube_control: KubeControlProvides
+    xcp: ExternalCloudProvider
 
     def get_cluster_name(self) -> str:
         """Get the cluster name.

--- a/charms/worker/k8s/src/protocols.py
+++ b/charms/worker/k8s/src/protocols.py
@@ -1,0 +1,26 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Protocol definitions module."""
+
+import ops
+
+
+class K8sCharmProtocol(ops.CharmBase):
+    """Typing for the K8sCharm."""
+
+    def get_cluster_name(self) -> str:
+        """Get the cluster name.
+
+        Raises:
+            NotImplementedError: If the method is not implemented.
+        """
+        raise NotImplementedError
+
+    def get_cloud_name(self) -> str:
+        """Get the cloud name.
+
+        Raises:
+            NotImplementedError: If the method is not implemented.
+        """
+        raise NotImplementedError

--- a/charms/worker/k8s/src/token_distributor.py
+++ b/charms/worker/k8s/src/token_distributor.py
@@ -7,7 +7,7 @@ import contextlib
 import logging
 import re
 from enum import Enum, auto
-from typing import Dict, Optional, Union
+from typing import Dict, Generator, Optional, Union
 
 import charms.contextual_status as status
 import ops
@@ -87,12 +87,13 @@ class ClusterTokenManager:
         worker = token_type == ClusterTokenType.WORKER
         return self.api_manager.create_join_token(name, worker=worker)
 
-    def revoke(self, name: str, ignore_errors: bool):
+    def revoke(self, name: str, _secret: Optional[ops.Secret], ignore_errors: bool):
         """Remove a cluster token.
 
         Args:
-            name (str): The name of the node.
-            ignore_errors (bool): Whether or not errors can be ignored
+            name (str):                     The name of the node.
+            _secret (Optional[ops.Secret]): The secret to revoke
+            ignore_errors (bool):           Whether or not errors can be ignored
 
         Raises:
             K8sdConnectionError: reraises cluster token revoke failures
@@ -100,7 +101,7 @@ class ClusterTokenManager:
         try:
             self.api_manager.remove_node(name)
         except (K8sdConnectionError, InvalidResponseError) as e:
-            if ignore_errors or e.code == ErrorCodes.STATUS_NODE_UNAVAILABLE:
+            if ignore_errors or getattr(e, "code") == ErrorCodes.STATUS_NODE_UNAVAILABLE:
                 # Let's just ignore some of these expected errors:
                 # "Remote end closed connection without response"
                 # "Failed to check if node is control-plane"
@@ -146,13 +147,32 @@ class CosTokenManager:
             username=f"system:cos:{name}", groups=["system:cos"]
         )
 
-    def revoke(self, name: str, ignore_errors: bool):
+    def revoke(self, _name: str, secret: Optional[ops.Secret], ignore_errors: bool):
         """Remove a COS token intentionally left unimplemented.
 
         Args:
-            name (str): The name of the node.
-            ignore_errors (bool): Whether or not errors can be ignored
+            _name (str):                   The name of the node.
+            secret (Optional[ops.Secret]): The secret to revoke
+            ignore_errors (bool):          Whether or not errors can be ignored
+
+        Raises:
+            K8sdConnectionError: reraises cluster token revoke failures
         """
+        # pylint: disable=unused-argument
+        if not secret:
+            return
+        content = secret.get_content(refresh=True)
+        try:
+            self.api_manager.revoke_auth_token(content["token"])
+        except (K8sdConnectionError, InvalidResponseError) as e:
+            if ignore_errors or getattr(e, "code") == ErrorCodes.STATUS_NODE_UNAVAILABLE:
+                # Let's just ignore some of these expected errors:
+                # "Remote end closed connection without response"
+                # "Failed to check if node is control-plane"
+                # Removing a node that doesn't exist
+                log.warning("Revoke_Auth_Token %s: but with an expected error: %s", _name, e)
+            else:
+                raise
 
 
 class TokenCollector:
@@ -207,7 +227,7 @@ class TokenCollector:
         return cluster_name or ""
 
     @contextlib.contextmanager
-    def recover_token(self, relation: ops.Relation):
+    def recover_token(self, relation: ops.Relation) -> Generator[str, None, None]:
         """Request, recover token, and acknowledge token once used.
 
         Args:
@@ -258,7 +278,7 @@ class TokenDistributor:
             TokenStrategy.COS: CosTokenManager(api_manager),
         }
 
-    def _get_juju_secret(self, relation: ops.Relation, unit: ops.Unit) -> Optional[str]:
+    def _get_juju_secret(self, relation: ops.Relation, unit: ops.Unit) -> Optional[ops.Secret]:
         """Lookup juju secret offered to a unit on this relation.
 
         Args:
@@ -266,9 +286,12 @@ class TokenDistributor:
             unit (ops.Unit): The unit the secret is intended for
 
         Returns:
-            secret_id (None | str) if on the relation
+            secret_id (None | ops.Secret) if on the relation
         """
-        return relation.data[self.charm.unit].get(SECRET_ID.format(unit.name))
+        secret_id = SECRET_ID.format(unit.name)
+        if juju_secret := relation.data[self.charm.unit].get(secret_id):
+            return self.charm.model.get_secret(id=juju_secret)
+        return None
 
     def _revoke_juju_secret(self, relation: ops.Relation, unit: ops.Unit) -> None:
         """Revoke and remove juju secret offered to a unit on this relation.
@@ -489,7 +512,9 @@ class TokenDistributor:
                 ignore_errors |= state == "pending"  # on pending tokens
                 # if cluster doesn't match
                 ignore_errors |= self.charm.get_cluster_name() != joined_cluster(relation, unit)
-                self.token_strategies[token_strategy].revoke(node, ignore_errors)
+                self.token_strategies[token_strategy].revoke(
+                    node, self._get_juju_secret(relation, unit), ignore_errors
+                )
                 self.drop_node(relation, unit)
                 self._revoke_juju_secret(relation, unit)
 

--- a/charms/worker/k8s/src/token_distributor.py
+++ b/charms/worker/k8s/src/token_distributor.py
@@ -7,7 +7,7 @@ import contextlib
 import logging
 import re
 from enum import Enum, auto
-from typing import Dict, Optional, Protocol, Union
+from typing import Dict, Optional, Union
 
 import charms.contextual_status as status
 import ops
@@ -17,6 +17,7 @@ from charms.k8s.v0.k8sd_api_manager import (
     K8sdAPIManager,
     K8sdConnectionError,
 )
+from protocols import K8sCharmProtocol
 from pydantic import SecretStr
 
 log = logging.getLogger(__name__)
@@ -24,35 +25,6 @@ log = logging.getLogger(__name__)
 SECRET_ID = "{0}-secret-id"  # nosec
 
 UNIT_RE = re.compile(r"k8s(-worker)?/\d+")
-
-
-class K8sCharm(Protocol):
-    """Typing for the K8sCharm.
-
-    Attributes:
-        app (ops.Application): The application object.
-        model (ops.Model): The model object.
-        unit (ops.Unit): The unit object.
-    """
-
-    @property
-    def app(self) -> ops.Application:
-        """The application object."""
-        ...  # pylint: disable=unnecessary-ellipsis
-
-    @property
-    def model(self) -> ops.Model:
-        """The model object."""
-        ...  # pylint: disable=unnecessary-ellipsis
-
-    @property
-    def unit(self) -> ops.Unit:
-        """The unit object."""
-        ...  # pylint: disable=unnecessary-ellipsis
-
-    def get_cluster_name(self) -> str:
-        """Get the cluster name."""
-        ...  # pylint: disable=unnecessary-ellipsis
 
 
 class TokenStrategy(Enum):
@@ -186,7 +158,7 @@ class CosTokenManager:
 class TokenCollector:
     """Helper class for collecting tokens for units in a relation."""
 
-    def __init__(self, charm: K8sCharm, node_name: str):
+    def __init__(self, charm: K8sCharmProtocol, node_name: str):
         """Initialize a TokenCollector instance.
 
         Args:
@@ -271,7 +243,7 @@ class TokenCollector:
 class TokenDistributor:
     """Helper class for distributing tokens to units in a relation."""
 
-    def __init__(self, charm: K8sCharm, node_name: str, api_manager: K8sdAPIManager):
+    def __init__(self, charm: K8sCharmProtocol, node_name: str, api_manager: K8sdAPIManager):
         """Initialize a TokenDistributor instance.
 
         Args:

--- a/charms/worker/k8s/tests/unit/test_cloud_integration.py
+++ b/charms/worker/k8s/tests/unit/test_cloud_integration.py
@@ -1,0 +1,196 @@
+import unittest.mock as mock
+from pathlib import Path
+from unittest import mock
+
+import ops
+import ops.testing
+import pytest
+from charm import K8sCharm
+from ops.interface_aws.requires import AWSIntegrationRequires
+from ops.interface_azure.requires import AzureIntegrationRequires
+from ops.interface_gcp.requires import GCPIntegrationRequires
+
+
+@pytest.fixture(autouse=True)
+def vendor_name():
+    with mock.patch(
+        "charms.interface_external_cloud_provider.ExternalCloudProvider.name",
+        new_callable=mock.PropertyMock,
+    ) as mock_vendor_name:
+        mock_vendor_name.return_value = "aws"
+        yield mock_vendor_name
+
+
+@pytest.fixture(params=["worker", "control-plane"])
+def harness(request):
+    """Craft a ops test harness.
+
+    Args:
+        request: pytest request object
+    """
+    meta = Path(__file__).parent / "../../charmcraft.yaml"
+    if request.param == "worker":
+        meta = Path(__file__).parent / "../../../charmcraft.yaml"
+    harness = ops.testing.Harness(K8sCharm, meta=meta.read_text())
+    harness.begin()
+    harness.charm.is_worker = request.param == "worker"
+    with mock.patch.object(harness.charm, "get_cloud_name"):
+        with mock.patch.object(harness.charm, "get_cluster_name", return_value="my-cluster"):
+            yield harness
+    harness.cleanup()
+
+
+@pytest.mark.parametrize(
+    "cloud_name, cloud_relation",
+    [
+        ("aws", "aws"),
+        ("gce", "gcp"),
+        ("azure", "azure"),
+        ("unknown", None),
+    ],
+    ids=["aws", "gce", "azure", "unknown"],
+)
+def test_cloud_detection(harness, cloud_name, cloud_relation, vendor_name):
+    # Test that the cloud property returns the correct integration requires object
+    harness.charm.get_cloud_name.return_value = cloud_name
+    integration = harness.charm.cloud_integration
+    assert integration.cloud is None
+    if cloud_name != "unknown":
+        harness.add_relation(cloud_relation, "cloud-integrator")
+        assert integration.cloud
+
+
+def test_cloud_aws(harness):
+    # Test that the cloud property returns the correct integration requires object
+    harness.charm.get_cloud_name.return_value = "aws"
+    # with mock.patch.object(harness.charm.cloud_integration, "cloud", callable=mock.PropertyMock) as mock_cloud:
+    with mock.patch(
+        "cloud_integration.CloudIntegration.cloud",
+        new_callable=mock.PropertyMock,
+        return_value=mock.create_autospec(AWSIntegrationRequires),
+    ) as mock_property:
+        mock_cloud = mock_property()
+        mock_cloud.evaluate_relation.return_value = None
+        event = mock.MagicMock()
+        harness.charm.cloud_integration.integrate(event)
+        if harness.charm.is_worker:
+            mock_cloud.tag_instance.assert_called_once_with(
+                {"kubernetes.io/cluster/my-cluster": "owned"}
+            )
+        else:
+            mock_cloud.tag_instance.assert_called_once_with(
+                {
+                    "kubernetes.io/cluster/my-cluster": "owned",
+                    "k8s.io/role/master": "true",  # wokeignore:rule=master
+                }
+            )
+        mock_cloud.tag_instance_security_group.assert_called_once_with(
+            {"kubernetes.io/cluster/my-cluster": "owned"}
+        )
+        mock_cloud.tag_instance_subnet.assert_called_once_with(
+            {"kubernetes.io/cluster/my-cluster": "owned"}
+        )
+        mock_cloud.enable_object_storage_management.assert_called_once_with(["kubernetes-*"])
+        if harness.charm.is_worker:
+            mock_cloud.enable_load_balancer_management.assert_not_called()
+            mock_cloud.enable_autoscaling_readonly.assert_not_called()
+            mock_cloud.enable_instance_modification.assert_not_called()
+            mock_cloud.enable_region_readonly.assert_not_called()
+            mock_cloud.enable_network_management.assert_not_called()
+            mock_cloud.enable_block_storage_management.assert_not_called()
+        else:
+            mock_cloud.enable_load_balancer_management.assert_called_once()
+            mock_cloud.enable_autoscaling_readonly.assert_called_once()
+            mock_cloud.enable_instance_modification.assert_called_once()
+            mock_cloud.enable_region_readonly.assert_called_once()
+            mock_cloud.enable_network_management.assert_called_once()
+            mock_cloud.enable_block_storage_management.assert_called_once()
+        mock_cloud.enable_instance_inspection.assert_called_once()
+        mock_cloud.enable_dns_management.assert_called_once()
+        mock_cloud.evaluate_relation.assert_called_once_with(event)
+
+
+def test_cloud_gce(harness):
+    # Test that the cloud property returns the correct integration requires object
+    harness.charm.get_cloud_name.return_value = "gce"
+    with mock.patch(
+        "cloud_integration.CloudIntegration.cloud",
+        new_callable=mock.PropertyMock,
+        return_value=mock.create_autospec(GCPIntegrationRequires),
+    ) as mock_property:
+        mock_cloud = mock_property()
+        mock_cloud.evaluate_relation.return_value = None
+        event = mock.MagicMock()
+        harness.charm.cloud_integration.integrate(event)
+
+        if harness.charm.is_worker:
+            mock_cloud.tag_instance.assert_called_once_with({"k8s-io-cluster-name": "my-cluster"})
+        else:
+            mock_cloud.tag_instance.assert_called_once_with(
+                {
+                    "k8s-io-cluster-name": "my-cluster",
+                    "k8s-io-role-master": "master",  # wokeignore:rule=master
+                }
+            )
+        mock_cloud.enable_object_storage_management.assert_called_once()
+        if harness.charm.is_worker:
+            mock_cloud.enable_security_management.assert_not_called()
+            mock_cloud.enable_network_management.assert_not_called()
+            mock_cloud.enable_block_storage_management.assert_not_called()
+        else:
+            mock_cloud.enable_security_management.assert_called_once()
+            mock_cloud.enable_network_management.assert_called_once()
+            mock_cloud.enable_block_storage_management.assert_called_once()
+        mock_cloud.enable_instance_inspection.assert_called_once()
+        mock_cloud.enable_dns_management.assert_called_once()
+        mock_cloud.evaluate_relation.assert_called_once_with(event)
+
+
+def test_cloud_azure(harness):
+    # Test that the cloud property returns the correct integration requires object
+    harness.charm.get_cloud_name.return_value = "azure"
+    with mock.patch(
+        "cloud_integration.CloudIntegration.cloud",
+        new_callable=mock.PropertyMock,
+        return_value=mock.create_autospec(AzureIntegrationRequires),
+    ) as mock_property:
+        mock_cloud = mock_property()
+        mock_cloud.evaluate_relation.return_value = None
+        event = mock.MagicMock()
+        harness.charm.cloud_integration.integrate(event)
+        if harness.charm.is_worker:
+            mock_cloud.tag_instance.assert_called_once_with({"k8s-io-cluster-name": "my-cluster"})
+        else:
+            mock_cloud.tag_instance.assert_called_once_with(
+                {
+                    "k8s-io-cluster-name": "my-cluster",
+                    "k8s-io-role-master": "master",  # wokeignore:rule=master
+                }
+            )
+        mock_cloud.enable_object_storage_management.assert_called_once()
+        if harness.charm.is_worker:
+            mock_cloud.enable_security_management.assert_not_called()
+            mock_cloud.enable_loadbalancer_management.assert_not_called()
+            mock_cloud.enable_network_management.assert_not_called()
+            mock_cloud.enable_block_storage_management.assert_not_called()
+        else:
+            mock_cloud.enable_security_management.assert_called_once()
+            mock_cloud.enable_loadbalancer_management.assert_called_once()
+            mock_cloud.enable_network_management.assert_called_once()
+            mock_cloud.enable_block_storage_management.assert_called_once()
+        mock_cloud.enable_dns_management.assert_called_once()
+        mock_cloud.enable_instance_inspection.assert_called_once()
+        mock_cloud.evaluate_relation.assert_called_once_with(event)
+
+
+def test_cloud_unknown(harness):
+    # Test that the cloud property returns the correct integration requires object
+    harness.charm.get_cloud_name.return_value = "unknown"
+    with mock.patch(
+        "cloud_integration.CloudIntegration.cloud",
+        new_callable=mock.PropertyMock,
+        return_value=None,
+    ) as mock_property:
+        event = mock.MagicMock()
+        harness.charm.cloud_integration.integrate(event)
+        assert mock_property.called

--- a/charms/worker/k8s/tests/unit/test_cloud_integration.py
+++ b/charms/worker/k8s/tests/unit/test_cloud_integration.py
@@ -1,4 +1,7 @@
-import unittest.mock as mock
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests cloud-integration module."""
 from pathlib import Path
 from unittest import mock
 
@@ -13,11 +16,11 @@ from ops.interface_gcp.requires import GCPIntegrationRequires
 
 @pytest.fixture(autouse=True)
 def vendor_name():
+    """Mock the ExternalCloudProvider name property."""
     with mock.patch(
         "charms.interface_external_cloud_provider.ExternalCloudProvider.name",
         new_callable=mock.PropertyMock,
     ) as mock_vendor_name:
-        mock_vendor_name.return_value = "aws"
         yield mock_vendor_name
 
 
@@ -36,7 +39,8 @@ def harness(request):
     harness.charm.is_worker = request.param == "worker"
     with mock.patch.object(harness.charm, "get_cloud_name"):
         with mock.patch.object(harness.charm, "get_cluster_name", return_value="my-cluster"):
-            yield harness
+            with mock.patch.object(harness.charm.reconciler, "reconcile"):
+                yield harness
     harness.cleanup()
 
 
@@ -50,8 +54,15 @@ def harness(request):
     ],
     ids=["aws", "gce", "azure", "unknown"],
 )
-def test_cloud_detection(harness, cloud_name, cloud_relation, vendor_name):
-    # Test that the cloud property returns the correct integration requires object
+def test_cloud_detection(harness, cloud_name, cloud_relation):
+    """Test that the cloud property returns the correct integration requires object.
+
+    Args:
+        harness (ops.testing.Harness): The test harness
+        cloud_name (str): The name of the cloud
+        cloud_relation (str): The name of the relation
+        vendor_name (mock.PropertyMock): The mock for the ExternalCloudProvider name property
+    """
     harness.charm.get_cloud_name.return_value = cloud_name
     integration = harness.charm.cloud_integration
     assert integration.cloud is None
@@ -61,9 +72,12 @@ def test_cloud_detection(harness, cloud_name, cloud_relation, vendor_name):
 
 
 def test_cloud_aws(harness):
-    # Test that the cloud property returns the correct integration requires object
+    """Test that the cloud property returns the correct integration requires object.
+
+    Args:
+        harness (ops.testing.Harness): The test harness
+    """
     harness.charm.get_cloud_name.return_value = "aws"
-    # with mock.patch.object(harness.charm.cloud_integration, "cloud", callable=mock.PropertyMock) as mock_cloud:
     with mock.patch(
         "cloud_integration.CloudIntegration.cloud",
         new_callable=mock.PropertyMock,
@@ -111,7 +125,11 @@ def test_cloud_aws(harness):
 
 
 def test_cloud_gce(harness):
-    # Test that the cloud property returns the correct integration requires object
+    """Test that the cloud property returns the correct integration requires object.
+
+    Args:
+        harness (ops.testing.Harness): The test harness
+    """
     harness.charm.get_cloud_name.return_value = "gce"
     with mock.patch(
         "cloud_integration.CloudIntegration.cloud",
@@ -147,7 +165,11 @@ def test_cloud_gce(harness):
 
 
 def test_cloud_azure(harness):
-    # Test that the cloud property returns the correct integration requires object
+    """Test that the cloud property returns the correct integration requires object.
+
+    Args:
+        harness (ops.testing.Harness): The test harness
+    """
     harness.charm.get_cloud_name.return_value = "azure"
     with mock.patch(
         "cloud_integration.CloudIntegration.cloud",
@@ -184,7 +206,11 @@ def test_cloud_azure(harness):
 
 
 def test_cloud_unknown(harness):
-    # Test that the cloud property returns the correct integration requires object
+    """Test that the cloud property returns the correct integration requires object.
+
+    Args:
+        harness (ops.testing.Harness): The test harness
+    """
     harness.charm.get_cloud_name.return_value = "unknown"
     with mock.patch(
         "cloud_integration.CloudIntegration.cloud",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ plugins = "pydantic.mypy"
 disable = "wrong-import-order,redefined-outer-name,too-many-instance-attributes,too-few-public-methods,no-self-argument,fixme,protected-access"
 # Ignore Pydantic check: https://github.com/pydantic/pydantic/issues/1961
 extension-pkg-whitelist = "pydantic" # wokeignore:rule=whitelist
+# Modules can be bigger than 1000 lines
+max-module-lines = 1500
 
 [tool.pylint.typecheck]
 # Ignore typechecking on pylxd manager classes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,5 +82,6 @@ max-complexity = 10
 
 [tool.codespell]
 skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
+
 [tool.pyright]
 extraPaths = ["./charms/worker/k8s/lib"]


### PR DESCRIPTION
### Overview

Make use of https://github.com/charmed-kubernetes/interface-kube-control/pull/2 to support integration of the k8s operator with aws

### Details
* support publishing the ca-cert of the k8s endpoint over the kube-control relation
* support publishing the auth tokens over the kube-control relation via secrets
* integration k8s and k8s-worker with gcp, azure, and aws cloud integrators
* bootstraps with a unique cluster-name passed to the k8s-snap