### PR TITLE
Add gateway charm options

### DIFF
--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -184,6 +184,11 @@ config:
         "Retain". If set to "Delete", the storage will be deleted when the
         PersistentVolumeClaim is deleted. If set to "Retain", the storage will
         be retained when the PersistentVolumeClaim is deleted.
+    gateway-enabled:
+      type: boolean
+      default: false
+      description: |
+        Enable/Disable the gateway feature on the cluster.
 
 actions:
   get-kubeconfig:

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -41,6 +41,7 @@ from charms.k8s.v0.k8sd_api_manager import (
     ControlPlaneNodeJoinConfig,
     CreateClusterRequest,
     DNSConfig,
+    GatewayConfig,
     InvalidResponseError,
     JoinClusterRequest,
     K8sdAPIManager,
@@ -413,12 +414,17 @@ class K8sCharm(ops.CharmBase):
             # https://github.com/canonical/k8s-operator/pull/169/files#r1847378214
         )
 
+        gateway = GatewayConfig(
+            enabled=self.config.get("gateway-enabled"),
+        )
+
         cloud_provider = None
         if self.xcp.has_xcp:
             cloud_provider = "external"
 
         return UserFacingClusterConfig(
             local_storage=local_storage,
+            gateway=gateway,
             annotations=self._get_valid_annotations(),
             cloud_provider=cloud_provider,
         )


### PR DESCRIPTION
# Overview
Add options to the k8s charm to configure the gateway via charm configuration.

# Rationale
A user may want to overwrite the default configuration for gateway. This should be possible both - when bootstrapping a cluster and during runtime. Currently, there is only the option to enable or disable the feature.

# Module Changes
* Add the gateway config to the cluster config map
