### PR TITLE
Remove unused tls field

### DIFF
--- a/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
+++ b/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
@@ -215,12 +215,10 @@ class IngressConfig(BaseModel, allow_population_by_field_name=True):
 
     Attributes:
         enabled: Optional flag which represents the status of Ingress.
-        default_tls_secret: The default TLS secret for ingress.
         enable_proxy_protocol: Optional flag to enable or disable proxy protocol.
     """
 
     enabled: Optional[bool] = Field(default=None)
-    default_tls_secret: Optional[str] = Field(default=None, alias="default-tls-secret")
     enable_proxy_protocol: Optional[bool] = Field(default=None, alias="enable-proxy-protocol")
 
 


### PR DESCRIPTION
### Overview
This PR removes the unused `default-tls-secret` field from the `IngressConfig` (left over from [this commit](https://github.com/canonical/k8s-operator/pull/176/commits/7233a6db9e2418f8b321b31f25be11b5c1d2d416)).