### PR TITLE
[DO NOT MERGE] Test Ceph 1.31/candidate

### DIFF
--- a/tests/integration/data/test-bundle-ceph.yaml
+++ b/tests/integration/data/test-bundle-ceph.yaml
@@ -13,7 +13,7 @@ applications:
     num_units: 1
   ceph-csi:
     charm: ceph-csi
-    channel: latest/stable
+    channel: 1.31/candidate
     options:
       provisioner-replicas: 1
   ceph-mon:


### PR DESCRIPTION
### DO NOT MERGE

This PR validates if Ceph 1.31/candidate can be safely promoted to 1.31/stable by running integration tests.