### PR TITLE
ci: add nightly CRON job for Tiobe TICS.

### DIFF
--- a/.github/workflows/tiobe-tics-cron.yaml
+++ b/.github/workflows/tiobe-tics-cron.yaml
@@ -67,9 +67,9 @@ jobs:
           GENERATED_COVERAGE_XML="$GITHUB_WORKSPACE/charms/worker/k8s/coverage.xml"
           cat "$GENERATED_COVERAGE_XML"
 
-          # TiCS expects the report to be under a "$(pwd)/.coverage" directory.
-          mkdir -p "$GITHUB_WORKSPACE/.coverage"
-          mv "$GENERATED_COVERAGE_XML" .coverage/coverage.xml
+          # TiCS expects the report to be under a "$(pwd)/cover" directory.
+          mkdir -p "$GITHUB_WORKSPACE/cover"
+          mv "$GENERATED_COVERAGE_XML" cover/coverage.xml
 
       - name: Run TiCS
         run: |

--- a/.github/workflows/tiobe-tics-cron.yaml
+++ b/.github/workflows/tiobe-tics-cron.yaml
@@ -85,3 +85,17 @@ jobs:
           cd $GITHUB_WORKSPACE
           TICSQServer -project k8s-operator -tmpdir /tmp/tics -branchdir "$GITHUB_WORKSPACE"
 
