### PR TITLE
integration: remove unused pytest.mark.ignore_blocked.

### DIFF
--- a/tests/integration/test_ceph.py
+++ b/tests/integration/test_ceph.py
@@ -12,8 +12,7 @@ from juju import model, unit
 # This pytest mark configures the test environment to use the Canonical Kubernetes
 # bundle with ceph, for all the test within this module.
 pytestmark = [
-    pytest.mark.bundle_file("test-bundle-ceph.yaml"),
-    pytest.mark.ignore_blocked,
+    pytest.mark.bundle_file("test-bundle-ceph.yaml")
 ]
 
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Remove unused `pytest.mark.ignore_blocked` from Ceph integration test.

### Rationale

The mark seems to not be used or referenced anywhere within this repo or the `canonical/operator-workflows` repo use to run the tests.

[Pytest warns of this in every workflow run](https://github.com/canonical/k8s-operator/actions/runs/11902415451/job/33178308951#step:22:1587).

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
