### PR TITLE
Add charm config for metrics-server and dns-config

### DIFF
--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -81,6 +81,58 @@ config:
 
         Example:
           e.g.: key1=value1 key2=value2
+    bootstrap-datastore:
+      default: dqlite
+      type: string
+      description: |
+        The datastore to use in Canonical Kubernetes. This cannot be changed
+        after deployment. Allowed values are "dqlite" and "etcd". If "etcd" is
+        chosen, the charm should be integrated with the etcd charm.
+    bootstrap-node-taints:
+      type: string
+      default: ""
+      description: |
+        Space-separated list of taints to apply to this node at registration time.
+
+        This config is only used at bootstrap time when Kubelet first registers the
+        node with Kubernetes. To change node taints after deploy time, use kubectl
+        instead.
+
+        For more information, see the upstream Kubernetes documentation about
+        taints:
+        https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+    bootstrap-pod-cidr:
+      type: string
+      default: "10.1.0.0/16"
+      description: |
+        Comma-separated CIDR blocks for IP addresses that can be assigned
+        to pods within the cluster. Can contain at most 2 blocks, one for IPv4
+        and one for IPv6.
+
+        After deployment it is not possible to change the size of
+        the IP range.
+
+        Examples:
+          - "192.0.2.0/24"
+          - "2001:db8::/32"
+          - "192.0.2.0/24,2001:db8::/32"
+          - "2001:db8::/32,192.0.2.0/24"
+    bootstrap-service-cidr:
+      type: string
+      default: 10.152.183.0/24
+      description: |
+        Comma-separated CIDR blocks for IP addresses that can be assigned
+        to services within the cluster. Can contain at most 2 blocks, one for IPv4
+        and one for IPv6.
+
+        After deployment it is not possible to change the size of
+        the IP range.
+
+        Examples:
+          - "192.0.2.0/24"
+          - "2001:db8::/32"
+          - "192.0.2.0/24,2001:db8::/32"
+          - "2001:db8::/32,192.0.2.0/24"
     containerd-custom-registries:
       type: string
       default: "[]"
@@ -127,59 +179,32 @@ config:
             "cert_file": "'"$(base64 -w 0 < ~/my.custom.cert.pem)"'",
             "key_file": "'"$(base64 -w 0 < ~/my.custom.key.pem)"'",
         }]'
-
-    bootstrap-datastore:
-      default: dqlite
-      type: string
+    dns-enabled:
+      type: boolean
+      default: true
       description: |
-        The datastore to use in Canonical Kubernetes. This cannot be changed
-        after deployment. Allowed values are "dqlite" and "etcd". If "etcd" is
-        chosen, the charm should be integrated with the etcd charm.
-    bootstrap-node-taints:
+        Enable/Disable the DNS feature on the cluster.
+    dns-cluster-domain:
+      type: string
+      default: "cluster.local"
+      description: |
+        Sets the local domain of the cluster
+    dns-service-ip:
       type: string
       default: ""
       description: |
-        Space-separated list of taints to apply to this node at registration time.
-
-        This config is only used at bootstrap time when Kubelet first registers the
-        node with Kubernetes. To change node taints after deploy time, use kubectl
-        instead.
-
-        For more information, see the upstream Kubernetes documentation about
-        taints:
-        https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-    bootstrap-pod-cidr:
+        Sets the IP address of the dns service. If omitted defaults to the IP address
+        of the Kubernetes service created by the feature.
+        
+        Can be used to point to an external dns server when feature is disabled.
+    dns-upstream-nameservers:
       type: string
-      default: "10.1.0.0/16"
+      default: ""
       description: |
-        Comma-separated CIDR blocks for IP addresses that can be assigned
-        to pods within the cluster. Can contain at most 2 blocks, one for IPv4 
-        and one for IPv6.
-
-        After deployment it is not possible to change the size of 
-        the IP range.
-
-        Examples: 
-          - "192.0.2.0/24"
-          - "2001:db8::/32"
-          - "192.0.2.0/24,2001:db8::/32"
-          - "2001:db8::/32,192.0.2.0/24"
-    bootstrap-service-cidr:
-      type: string
-      default: 10.152.183.0/24
-      description: |
-        Comma-separated CIDR blocks for IP addresses that can be assigned
-        to services within the cluster. Can contain at most 2 blocks, one for IPv4 
-        and one for IPv6.
-
-        After deployment it is not possible to change the size of 
-        the IP range.
-
-        Examples: 
-          - "192.0.2.0/24"
-          - "2001:db8::/32"
-          - "192.0.2.0/24,2001:db8::/32"
-          - "2001:db8::/32,192.0.2.0/24"
+        Space-separated list of upstream nameservers used to forward queries for out-of-cluster
+        endpoints.
+        
+        If omitted defaults to `/etc/resolv.conf` and uses the nameservers on each node.
     gateway-enabled:
       type: boolean
       default: false
