### PR TITLE
Adds ability to set extra args for kube services

### DIFF
--- a/charms/worker/charmcraft.yaml
+++ b/charms/worker/charmcraft.yaml
@@ -69,6 +69,34 @@ config:
         
         Note: Due to NodeRestriction, workers are limited to how they can label themselves
         https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction
+    kube-proxy-extra-args:
+      type: string
+      default: ""
+      description: |
+        Space separated list of flags and key=value pairs that will be passed as arguments to
+        kube-proxy.
+
+        Notes:
+          Options may only be set on charm deployment
+
+        For example a value like this:
+          runtime-config=batch/v2alpha1=true profiling=true
+        will result in kube-proxy being run with the following options:
+          --runtime-config=batch/v2alpha1=true --profiling=true
+    kubelet-extra-args:
+      type: string
+      default: ""
+      description: |
+        Space separated list of flags and key=value pairs that will be passed as arguments to
+        kubelet.
+
+        Notes:
+          Options may only be set on charm deployment
+
+        For example a value like this:
+          runtime-config=batch/v2alpha1=true profiling=true
+        will result in kubelet being run with the following options:
+          --runtime-config=batch/v2alpha1=true --profiling=true
 
 resources:
   snap-installation:

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -210,6 +210,77 @@ config:
       default: false
       description: |
         Enable/Disable the gateway feature on the cluster.
+    kube-apiserver-extra-args:
+      type: string
+      default: ""
+      description: |
+        Space separated list of flags and key=value pairs that will be passed as arguments to
+        kube-apiserver.
+
+        Notes:
+          Options may only be set on charm deployment
+
+        For example a value like this:
+          runtime-config=batch/v2alpha1=true profiling=true
+        will result in kube-apiserver being run with the following options:
+          --runtime-config=batch/v2alpha1=true --profiling=true
+    kube-controller-manager-extra-args:
+      type: string
+      default: ""
+      description: |
+        Space separated list of flags and key=value pairs that will be passed as arguments to
+        kube-controller-manager.
+
+        Notes:
+          Options may only be set on charm deployment
+          cluster-name: cannot be overridden
+
+        For example a value like this:
+          runtime-config=batch/v2alpha1=true profiling=true
+        will result in kube-controller-manager being run with the following options:
+          --runtime-config=batch/v2alpha1=true --profiling=true
+    kube-proxy-extra-args:
+      type: string
+      default: ""
+      description: |
+        Space separated list of flags and key=value pairs that will be passed as arguments to
+        kube-proxy.
+
+        Notes:
+          Options may only be set on charm deployment
+
+        For example a value like this:
+          runtime-config=batch/v2alpha1=true profiling=true
+        will result in kube-proxy being run with the following options:
+          --runtime-config=batch/v2alpha1=true --profiling=true
+    kube-scheduler-extra-args:
+      type: string
+      default: ""
+      description: |
+        Space separated list of flags and key=value pairs that will be passed as arguments to
+        kube-scheduler.
+
+        Notes:
+          Options may only be set on charm deployment
+
+        For example a value like this:
+          runtime-config=batch/v2alpha1=true profiling=true
+        will result in kube-scheduler being run with the following options:
+          --runtime-config=batch/v2alpha1=true --profiling=true
+    kubelet-extra-args:
+      type: string
+      default: ""
+      description: |
+        Space separated list of flags and key=value pairs that will be passed as arguments to
+        kubelet.
+
+        Notes:
+          Options may only be set on charm deployment
+
+        For example a value like this:
+          runtime-config=batch/v2alpha1=true profiling=true
+        will result in kubelet being run with the following options:
+          --runtime-config=batch/v2alpha1=true --profiling=true
     load-balancer-enabled:
       type: boolean
       default: false

--- a/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
+++ b/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
@@ -45,7 +45,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 logger = logging.getLogger(__name__)
 
