### PR TITLE
Rename annotations to cluster-annotations

### DIFF
--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -68,11 +68,11 @@ bases:
       architectures: [arm64]
 config:
   options:
-    annotations:
+    cluster-annotations:
       type: string
       default: ""
       description: |
-        Annotations is a space separated list of (key/value) pairs)  that can be
+        Space-separated list of (key/value) pairs) that can be
         used to add arbitrary metadata configuration to the Canonical
         Kubernetes cluster. For more information, see the upstream Canonical
         Kubernetes documentation about annotations:

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -391,7 +391,7 @@ class K8sCharm(ops.CharmBase):
             self.collector.request(relation)
 
     def _get_valid_annotations(self) -> Optional[dict]:
-        """Fetch and validate annotations from charm configuration.
+        """Fetch and validate cluster-annotations from charm configuration.
 
         The values are expected to be a space-separated string of key-value pairs.
 
@@ -401,7 +401,7 @@ class K8sCharm(ops.CharmBase):
         Raises:
             ReconcilerError: If any annotation is invalid.
         """
-        raw_annotations = self.config.get("annotations")
+        raw_annotations = self.config.get("cluster-annotations")
         if not raw_annotations:
             return None
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -30,7 +30,7 @@ from .helpers import get_unit_cidrs, is_deployed
 log = logging.getLogger(__name__)
 TEST_DATA = Path(__file__).parent / "data"
 DEFAULT_SNAP_INSTALLATION = TEST_DATA / "default-snap-installation.tar.gz"
-DEFAULT_RESOURCES = {"snap-installation": None}
+DEFAULT_RESOURCES = {"snap-installation": ""}
 
 
 def pytest_addoption(parser: pytest.Parser):


### PR DESCRIPTION
Renames `annotations` to `cluster-annotations` in charm config.