### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a security issue, please follow the steps below:
+
+Using GitHub, file a [Private Security Report](https://github.com/canonical/k8s-operator/security/advisories/new) with:
+- A description of the issue
+- Steps to reproduce the issue
+- Affected versions of the `k8s-operator` package
+- Any known mitigations for the issue
+
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy) contains more information about what to expect during this process and our requirements for responsible disclosure.
+
+Thank you for contributing to the security and integrity of the `k8s-operator`!


### PR DESCRIPTION
### Overview

This pr adds security.md and introduces a security policy enabling users to report security issues

KU-2046

### Rationale

Currently, there is no security policy.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
