### PR TITLE
Replace Magic Strings with `literals.py` Constants

### DIFF
--- a/charms/worker/k8s/src/literals.py
+++ b/charms/worker/k8s/src/literals.py
@@ -3,8 +3,32 @@
 
 """Literals for the charm."""
 
+from pathlib import Path
+
+# Snap
 SNAP_NAME = "k8s"
 
+# Logging
+VALID_LOG_LEVELS = ["info", "debug", "warning", "error", "critical"]
+
+# Charm
+ETC_KUBERNETES = Path("/etc/kubernetes")
+KUBECONFIG = Path.home() / ".kube/config"
+KUBECTL_PATH = Path("/snap/k8s/current/bin/kubectl")
+K8SD_SNAP_SOCKET = "/var/snap/k8s/common/var/lib/k8sd/state/control.socket"
+K8SD_PORT = 6400
+SUPPORTED_DATASTORES = ["dqlite", "etcd"]
+
+# Relations
+CLUSTER_RELATION = "cluster"
+CLUSTER_WORKER_RELATION = "k8s-cluster"
+CONTAINERD_RELATION = "containerd"
+COS_TOKENS_RELATION = "cos-tokens"
+COS_TOKENS_WORKER_RELATION = "cos-worker-tokens"
+COS_RELATION = "cos-agent"
+ETCD_RELATION = "etcd"
+
+# Kubernetes services
 K8S_COMMON_SERVICES = [
     "kubelet",
     "kube-proxy",
@@ -18,12 +42,15 @@ K8S_CONTROL_PLANE_SERVICES = [
     K8S_DQLITE_SERVICE,
     "kube-controller-manager",
     "kube-scheduler",
+    *K8S_COMMON_SERVICES,
 ]
 
 K8S_WORKER_SERVICES = [
     "k8s-apiserver-proxy",
+    *K8S_COMMON_SERVICES,
 ]
 
+# Upgrade
 DEPENDENCIES = {
     # NOTE: Update the dependencies for the k8s-charm before releasing.
     "k8s_charm": {

--- a/charms/worker/k8s/src/upgrade.py
+++ b/charms/worker/k8s/src/upgrade.py
@@ -19,7 +19,7 @@ from charms.data_platform_libs.v0.upgrade import (
 from charms.operator_libs_linux.v2.snap import SnapError
 from inspector import ClusterInspector
 from literals import (
-    K8S_COMMON_SERVICES,
+    CLUSTER_RELATION,
     K8S_CONTROL_PLANE_SERVICES,
     K8S_DQLITE_SERVICE,
     K8S_WORKER_SERVICES,
@@ -199,12 +199,10 @@ class K8sUpgrade(DataUpgrade):
         self.charm.grant_upgrade()
 
         services = (
-            K8S_CONTROL_PLANE_SERVICES + K8S_COMMON_SERVICES
-            if self.charm.is_control_plane
-            else K8S_COMMON_SERVICES + K8S_WORKER_SERVICES
+            K8S_CONTROL_PLANE_SERVICES if self.charm.is_control_plane else K8S_WORKER_SERVICES
         )
 
-        if K8S_DQLITE_SERVICE in services and self.charm.datastore == "dqlite":
+        if K8S_DQLITE_SERVICE in services and self.charm.datastore != "dqlite":
             services.remove(K8S_DQLITE_SERVICE)
 
         try:
@@ -227,7 +225,7 @@ class K8sUpgrade(DataUpgrade):
         Returns:
             A list of unit numbers to upgrade in order.
         """
-        relation = self.charm.model.get_relation("cluster")
+        relation = self.charm.model.get_relation(CLUSTER_RELATION)
         if not relation:
             return [int(self.charm.unit.name.split("/")[-1])]
 

--- a/charms/worker/k8s/tests/unit/test_token_distributor.py
+++ b/charms/worker/k8s/tests/unit/test_token_distributor.py
@@ -13,6 +13,7 @@ import ops.testing
 import pytest
 import token_distributor
 from charm import K8sCharm
+from literals import CLUSTER_RELATION
 
 
 @pytest.fixture(params=["worker", "control-plane"])
@@ -37,7 +38,7 @@ def test_request(harness):
     harness.disable_hooks()
     collector = token_distributor.TokenCollector(harness.charm, "my-node")
     relation_id = harness.add_relation("cluster", "remote")
-    collector.request(harness.charm.model.get_relation("cluster"))
+    collector.request(harness.charm.model.get_relation(CLUSTER_RELATION))
     data = harness.get_relation_data(relation_id, harness.charm.unit.name)
     assert data["node-name"] == "my-node"
 
@@ -47,8 +48,8 @@ def test_cluster_name_not_joined(harness):
     harness.disable_hooks()
     collector = token_distributor.TokenCollector(harness.charm, "my-node")
     relation_id = harness.add_relation("cluster", "remote")
-    remote = collector.cluster_name(harness.charm.model.get_relation("cluster"), False)
-    local = collector.cluster_name(harness.charm.model.get_relation("cluster"), True)
+    remote = collector.cluster_name(harness.charm.model.get_relation(CLUSTER_RELATION), False)
+    local = collector.cluster_name(harness.charm.model.get_relation(CLUSTER_RELATION), True)
     assert remote == local == ""
     data = harness.get_relation_data(relation_id, harness.charm.unit.name)
     assert not data.get("joined")
@@ -60,13 +61,13 @@ def test_cluster_name_joined(harness):
     collector = token_distributor.TokenCollector(harness.charm, "my-node")
     relation_id = harness.add_relation("cluster", "k8s", unit_data={"cluster-name": "my-cluster"})
     # Fetching the remote doesn't update joined field
-    remote = collector.cluster_name(harness.charm.model.get_relation("cluster"), False)
+    remote = collector.cluster_name(harness.charm.model.get_relation(CLUSTER_RELATION), False)
     assert remote == "my-cluster"
     data = harness.get_relation_data(relation_id, harness.charm.unit.name)
     assert not data.get("joined")
 
     # Fetching the local does update joined field
-    local = collector.cluster_name(harness.charm.model.get_relation("cluster"), True)
+    local = collector.cluster_name(harness.charm.model.get_relation(CLUSTER_RELATION), True)
     assert remote == local == "my-cluster"
     data = harness.get_relation_data(relation_id, harness.charm.unit.name)
     assert data["joined"] == "my-cluster"

--- a/charms/worker/k8s/tests/unit/test_upgrade.py
+++ b/charms/worker/k8s/tests/unit/test_upgrade.py
@@ -11,6 +11,7 @@ from charms.data_platform_libs.v0.upgrade import ClusterNotReadyError
 from inspector import ClusterInspector
 from lightkube.models.core_v1 import Node
 from lightkube.models.meta_v1 import ObjectMeta
+from literals import CLUSTER_RELATION
 from upgrade import K8sDependenciesModel, K8sUpgrade
 
 
@@ -103,7 +104,7 @@ class TestK8sUpgrade(unittest.TestCase):
         result = self.upgrade.build_upgrade_stack()
 
         self.assertEqual(result, [0])
-        self.charm.model.get_relation.assert_called_once_with("cluster")
+        self.charm.model.get_relation.assert_called_once_with(CLUSTER_RELATION)
 
     def test_build_upgrade_stack_with_relation(self):
         """Test build_upgrade_stack with cluster relation."""
@@ -119,7 +120,7 @@ class TestK8sUpgrade(unittest.TestCase):
         result = self.upgrade.build_upgrade_stack()
 
         self.assertEqual(sorted(result), [0, 1, 2])
-        self.charm.model.get_relation.assert_called_once_with("cluster")
+        self.charm.model.get_relation.assert_called_once_with(CLUSTER_RELATION)
 
     def test_verify_worker_versions_compatible(self):
         """Test _verify_worker_versions returns True when worker versions is compatible."""


### PR DESCRIPTION
## Overview
Replace magic string in the codebase with constants.
## Rationale
To align with the best practices from other charms and improve the code maintainability, this pull request replaces the "magic strings" used in the code with constants.