### PR TITLE
inital pass at adding terraform for the k8s charms

### DIFF
--- a/charms/worker/k8s/terraform/README.md
+++ b/charms/worker/k8s/terraform/README.md
@@ -49,7 +49,7 @@ module "k8s" {
 ```
 
 ### Define a `data` source
-Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+Define a `data` source and pass a reference to the `model_name` input to the `data.juju_model` resource's name. Terraform will look for a `juju_model` resource with a matching model name and only apply resources if the names match.
 ```
 data "juju_model" "testing" {
   name = var.model_name

--- a/charms/worker/k8s/terraform/README.md
+++ b/charms/worker/k8s/terraform/README.md
@@ -1,0 +1,61 @@
+# Terraform module for k8s
+
+This is a Terraform module facilitating the deployment of the k8s charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `constriants` | string | Juju constraits to apply for this aplication | False |
+| `model`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+| `series` | string | Ubuntu series to deploy the carm onto | False |
+| `units` | number | Number of units to deploy | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `requires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = canonical-k8s
+}
+module "k8s" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+module "k8s" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/worker/k8s/terraform/README.md
+++ b/charms/worker/k8s/terraform/README.md
@@ -44,7 +44,7 @@ resource "juju_model" "testing" {
 }
 module "k8s" {
   source = "<path-to-this-directory>"
-  model_name = juju_model.testing.name
+  model = juju_model.testing.name
 }
 ```
 

--- a/charms/worker/k8s/terraform/README.md
+++ b/charms/worker/k8s/terraform/README.md
@@ -10,17 +10,17 @@ This module requires a `juju` model to be available. Refer to the [usage section
 ### Inputs
 The module offers the following configurable inputs:
 
-| Name | Type | Description | Required |
-| - | - | - | - |
-| `app_name`| string | Application name | False |
-| `channel`| string | Channel that the charm is deployed from | False |
-| `config`| map(string) | Map of the charm configuration options | False |
-| `constraints` | string | Juju constraints to apply for this application | False |
-| `model`| string | Name of the model that the charm is deployed on | True |
-| `resources`| map(string) | Map of the charm resources | False |
-| `revision`| number | Revision number of the charm name | False |
-| `series` | string | Ubuntu series to deploy the carm onto | False |
-| `units` | number | Number of units to deploy | False |
+| Name | Type | Description | Required | Default |
+| - | - | - | - | - |
+| `app_name`| string | Application name | False | k8s |
+| `base` | string | Ubuntu base to deploy the carm onto | False | ubuntu@24.04 |
+| `channel`| string | Channel that the charm is deployed from | False | 1.30/edge |
+| `config`| map(string) | Map of the charm configuration options | False | {} |
+| `constraints` | string | Juju constraints to apply for this application | False | arch=amd64 |
+| `model`| string | Name of the model that the charm is deployed on | True | null |
+| `resources`| map(string) | Map of the charm resources | False | {} |
+| `revision`| number | Revision number of the charm name | False | null |
+| `units` | number | Number of units to deploy | False | 1 |
 
 ### Outputs
 Upon applied, the module exports the following outputs:

--- a/charms/worker/k8s/terraform/README.md
+++ b/charms/worker/k8s/terraform/README.md
@@ -56,6 +56,6 @@ data "juju_model" "testing" {
 }
 module "k8s" {
   source = "<path-to-this-directory>"
-  model_name = data.juju_model.testing.name
+  model = data.juju_model.testing.name
 }
 ```

--- a/charms/worker/k8s/terraform/README.md
+++ b/charms/worker/k8s/terraform/README.md
@@ -15,7 +15,7 @@ The module offers the following configurable inputs:
 | `app_name`| string | Application name | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
-| `constriants` | string | Juju constraits to apply for this aplication | False |
+| `constraints` | string | Juju constraints to apply for this application | False |
 | `model`| string | Name of the model that the charm is deployed on | True |
 | `resources`| map(string) | Map of the charm resources | False |
 | `revision`| number | Revision number of the charm name | False |

--- a/charms/worker/k8s/terraform/main.tf
+++ b/charms/worker/k8s/terraform/main.tf
@@ -1,0 +1,19 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "k8s" {
+  name  = var.app_name
+  model = var.model
+
+  charm {
+    name     = "k8s"
+    channel  = var.channel
+    revision = var.revision
+    series   = var.series
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  units       = var.units
+  resources   = var.resources
+}

--- a/charms/worker/k8s/terraform/main.tf
+++ b/charms/worker/k8s/terraform/main.tf
@@ -9,7 +9,7 @@ resource "juju_application" "k8s" {
     name     = "k8s"
     channel  = var.channel
     revision = var.revision
-    bases   = var.base
+    base   = var.base
   }
 
   config      = var.config

--- a/charms/worker/k8s/terraform/main.tf
+++ b/charms/worker/k8s/terraform/main.tf
@@ -9,7 +9,7 @@ resource "juju_application" "k8s" {
     name     = "k8s"
     channel  = var.channel
     revision = var.revision
-    series   = var.series
+    bases   = var.base
   }
 
   config      = var.config

--- a/charms/worker/k8s/terraform/main.tf
+++ b/charms/worker/k8s/terraform/main.tf
@@ -9,7 +9,7 @@ resource "juju_application" "k8s" {
     name     = "k8s"
     channel  = var.channel
     revision = var.revision
-    base   = var.base
+    base     = var.base
   }
 
   config      = var.config

--- a/charms/worker/k8s/terraform/outputs.tf
+++ b/charms/worker/k8s/terraform/outputs.tf
@@ -10,15 +10,19 @@ output "requires" {
   value = {
     aws         = "aws-integration"
     azure       = "azure-integration"
-    cluster     = "k8s-cluster"
-    cos_tokens  = "cos-k8s-tokens"
-    containerd  = "containerd"
+    etcd        = "etcd"
+    external_cloud_provider = "external_cloud_provider"
     gcp         = "gcp-integration"
   }
 }
 
 output "provides" {
   value = {
-    cos_agent   = "cos_agent"
+    cos_agent         = "cos_agent"
+    cos_worker_tokens = "cos-k8s-tokens"
+    containerd        = "containerd"
+    ceph_k8s_info     = "kubernetes-info"
+    k8s_cluster       = "k8s-cluster"
+    kube_contro       = "kube-control"
   }
 }

--- a/charms/worker/k8s/terraform/outputs.tf
+++ b/charms/worker/k8s/terraform/outputs.tf
@@ -8,21 +8,21 @@ output "app_name" {
 
 output "requires" {
   value = {
-    aws         = "aws-integration"
-    azure       = "azure-integration"
-    etcd        = "etcd"
-    external_cloud_provider = "external_cloud_provider"
-    gcp         = "gcp-integration"
+    aws                     = "aws"
+    azure                   = "azure"
+    etcd                    = "etcd"
+    external_cloud_provider = "external-cloud-provider"
+    gcp                     = "gcp"
   }
 }
 
 output "provides" {
   value = {
-    cos_agent         = "cos_agent"
-    cos_worker_tokens = "cos-k8s-tokens"
+    cos_agent         = "cos-agent"
+    cos_worker_tokens = "cos-worker-tokens"
     containerd        = "containerd"
-    ceph_k8s_info     = "kubernetes-info"
+    ceph_k8s_info     = "ceph-k8s-info"
     k8s_cluster       = "k8s-cluster"
-    kube_contro       = "kube-control"
+    kube_control      = "kube-control"
   }
 }

--- a/charms/worker/k8s/terraform/outputs.tf
+++ b/charms/worker/k8s/terraform/outputs.tf
@@ -1,0 +1,24 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.k8s.name
+}
+
+output "requires" {
+  value = {
+    aws         = "aws-integration"
+    azure       = "azure-integration"
+    cluster     = "k8s-cluster"
+    cos_tokens  = "cos-k8s-tokens"
+    containerd  = "containerd"
+    gcp         = "gcp-integration"
+  }
+}
+
+output "provides" {
+  value = {
+    cos_agent   = "cos_agent"
+  }
+}

--- a/charms/worker/k8s/terraform/variables.tf
+++ b/charms/worker/k8s/terraform/variables.tf
@@ -49,8 +49,8 @@ variable "base" {
   default     = "24.04"
 
   validation {
-    condition     = contains(["20.04", "22.04", "24.04"], var.base)
-    error_message = "Base must be one of 20.04, 22.04, 24.04"
+    condition     = contains(["ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"], var.base)
+    error_message = "Base must be one of ubuntu@20.04, ubuntu@22.04, ubuntu@24.04"
   }
 }
 

--- a/charms/worker/k8s/terraform/variables.tf
+++ b/charms/worker/k8s/terraform/variables.tf
@@ -43,14 +43,14 @@ variable "revision" {
   default     = null
 }
 
-variable "series" {
-  description = "Ubuntu series to deploy the charm onto"
+variable "base" {
+  description = "Ubuntu base to deploy the charm onto"
   type        = string
   default     = "24.04"
 
   validation {
-    condition     = contains(["20.04", "22.04", "24.04"], var.series)
-    error_message = "Series must be one of 20.04, 22.04, 24.04"
+    condition     = contains(["20.04", "22.04", "24.04"], var.base)
+    error_message = "Base must be one of 20.04, 22.04, 24.04"
   }
 }
 

--- a/charms/worker/k8s/terraform/variables.tf
+++ b/charms/worker/k8s/terraform/variables.tf
@@ -7,6 +7,17 @@ variable "app_name" {
   default     = "k8s"
 }
 
+variable "base" {
+  description = "Ubuntu base to deploy the charm onto"
+  type        = string
+  default     = "ubuntu@24.04"
+
+  validation {
+    condition     = contains(["ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"], var.base)
+    error_message = "Base must be one of ubuntu@20.04, ubuntu@22.04, ubuntu@24.04"
+  }
+}
+
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
@@ -28,7 +39,6 @@ variable "constraints" {
 variable "model" {
   description = "Reference to a `juju_model`."
   type        = string
-  default     = ""
 }
 
 variable "resources" {
@@ -41,17 +51,6 @@ variable "revision" {
   description = "Revision number of the charm"
   type        = number
   default     = null
-}
-
-variable "base" {
-  description = "Ubuntu base to deploy the charm onto"
-  type        = string
-  default     = "24.04"
-
-  validation {
-    condition     = contains(["ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"], var.base)
-    error_message = "Base must be one of ubuntu@20.04, ubuntu@22.04, ubuntu@24.04"
-  }
 }
 
 variable "units" {

--- a/charms/worker/k8s/terraform/variables.tf
+++ b/charms/worker/k8s/terraform/variables.tf
@@ -1,0 +1,61 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "k8s"
+}
+
+variable "channel" {
+  description = "The channel to use when deploying a charm."
+  type        = string
+  default     = "1.30/edge"
+}
+
+variable "config" {
+  description = "Application config. Details about available options can be found at https://charmhub.io/k8s/configurations."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "model" {
+  description = "Reference to a `juju_model`."
+  type        = string
+  default     = ""
+}
+
+variable "resources" {
+  description = "Resources to use with the application. Details about available options can be found at https://charmhub.io/k8s/configurations."
+  type        = map(string)
+  default     = {}
+}
+
+variable "revision" {
+  description = "Revision number of the charm"
+  type        = number
+  default     = null
+}
+
+variable "series" {
+  description = "Ubuntu series to deploy the charm onto"
+  type        = string
+  default     = "24.04"
+
+  validation {
+    condition     = contains(["20.04", "22.04", "24.04"], var.series)
+    error_message = "Series must be one of 20.04, 22.04, 24.04"
+  }
+}
+
+variable "units" {
+  description = "Number of units to deploy"
+  type        = number
+  default     = 1
+}

--- a/charms/worker/k8s/terraform/versions.tf
+++ b/charms/worker/k8s/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/worker/k8s/terraform/versions.tf
+++ b/charms/worker/k8s/terraform/versions.tf
@@ -1,4 +1,7 @@
 terraform {
+  # Copyright 2024 Canonical Ltd.
+  # See LICENSE file for licensing details.
+
   required_version = ">= 1.6"
   required_providers {
     juju = {

--- a/charms/worker/terraform/README.md
+++ b/charms/worker/terraform/README.md
@@ -1,0 +1,61 @@
+# Terraform module for k8s-worker
+
+This is a Terraform module facilitating the deployment of the k8s-worker charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `constriants` | string | Juju constraits to apply for this aplication | False |
+| `model`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+| `series` | string | Ubuntu series to deploy the carm onto | False |
+| `units` | number | Number of units to deploy | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `requires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = canonical-k8s
+}
+module "k8s_worker" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+module "k8s_worker" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/worker/terraform/README.md
+++ b/charms/worker/terraform/README.md
@@ -44,7 +44,7 @@ resource "juju_model" "testing" {
 }
 module "k8s_worker" {
   source = "<path-to-this-directory>"
-  model_name = juju_model.testing.name
+  model = juju_model.testing.name
 }
 ```
 
@@ -56,6 +56,6 @@ data "juju_model" "testing" {
 }
 module "k8s_worker" {
   source = "<path-to-this-directory>"
-  model_name = data.juju_model.testing.name
+  model = data.juju_model.testing.name
 }
 ```

--- a/charms/worker/terraform/README.md
+++ b/charms/worker/terraform/README.md
@@ -10,17 +10,17 @@ This module requires a `juju` model to be available. Refer to the [usage section
 ### Inputs
 The module offers the following configurable inputs:
 
-| Name | Type | Description | Required |
-| - | - | - | - |
-| `app_name`| string | Application name | False |
-| `channel`| string | Channel that the charm is deployed from | False |
-| `config`| map(string) | Map of the charm configuration options | False |
-| `constraints` | string | Juju constraints to apply for this application | False |
-| `model`| string | Name of the model that the charm is deployed on | True |
-| `resources`| map(string) | Map of the charm resources | False |
-| `revision`| number | Revision number of the charm name | False |
-| `series` | string | Ubuntu series to deploy the carm onto | False |
-| `units` | number | Number of units to deploy | False |
+| Name | Type | Description | Required | Default |
+| - | - | - | - | - |
+| `app_name`| string | Application name | False | k8s-worker | 
+| `base` | string | Ubuntu base to deploy the carm onto | False | ubuntu@24.04 |
+| `channel`| string | Channel that the charm is deployed from | False | 1.30/edge |
+| `config`| map(string) | Map of the charm configuration options | False | {} |
+| `constraints` | string | Juju constraints to apply for this application | False | arch=amd64 |
+| `model`| string | Name of the model that the charm is deployed on | True | - |
+| `resources`| map(string) | Map of the charm resources | False | {} |
+| `revision`| number | Revision number of the charm name | False | null |
+| `units` | number | Number of units to deploy | False | 1 |
 
 ### Outputs
 Upon applied, the module exports the following outputs:

--- a/charms/worker/terraform/README.md
+++ b/charms/worker/terraform/README.md
@@ -15,7 +15,7 @@ The module offers the following configurable inputs:
 | `app_name`| string | Application name | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
-| `constriants` | string | Juju constraits to apply for this aplication | False |
+| `constraints` | string | Juju constraints to apply for this application | False |
 | `model`| string | Name of the model that the charm is deployed on | True |
 | `resources`| map(string) | Map of the charm resources | False |
 | `revision`| number | Revision number of the charm name | False |

--- a/charms/worker/terraform/main.tf
+++ b/charms/worker/terraform/main.tf
@@ -9,7 +9,7 @@ resource "juju_application" "k8s_worker" {
     name     = "k8s-worker"
     channel  = var.channel
     revision = var.revision
-    series   = var.series
+    base   = var.base
   }
 
   config      = var.config

--- a/charms/worker/terraform/main.tf
+++ b/charms/worker/terraform/main.tf
@@ -1,0 +1,19 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "k8s_worker" {
+  name  = var.app_name
+  model = var.model
+
+  charm {
+    name     = "k8s-worker"
+    channel  = var.channel
+    revision = var.revision
+    series   = var.series
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  units       = var.units
+  resources   = var.resources
+}

--- a/charms/worker/terraform/main.tf
+++ b/charms/worker/terraform/main.tf
@@ -9,7 +9,7 @@ resource "juju_application" "k8s_worker" {
     name     = "k8s-worker"
     channel  = var.channel
     revision = var.revision
-    base   = var.base
+    base     = var.base
   }
 
   config      = var.config

--- a/charms/worker/terraform/outputs.tf
+++ b/charms/worker/terraform/outputs.tf
@@ -8,17 +8,17 @@ output "app_name" {
 
 output "requires" {
   value = {
-    aws         = "aws-integration"
-    azure       = "azure-integration"
-    cluster     = "k8s-cluster"
-    cos_tokens  = "cos-k8s-tokens"
+    aws         = "aws"
+    azure       = "azure"
+    cluster     = "k8s"
+    cos_tokens  = "cos-tokens"
     containerd  = "containerd"
-    gcp         = "gcp-integration"
+    gcp         = "gcp"
   }
 }
 
 output "provides" {
   value = {
-    cos_agent   = "cos_agent"
+    cos_agent   = "cos-agent"
   }
 }

--- a/charms/worker/terraform/outputs.tf
+++ b/charms/worker/terraform/outputs.tf
@@ -1,0 +1,24 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.k8s_worker.name
+}
+
+output "requires" {
+  value = {
+    aws         = "aws-integration"
+    azure       = "azure-integration"
+    cluster     = "k8s-cluster"
+    cos_tokens  = "cos-k8s-tokens"
+    containerd  = "containerd"
+    gcp         = "gcp-integration"
+  }
+}
+
+output "provides" {
+  value = {
+    cos_agent   = "cos_agent"
+  }
+}

--- a/charms/worker/terraform/outputs.tf
+++ b/charms/worker/terraform/outputs.tf
@@ -8,17 +8,17 @@ output "app_name" {
 
 output "requires" {
   value = {
-    aws         = "aws"
-    azure       = "azure"
-    cluster     = "cluster"
-    cos_tokens  = "cos-tokens"
-    containerd  = "containerd"
-    gcp         = "gcp"
+    aws        = "aws"
+    azure      = "azure"
+    cluster    = "cluster"
+    cos_tokens = "cos-tokens"
+    containerd = "containerd"
+    gcp        = "gcp"
   }
 }
 
 output "provides" {
   value = {
-    cos_agent   = "cos-agent"
+    cos_agent = "cos-agent"
   }
 }

--- a/charms/worker/terraform/outputs.tf
+++ b/charms/worker/terraform/outputs.tf
@@ -10,7 +10,7 @@ output "requires" {
   value = {
     aws         = "aws"
     azure       = "azure"
-    cluster     = "k8s"
+    cluster     = "cluster"
     cos_tokens  = "cos-tokens"
     containerd  = "containerd"
     gcp         = "gcp"

--- a/charms/worker/terraform/variables.tf
+++ b/charms/worker/terraform/variables.tf
@@ -43,14 +43,14 @@ variable "revision" {
   default     = null
 }
 
-variable "series" {
-  description = "Ubuntu series to deploy the charm onto"
+variable "base" {
+  description = "Ubuntu bases to deploy the charm onto"
   type        = string
   default     = "24.04"
 
   validation {
-    condition     = contains(["20.04", "22.04", "24.04"], var.series)
-    error_message = "Series must be one of 20.04, 22.04, 24.04"
+    condition     = contains(["20.04", "22.04", "24.04"], var.base)
+    error_message = "Base must be one of 20.04, 22.04, 24.04"
   }
 }
 

--- a/charms/worker/terraform/variables.tf
+++ b/charms/worker/terraform/variables.tf
@@ -49,8 +49,8 @@ variable "base" {
   default     = "24.04"
 
   validation {
-    condition     = contains(["20.04", "22.04", "24.04"], var.base)
-    error_message = "Base must be one of 20.04, 22.04, 24.04"
+    condition     = contains(["ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"], var.base)
+    error_message = "Base must be one of ubuntu@20.04, ubuntu@22.04, ubuntu@24.04"
   }
 }
 

--- a/charms/worker/terraform/variables.tf
+++ b/charms/worker/terraform/variables.tf
@@ -7,6 +7,17 @@ variable "app_name" {
   default     = "k8s-worker"
 }
 
+variable "base" {
+  description = "Ubuntu bases to deploy the charm onto"
+  type        = string
+  default     = "ubuntu@24.04"
+
+  validation {
+    condition     = contains(["ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"], var.base)
+    error_message = "Base must be one of ubuntu@20.04, ubuntu@22.04, ubuntu@24.04"
+  }
+}
+
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
@@ -28,7 +39,6 @@ variable "constraints" {
 variable "model" {
   description = "Reference to a `juju_model`."
   type        = string
-  default     = ""
 }
 
 variable "resources" {
@@ -41,17 +51,6 @@ variable "revision" {
   description = "Revision number of the charm"
   type        = number
   default     = null
-}
-
-variable "base" {
-  description = "Ubuntu bases to deploy the charm onto"
-  type        = string
-  default     = "24.04"
-
-  validation {
-    condition     = contains(["ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"], var.base)
-    error_message = "Base must be one of ubuntu@20.04, ubuntu@22.04, ubuntu@24.04"
-  }
 }
 
 variable "units" {

--- a/charms/worker/terraform/variables.tf
+++ b/charms/worker/terraform/variables.tf
@@ -1,0 +1,61 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "k8s-worker"
+}
+
+variable "channel" {
+  description = "The channel to use when deploying a charm."
+  type        = string
+  default     = "1.30/edge"
+}
+
+variable "config" {
+  description = "Application config. Details about available options can be found at https://charmhub.io/k8s-worker/configurations."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "model" {
+  description = "Reference to a `juju_model`."
+  type        = string
+  default     = ""
+}
+
+variable "resources" {
+  description = "Resources to use with the application. Details about available options can be found at https://charmhub.io/k8s-worker/configurations."
+  type        = map(string)
+  default     = {}
+}
+
+variable "revision" {
+  description = "Revision number of the charm"
+  type        = number
+  default     = null
+}
+
+variable "series" {
+  description = "Ubuntu series to deploy the charm onto"
+  type        = string
+  default     = "24.04"
+
+  validation {
+    condition     = contains(["20.04", "22.04", "24.04"], var.series)
+    error_message = "Series must be one of 20.04, 22.04, 24.04"
+  }
+}
+
+variable "units" {
+  description = "Number of units to deploy"
+  type        = number
+  default     = 1
+}

--- a/charms/worker/terraform/versions.tf
+++ b/charms/worker/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/worker/terraform/versions.tf
+++ b/charms/worker/terraform/versions.tf
@@ -1,4 +1,7 @@
 terraform {
+  # Copyright 2024 Canonical Ltd.
+  # See LICENSE file for licensing details.
+
   required_version = ">= 1.6"
   required_providers {
     juju = {


### PR DESCRIPTION
Applicable spec: https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit?tab=t.0

### Overview

Adds basic terraform modules for the k8s charms

### Rationale

Enable deploying canonical k8s with terraform

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