@@ -357,7 +357,11 @@ class BootstrapConfig(BaseModel):
         datastore_client_cert (str): The client certificate for accessing the datastore.
         datastore_client_key (str): The client key for accessing the datastore.
         extra_sans (List[str]): List of extra sans for the self-signed certificates
+        extra_node_kube_apiserver_args ([Dict[str,str]]): key-value service args
         extra_node_kube_controller_manager_args ([Dict[str,str]]): key-value service args
+        extra_node_kube_scheduler_args ([Dict[str,str]]): key-value service args
+        extra_node_kube_proxy_args ([Dict[str,str]]): key-value service args
+        extra_node_kubelet_args ([Dict[str,str]]): key-value service args
     """
 
     cluster_config: Optional[UserFacingClusterConfig] = Field(default=None, alias="cluster-config")
@@ -373,8 +377,20 @@ class BootstrapConfig(BaseModel):
     datastore_client_cert: Optional[str] = Field(default=None, alias="datastore-client-crt")
     datastore_client_key: Optional[str] = Field(default=None, alias="datastore-client-key")
     extra_sans: Optional[List[str]] = Field(default=None, alias="extra-sans")
+    extra_node_kube_apiserver_args: Optional[Dict[str, str]] = Field(
+        default=None, alias="extra-node-kube-apiserver-args"
+    )
     extra_node_kube_controller_manager_args: Optional[Dict[str, str]] = Field(
         default=None, alias="extra-node-kube-controller-manager-args"
+    )
+    extra_node_kube_scheduler_args: Optional[Dict[str, str]] = Field(
+        default=None, alias="extra-node-kube-scheduler-args"
+    )
+    extra_node_kube_proxy_args: Optional[Dict[str, str]] = Field(
+        default=None, alias="extra-node-kube-proxy-args"
+    )
+    extra_node_kubelet_args: Optional[Dict[str, str]] = Field(
+        default=None, alias="extra-node-kubelet-args"
     )
 
 
@@ -410,10 +426,18 @@ class NodeJoinConfig(BaseModel, allow_population_by_field_name=True):
     Attributes:
         kubelet_crt (str): node's certificate
         kubelet_key (str): node's certificate key
+        extra_node_kube_proxy_args (Dict[str, str]): key-value service args
+        extra_node_kubelet_args (Dict[str, str]): key-value service args
     """
 
     kubelet_crt: Optional[str] = Field(default=None, alias="kubelet-crt")
     kubelet_key: Optional[str] = Field(default=None, alias="kubelet-key")
+    extra_node_kube_proxy_args: Optional[Dict[str, str]] = Field(
+        default=None, alias="extra-node-kube-proxy-args"
+    )
+    extra_node_kubelet_args: Optional[Dict[str, str]] = Field(
+        default=None, alias="extra-node-kubelet-args"
+    )
 
 
 class ControlPlaneNodeJoinConfig(NodeJoinConfig, allow_population_by_field_name=True):