@@ -208,6 +233,11 @@ config:
         "Retain". If set to "Delete", the storage will be deleted when the
         PersistentVolumeClaim is deleted. If set to "Retain", the storage will
         be retained when the PersistentVolumeClaim is deleted.
+    metrics-server-enabled:
+      type: boolean
+      default: true
+      description: |
+        Enable/Disable the metrics-server feature on the cluster.
     network-enabled:
       type: boolean
       default: true

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -46,6 +46,7 @@ from charms.k8s.v0.k8sd_api_manager import (
     K8sdAPIManager,
     K8sdConnectionError,
     LocalStorageConfig,
+    MetricsServerConfig,
     NetworkConfig,
     UnixSocketConnectionFactory,
     UpdateClusterConfigRequest,
@@ -421,22 +422,36 @@ class K8sCharm(ops.CharmBase):
             # https://github.com/canonical/k8s-operator/pull/169/files#r1847378214
         )
 
+        dns_config = DNSConfig(
+            enabled=self.config.get("dns-enabled"),
+        )
+        if cfg := self.config.get("dns-cluster-domain"):
+            dns_config.cluster_domain = str(cfg)
+        if cfg := self.config.get("dns-service-ip"):
+            dns_config.service_ip = str(cfg)
+        if cfg := self.config.get("dns-upstream-nameservers"):
+            dns_config.upstream_nameservers = str(cfg).split()
+
         gateway = GatewayConfig(enabled=self.config.get("gateway-enabled"))
 
         network = NetworkConfig(
             enabled=self.config.get("network-enabled"),
         )
 
+        metrics_server = MetricsServerConfig(enabled=self.config.get("metrics-server-enabled"))
+
         cloud_provider = None
         if self.xcp.has_xcp:
             cloud_provider = "external"
 
         return UserFacingClusterConfig(
-            local_storage=local_storage,
-            gateway=gateway,
-            network=network,
             annotations=self._get_valid_annotations(),
             cloud_provider=cloud_provider,
+            dns_config=dns_config,
+            gateway=gateway,
+            local_storage=local_storage,
+            metrics_server=metrics_server,
+            network=network,
         )
 
     def _configure_datastore(self, config: Union[BootstrapConfig, UpdateClusterConfigRequest]):
@@ -562,25 +577,6 @@ class K8sCharm(ops.CharmBase):
                 token_strategy=TokenStrategy.COS,
                 token_type=ClusterTokenType.WORKER,
             )
-
-    @on_error(
-        WaitingStatus("Waiting to enable features"),
-        InvalidResponseError,
-        K8sdConnectionError,
-    )
-    def _enable_functionalities(self):
-        """Enable necessary components for the Kubernetes cluster."""
-        status.add(ops.MaintenanceStatus("Updating K8s features"))
-        log.info("Enabling K8s features")
-        dns_config = DNSConfig(enabled=True)
-        network_config = NetworkConfig(enabled=True)
-        local_storage_config = LocalStorageConfig(enabled=True)
-        user_cluster_config = UserFacingClusterConfig(
-            dns=dns_config, network=network_config, local_storage=local_storage_config
-        )
-        update_request = UpdateClusterConfigRequest(config=user_cluster_config)
-
-        self.api_manager.update_cluster_config(update_request)
 
     @on_error(
         WaitingStatus("Ensure that the cluster configuration is up-to-date"),
@@ -780,12 +776,11 @@ class K8sCharm(ops.CharmBase):
         if self.lead_control_plane:
             self._k8s_info(event)
             self._bootstrap_k8s_snap()
-            self._enable_functionalities()
+            self._ensure_cluster_config()
             self._create_cluster_tokens()
             self._create_cos_tokens()
             self._apply_cos_requirements()
             self._revoke_cluster_tokens(event)
-            self._ensure_cluster_config()
             self._announce_kubernetes_version()
         self._join_cluster(event)
         self._config_containerd_registries()

--- a/charms/worker/k8s/tests/unit/test_base.py
+++ b/charms/worker/k8s/tests/unit/test_base.py
@@ -58,7 +58,6 @@ def mock_reconciler_handlers(harness):
     if harness.charm.is_control_plane:
         handler_names |= {
             "_bootstrap_k8s_snap",
-            "_enable_functionalities",
             "_create_cluster_tokens",
             "_create_cos_tokens",
             "_apply_cos_requirements",


### PR DESCRIPTION
Applicable spec: KU-2118

### Overview

Adds metric-server and dns-config

### Rationale

Allows a juju admin to adjust features deployed by the charm

### Juju Events Changes

None

### Module Changes

Removed redundant charm.py method `_ensure_features()`

### Library Changes

None

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