+      - name: Print TICSQServer Logs
+        if: always()
+        run: |
+          set -eux -o pipefail
+
+          TICS_TEMP_DIR="/tmp/tics/ticstmpdir"
+
+          if [ -d "$TICS_TEMP_DIR" ]; then
+            for file in "$TICS_TEMP_DIR"/*; do
+              echo "### cat $file"
+              cat "$file"
+              echo
+            done
+          fi

--- a/.github/workflows/tiobe-tics-cron.yaml
+++ b/.github/workflows/tiobe-tics-cron.yaml
@@ -39,7 +39,18 @@ jobs:
         run: |
           set -eux -o pipefail
 
+          # Upgrade pip to be able to read the requirements.txt
+          sudo python3 -m pip install --upgrade pip
+
+          # tox required for running the unit tests with coverage:
           sudo python3 -m pip install tox
+
+          # Required by TICSQServer:
+          sudo python3 -m pip install pylint flake8
+
+          # Must pre-install dependencies for TICSQServer:
+          sudo python3 -m pip install -r $GITHUB_WORKSPACE/charms/worker/k8s/requirements.txt
+          sudo python3 -m pip install -r $GITHUB_WORKSPACE/test_requirements.txt
 
       - name: Install Go for Cobertura Coverage Converter
         uses: actions/setup-go@v5

--- a/.github/workflows/tiobe-tics-cron.yaml
+++ b/.github/workflows/tiobe-tics-cron.yaml
@@ -1,0 +1,76 @@
+name: TiCS Nightly Security Report
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 10 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  TiCS:
+
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # Latest branches
+          - { branch: main }
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - name: Checking out repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{matrix.branch}}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python Testing Deps
+        run: |
+          set -eux -o pipefail
+
+          sudo python3 -m pip install tox
+
+      - name: Install Go for Cobertura Coverage Converter
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Run Tests With Coverage
+        run: |
+          set -eux -o pipefail
+
+          pushd $GITHUB_WORKSPACE
+          tox -e unit,coverage-xml
+
+          GENERATED_COVERAGE_XML="$GITHUB_WORKSPACE/charms/worker/k8s/coverage.xml"
+          cat "$GENERATED_COVERAGE_XML"
+
+          # TiCS expects the report to be under a "$(pwd)/.coverage" directory.
+          mkdir -p "$GITHUB_WORKSPACE/.coverage"
+          mv "$GENERATED_COVERAGE_XML" .coverage/coverage.xml
+
+      - name: Run TiCS
+        run: |
+          # NOTE(aznashwan): TiCS install script doesn't define defaults; cannot '-u'
+          set -ex -o pipefail
+
+          export TICSAUTHTOKEN=${{ secrets.TICSAUTHTOKEN }}
+
+          # Install the TiCS and staticcheck
+          go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
+          . <(curl --silent --show-error 'https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/')
+
+          cd $GITHUB_WORKSPACE
+          TICSQServer -project k8s-operator -tmpdir /tmp/tics -branchdir "$GITHUB_WORKSPACE"
+

--- a/.github/workflows/tiobe-tics-cron.yaml
+++ b/.github/workflows/tiobe-tics-cron.yaml
@@ -35,23 +35,6 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install Python Testing Deps
-        run: |
-          set -eux -o pipefail
-
-          # Upgrade pip to be able to read the requirements.txt
-          sudo python3 -m pip install --upgrade pip
-
-          # tox required for running the unit tests with coverage:
-          sudo python3 -m pip install tox
-
-          # Required by TICSQServer:
-          sudo python3 -m pip install pylint flake8
-
-          # Must pre-install dependencies for TICSQServer:
-          sudo python3 -m pip install -r $GITHUB_WORKSPACE/charms/worker/k8s/requirements.txt
-          sudo python3 -m pip install -r $GITHUB_WORKSPACE/test_requirements.txt
-
       - name: Install Go for Cobertura Coverage Converter
         uses: actions/setup-go@v5
         with:
@@ -61,11 +44,13 @@ jobs:
         run: |
           set -eux -o pipefail
 
+          # tox required for running the unit tests with coverage:
+          pip install tox
+
           pushd $GITHUB_WORKSPACE
           tox -e unit,coverage-xml
 
           GENERATED_COVERAGE_XML="$GITHUB_WORKSPACE/charms/worker/k8s/coverage.xml"
-          cat "$GENERATED_COVERAGE_XML"
 
           # TiCS expects the report to be under a "$(pwd)/cover" directory.
           mkdir -p "$GITHUB_WORKSPACE/cover"
@@ -73,10 +58,10 @@ jobs:
 
       - name: Run TiCS
         run: |
+          export TICSAUTHTOKEN=${{ secrets.TICSAUTHTOKEN }}
+
           # NOTE(aznashwan): TiCS install script doesn't define defaults; cannot '-u'
           set -ex -o pipefail
-
-          export TICSAUTHTOKEN=${{ secrets.TICSAUTHTOKEN }}
 
           # Install the TiCS and staticcheck
           go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
@@ -84,18 +69,3 @@ jobs:
 
           cd $GITHUB_WORKSPACE
           TICSQServer -project k8s-operator -tmpdir /tmp/tics -branchdir "$GITHUB_WORKSPACE"
-
-      - name: Print TICSQServer Logs
-        if: always()
-        run: |
-          set -eux -o pipefail
-
-          TICS_TEMP_DIR="/tmp/tics/ticstmpdir"
-
-          if [ -d "$TICS_TEMP_DIR" ]; then
-            for file in "$TICS_TEMP_DIR"/*; do
-              echo "### cat $file"
-              cat "$file"
-              echo
-            done
-          fi

--- a/charms/worker/k8s/tox.ini
+++ b/charms/worker/k8s/tox.ini
@@ -43,6 +43,13 @@ deps =
 commands =
     coverage report
 
+[testenv:coverage-xml]
+description = Create test coverage XML report
+deps =
+    coverage[xml]
+commands =
+    coverage xml
+
 [testenv:update-dashboards]
 description = Run the Grafana dashboards update script
 deps = pyyaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ target-version = ["py38"]
 [tool.coverage.report]
 show_missing = true
 
+[tool.coverage.xml]
+output = "coverage.xml"
+
 # Linting tools configuration
 [tool.flake8]
 max-line-length = 99

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, unit, static, coverage-report
+envlist = lint, unit, static, coverage-report, coverage-xml
 
 [vars]
 lib_path = {toxinidir}/charms/worker/k8s/lib
@@ -76,6 +76,11 @@ commands =
 allowlist_externals = tox
 commands =
     tox -c {toxinidir}/charms/worker/k8s -e coverage-report
+
+[testenv:coverage-xml]
+allowlist_externals = tox
+commands =
+    tox -c {toxinidir}/charms/worker/k8s -e coverage-xml
 
 [testenv:static]
 description = Run static analysis tests


### PR DESCRIPTION
### Overview

This patch adds:
- the necessary tox env targets for generating Cobertura coverage report XML format
- a GitHub Workflow which runs the unit tests with coverage enabled, and calls the `TICSServer` to upload the analysis results

### Rationale

Workflow will allow for daily automatic code quality report uploads to Tiobe after the project is onboarded on their end and we receive our `TICSAUTHTOKEN` for the workflow.

### Juju Events Changes

None.

### Module Changes

None.

### Library Changes

None.

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