@@ -425,6 +449,9 @@ class ControlPlaneNodeJoinConfig(NodeJoinConfig, allow_population_by_field_name=
         apiserver_client_key (str): apiserver certificate key
         front_proxy_client_crt (str): front-proxy certificate
         front_proxy_client_key (str): front-proxy certificate key
+        extra_node_kube_apiserver_args (Dict[str, str]): key-value service args
+        extra_node_kube_controller_manager_args (Dict[str, str]): key-value service args
+        extra_node_kube_scheduler_args (Dict[str, str]): key-value service args
     """
 
     extra_sans: Optional[List[str]] = Field(default=None, alias="extra-sans")
@@ -433,6 +460,15 @@ class ControlPlaneNodeJoinConfig(NodeJoinConfig, allow_population_by_field_name=
     apiserver_client_key: Optional[str] = Field(default=None, alias="apiserver-key")
     front_proxy_client_crt: Optional[str] = Field(default=None, alias="front-proxy-client-crt")
     front_proxy_client_key: Optional[str] = Field(default=None, alias="front-proxy-client-key")
+    extra_node_kube_apiserver_args: Optional[Dict[str, str]] = Field(
+        default=None, alias="extra-node-kube-apiserver-args"
+    )
+    extra_node_kube_controller_manager_args: Optional[Dict[str, str]] = Field(
+        default=None, alias="extra-node-kube-controller-manager-args"
+    )
+    extra_node_kube_scheduler_args: Optional[Dict[str, str]] = Field(
+        default=None, alias="extra-node-kube-scheduler-args"
+    )
 
 
 class JoinClusterRequest(BaseModel, allow_population_by_field_name=True):

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -29,6 +29,7 @@ from urllib.parse import urlparse
 
 import charms.contextual_status as status
 import charms.operator_libs_linux.v2.snap as snap_lib
+import config.extra_args
 import containerd
 import ops
 import yaml
@@ -109,58 +110,6 @@ def _cluster_departing_unit(event: ops.EventBase) -> Union[Literal[False], ops.U
         and event.departing_unit
         or False
     )
-
-
-class ArgsMapping:
-    """A class to map string key,val pairs to be used as cmd args.
-
-    Attributes:
-        base_args: the base args to be used
-        extra_args: additional args to be used
-    """
-
-    def __init__(self, *_, **kwargs: str):
-        """Initialise the ArgsMapping class.
-
-        Args:
-            kwargs: the base args to be used
-        """
-        self.base_args = {k.lstrip("-"): v for k, v in kwargs.items()}
-        self.extra_args: Dict[str, str] = {}
-
-    def dict(self) -> Dict[str, str]:
-        """Return an args based representative view.
-
-        Returns:
-            Dict[str, str]: the args as a dictionary
-        """
-        args = {**self.base_args, **self.extra_args}
-        return {f"--{k}": v for k, v in args.items() if v is not None}
-
-    def parse(self, as_str: str):
-        """Parse the given string into extra_args.
-
-        Args:
-            as_str (str): the extra args to be added
-        """
-        elements = as_str.split()
-        args = {}
-
-        for element in elements:
-            if "=" in element:
-                key, _, value = element.partition("=")
-                args[key] = value
-            else:
-                args[element] = "true"
-        self.update(**args)
-
-    def update(self, *_, **kwargs: str):
-        """Update the extra_args with the given kwargs.
-
-        Args:
-            kwargs: the extra args to be added
-        """
-        self.extra_args.update({k.lstrip("-"): v for k, v in kwargs.items()})
 
 
 class NodeRemovedError(Exception):
@@ -368,47 +317,21 @@ class K8sCharm(ops.CharmBase):
         status.add(ops.MaintenanceStatus("Ensuring snap readiness"))
         self.api_manager.check_k8sd_ready()
 
-    def _extra_arguments(
-        self, config: Union[BootstrapConfig, ControlPlaneNodeJoinConfig, NodeJoinConfig]
-    ):
-        """Set extra arguments for Kubernetes components based on the provided configuration.
+    def _assemble_bootstrap_config(self):
+        """Assemble the bootstrap configuration for the Kubernetes cluster.
 
-        Updates the following attributes of the `config` object:
-            - extra_node_kube_apiserver_args: arguments for kube-apiserver.
-            - extra_node_kube_controller_manager_args: arguments for kube-controller-manager.
-            - extra_node_kube_scheduler_args: arguments for kube-scheduler.
-            - extra_node_kube_proxy_args: arguments for kube-proxy.
-            - extra_node_kubelet_args: arguments for kubelet.
-
-        Args:
-            config (Union[BootstrapConfig, ControlPlaneNodeJoinConfig, NodeJoinConfig]):
-                The configuration object to be updated with extra arguments.
+        Returns:
+            BootstrapConfig: The bootstrap configuration object.
         """
-        if isinstance(config, (BootstrapConfig, ControlPlaneNodeJoinConfig)):
-            kube_api_server_args = ArgsMapping()
-            kube_api_server_args.parse(str(self.config["kube-apiserver-extra-args"]))
-            config.extra_node_kube_apiserver_args = kube_api_server_args.dict()
-
-            kube_controller_manager_args = ArgsMapping()
-            kube_controller_manager_args.parse(
-                str(self.config["kube-controller-manager-extra-args"])
-            )
-            kube_controller_manager_args.update(
-                **{"cluster-name": self._generate_unique_cluster_name()}
-            )
-            config.extra_node_kube_controller_manager_args = kube_controller_manager_args.dict()
-
-            kube_scheduler_args = ArgsMapping()
-            kube_scheduler_args.parse(str(self.config["kube-scheduler-extra-args"]))
-            config.extra_node_kube_scheduler_args = kube_scheduler_args.dict()
-
-        kube_proxy_args = ArgsMapping()
-        kube_proxy_args.parse(str(self.config["kube-proxy-extra-args"]))
-        config.extra_node_kube_proxy_args = kube_proxy_args.dict()
-
-        kubelet_args = ArgsMapping()
-        kubelet_args.parse(str(self.config["kubelet-extra-args"]))
-        config.extra_node_kubelet_args = kubelet_args.dict()
+        bootstrap_config = BootstrapConfig.construct()
+        self._configure_datastore(bootstrap_config)
+        bootstrap_config.cluster_config = self._assemble_cluster_config()
+        bootstrap_config.service_cidr = str(self.config["bootstrap-service-cidr"])
+        bootstrap_config.pod_cidr = str(self.config["bootstrap-pod-cidr"])
+        bootstrap_config.control_plane_taints = str(self.config["bootstrap-node-taints"]).split()
+        bootstrap_config.extra_sans = [_get_public_address()]
+        config.extra_args.craft(self, bootstrap_config)
+        return bootstrap_config
 
     @on_error(
         ops.WaitingStatus("Waiting to bootstrap k8s snap"),
@@ -422,22 +345,15 @@ class K8sCharm(ops.CharmBase):
             log.info("K8s cluster already bootstrapped")
             return
 
-        bootstrap_config = BootstrapConfig.construct()
-        self._configure_datastore(bootstrap_config)
-        bootstrap_config.cluster_config = self._assemble_cluster_config()
-        bootstrap_config.service_cidr = str(self.config["bootstrap-service-cidr"])
-        bootstrap_config.pod_cidr = str(self.config["bootstrap-pod-cidr"])
-        bootstrap_config.control_plane_taints = str(self.config["bootstrap-node-taints"]).split()
-        bootstrap_config.extra_sans = [_get_public_address()]
-        self._extra_arguments(bootstrap_config)
-
         status.add(ops.MaintenanceStatus("Bootstrapping Cluster"))
 
         binding = self.model.get_binding("cluster")
         address = binding and binding.network.ingress_address
         node_name = self.get_node_name()
         payload = CreateClusterRequest(
-            name=node_name, address=f"{address}:{K8SD_PORT}", config=bootstrap_config
+            name=node_name,
+            address=f"{address}:{K8SD_PORT}",
+            config=self._assemble_bootstrap_config(),
         )
 
         # TODO: Make port (and address) configurable.
@@ -844,10 +760,10 @@ class K8sCharm(ops.CharmBase):
         if self.is_control_plane:
             request.config = ControlPlaneNodeJoinConfig()
             request.config.extra_sans = [_get_public_address()]
-            self._extra_arguments(request.config)
+            config.extra_args.craft(self, request.config)
         else:
             request.config = NodeJoinConfig()
-            self._extra_arguments(request.config)
+            config.extra_args.craft(self, request.config)
 
         self.api_manager.join_cluster(request)
         log.info("Joined %s(%s)", self.unit, node_name)

--- a/charms/worker/k8s/src/config/extra_args.py
+++ b/charms/worker/k8s/src/config/extra_args.py
@@ -1,0 +1,83 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Learn more at: https://juju.is/docs/sdk
+
+"""Parse extra arguments for Kubernetes components."""
+from typing import Dict, Union
+
+from charms.k8s.v0.k8sd_api_manager import (
+    BootstrapConfig,
+    ControlPlaneNodeJoinConfig,
+    NodeJoinConfig,
+)
+from protocols import K8sCharmProtocol
+
+
+class ArgMapper:
+    """A class to map string key,val pairs to be used as cmd args.
+
+    Attributes:
+        args: the args to be used made into command args
+    """
+
+    def __init__(self, config_data):
+        """Initialise the ArgMapper class.
+
+        Args:
+            config_data: the charm config data for an extra-args
+        """
+        self.args: Dict[str, str] = {}
+        for element in str(config_data).split():
+            if "=" in element:
+                key, _, value = element.partition("=")
+            else:
+                key, value = element, "true"
+            self.args[key.lstrip("-")] = value
+
+    def dict(self) -> Dict[str, str]:
+        """Return an args based representative view.
+
+        Returns:
+            Dict[str, str]: the args as a dictionary
+        """
+        return {f"--{k}": v for k, v in self.args.items() if v is not None}
+
+
+def craft(
+    charm: K8sCharmProtocol,
+    config: Union[BootstrapConfig, ControlPlaneNodeJoinConfig, NodeJoinConfig],
+):
+    """Set extra arguments for Kubernetes components based on the provided configuration.
+
+    Updates the following attributes of the `config` object:
+        - extra_node_kube_apiserver_args: arguments for kube-apiserver.
+        - extra_node_kube_controller_manager_args: arguments for kube-controller-manager.
+        - extra_node_kube_scheduler_args: arguments for kube-scheduler.
+        - extra_node_kube_proxy_args: arguments for kube-proxy.
+        - extra_node_kubelet_args: arguments for kubelet.
+
+    Args:
+        charm (ops.CharmBase): the charm instance to get the configuration from.
+        config (Union[BootstrapConfig, ControlPlaneNodeJoinConfig, NodeJoinConfig]):
+            The configuration object to be updated with extra arguments.
+    """
+    if isinstance(config, (BootstrapConfig, ControlPlaneNodeJoinConfig)):
+        cmd = ArgMapper(charm.config["kube-apiserver-extra-args"])
+        config.extra_node_kube_apiserver_args = cmd.dict()
+
+        cmd = ArgMapper(charm.config["kube-controller-manager-extra-args"])
+        if cluster_name := charm.get_cluster_name():
+            cmd.args.update(**{"cluster-name": cluster_name})
+        else:
+            cmd.args.pop("cluster-name", None)
+        config.extra_node_kube_controller_manager_args = cmd.dict()
+
+        cmd = ArgMapper(charm.config["kube-scheduler-extra-args"])
+        config.extra_node_kube_scheduler_args = cmd.dict()
+
+    cmd = ArgMapper(charm.config["kube-proxy-extra-args"])
+    config.extra_node_kube_proxy_args = cmd.dict()
+
+    cmd = ArgMapper(charm.config["kubelet-extra-args"])
+    config.extra_node_kubelet_args = cmd.dict()

--- a/charms/worker/k8s/src/config/extra_args.py
+++ b/charms/worker/k8s/src/config/extra_args.py
@@ -6,47 +6,35 @@
 """Parse extra arguments for Kubernetes components."""
 from typing import Dict, Union
 
+import ops
 from charms.k8s.v0.k8sd_api_manager import (
     BootstrapConfig,
     ControlPlaneNodeJoinConfig,
     NodeJoinConfig,
 )
-from protocols import K8sCharmProtocol
 
 
-class ArgMapper:
-    """A class to map string key,val pairs to be used as cmd args.
+def _parse(config_data) -> Dict[str, str]:
+    """Parse user config data into a dictionary.
 
-    Attributes:
-        args: the args to be used made into command args
+    Args:
+        config_data: the charm config data for an extra-args
     """
-
-    def __init__(self, config_data):
-        """Initialise the ArgMapper class.
-
-        Args:
-            config_data: the charm config data for an extra-args
-        """
-        self.args: Dict[str, str] = {}
-        for element in str(config_data).split():
-            if "=" in element:
-                key, _, value = element.partition("=")
-            else:
-                key, value = element, "true"
-            self.args[key.lstrip("-")] = value
-
-    def dict(self) -> Dict[str, str]:
-        """Return an args based representative view.
-
-        Returns:
-            Dict[str, str]: the args as a dictionary
-        """
-        return {f"--{k}": v for k, v in self.args.items() if v is not None}
+    args: Dict[str, str] = {}
+    for element in str(config_data).split():
+        if "=" in element:
+            key, _, value = element.partition("=")
+        else:
+            key, value = element, "true"
+        if value is not None:
+            args["--" + key.lstrip("-")] = value
+    return args
 
 
 def craft(
-    charm: K8sCharmProtocol,
-    config: Union[BootstrapConfig, ControlPlaneNodeJoinConfig, NodeJoinConfig],
+    src: ops.ConfigData,
+    dest: Union[BootstrapConfig, ControlPlaneNodeJoinConfig, NodeJoinConfig],
+    cluster_name: str,
 ):
     """Set extra arguments for Kubernetes components based on the provided configuration.
 
@@ -58,26 +46,27 @@ def craft(
         - extra_node_kubelet_args: arguments for kubelet.
 
     Args:
-        charm (ops.CharmBase): the charm instance to get the configuration from.
-        config (Union[BootstrapConfig, ControlPlaneNodeJoinConfig, NodeJoinConfig]):
+        src (ops.ConfigData): the charm instance to get the configuration from.
+        dest (Union[BootstrapConfig, ControlPlaneNodeJoinConfig, NodeJoinConfig]):
             The configuration object to be updated with extra arguments.
+        cluster_name (str): the name of the cluster to override in the extra arguments.
     """
-    if isinstance(config, (BootstrapConfig, ControlPlaneNodeJoinConfig)):
-        cmd = ArgMapper(charm.config["kube-apiserver-extra-args"])
-        config.extra_node_kube_apiserver_args = cmd.dict()
+    if isinstance(dest, (BootstrapConfig, ControlPlaneNodeJoinConfig)):
+        cmd = _parse(src["kube-apiserver-extra-args"])
+        dest.extra_node_kube_apiserver_args = cmd
 
-        cmd = ArgMapper(charm.config["kube-controller-manager-extra-args"])
-        if cluster_name := charm.get_cluster_name():
-            cmd.args.update(**{"cluster-name": cluster_name})
+        cmd = _parse(src["kube-controller-manager-extra-args"])
+        if cluster_name:
+            cmd.update(**{"--cluster-name": cluster_name})
         else:
-            cmd.args.pop("cluster-name", None)
-        config.extra_node_kube_controller_manager_args = cmd.dict()
+            cmd.pop("--cluster-name", None)
+        dest.extra_node_kube_controller_manager_args = cmd
 
-        cmd = ArgMapper(charm.config["kube-scheduler-extra-args"])
-        config.extra_node_kube_scheduler_args = cmd.dict()
+        cmd = _parse(src["kube-scheduler-extra-args"])
+        dest.extra_node_kube_scheduler_args = cmd
 
-    cmd = ArgMapper(charm.config["kube-proxy-extra-args"])
-    config.extra_node_kube_proxy_args = cmd.dict()
+    cmd = _parse(src["kube-proxy-extra-args"])
+    dest.extra_node_kube_proxy_args = cmd
 
-    cmd = ArgMapper(charm.config["kubelet-extra-args"])
-    config.extra_node_kubelet_args = cmd.dict()
+    cmd = _parse(src["kubelet-extra-args"])
+    dest.extra_node_kubelet_args = cmd

--- a/charms/worker/k8s/src/events/update_status.py
+++ b/charms/worker/k8s/src/events/update_status.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 

--- a/charms/worker/k8s/tests/unit/test_config_options.py
+++ b/charms/worker/k8s/tests/unit/test_config_options.py
@@ -8,6 +8,7 @@
 
 
 from pathlib import Path
+from unittest import mock
 
 import ops
 import ops.testing
@@ -72,3 +73,62 @@ def test_configure_ingress_options(harness):
     ufcg = harness.charm._assemble_cluster_config()
     assert ufcg.ingress.enabled == enabled
     assert ufcg.ingress.enable_proxy_protocol == proxy_protocol_enabled
+
+
+def test_configure_common_extra_args(harness):
+    """Test configuring the extra options.
+
+    Args:
+        harness: the harness under test
+    """
+    harness.disable_hooks()
+
+    harness.update_config({"kubelet-extra-args": "v=3 foo=bar flag"})
+    harness.update_config({"kube-proxy-extra-args": "v=4 foo=baz flog"})
+
+    with mock.patch("charm._get_public_address"):
+        bootstrap_config = harness.charm._assemble_bootstrap_config()
+    assert bootstrap_config.extra_node_kubelet_args == {
+        "--v": "3",
+        "--foo": "bar",
+        "--flag": "true",
+    }
+    assert bootstrap_config.extra_node_kube_proxy_args == {
+        "--v": "4",
+        "--foo": "baz",
+        "--flog": "true",
+    }
+
+
+def test_configure_controller_extra_args(harness):
+    """Test configuring the extra options.
+
+    Args:
+        harness: the harness under test
+    """
+    if harness.charm.is_worker:
+        pytest.skip("Not applicable on workers")
+
+    harness.disable_hooks()
+
+    harness.update_config({"kube-apiserver-extra-args": "v=3 foo=bar flag"})
+    harness.update_config({"kube-controller-manager-extra-args": "v=4 foo=baz flog"})
+    harness.update_config({"kube-scheduler-extra-args": "v=5 foo=bat blog"})
+
+    with mock.patch("charm._get_public_address"):
+        bootstrap_config = harness.charm._assemble_bootstrap_config()
+    assert bootstrap_config.extra_node_kube_apiserver_args == {
+        "--v": "3",
+        "--foo": "bar",
+        "--flag": "true",
+    }
+    assert bootstrap_config.extra_node_kube_controller_manager_args == {
+        "--v": "4",
+        "--foo": "baz",
+        "--flog": "true",
+    }
+    assert bootstrap_config.extra_node_kube_scheduler_args == {
+        "--v": "5",
+        "--foo": "bat",
+        "--blog": "true",
+    }

--- a/tests/integration/data/test-bundle.yaml
+++ b/tests/integration/data/test-bundle.yaml
@@ -14,10 +14,18 @@ applications:
     expose: true
     options:
       bootstrap-node-taints: "node-role.kubernetes.io/control-plane=:NoSchedule"
+      kube-apiserver-extra-args: "v=3"
+      kube-controller-manager-extra-args: "v=3"
+      kube-proxy-extra-args: "v=3"
+      kube-scheduler-extra-args: "v=3"
+      kubelet-extra-args: "v=3"
   k8s-worker:
     charm: k8s-worker
     channel: latest/edge
     num_units: 2
     constraints: cores=2 mem=8G root-disk=16G
+    options:
+      kube-proxy-extra-args: "v=3"
+      kubelet-extra-args: "v=3"
 relations:
   - [k8s, k8s-worker:cluster]


### PR DESCRIPTION
### Overview

During bootstrap, control-plane node-join, and worker node join, apply extra arguments for kube services. 

### Details
* test that the `v=3` option set the options to `--v=3` for each kube service on each unit
* ensure that joined control-planes and joined workers use the same charm config arguments