### PR TITLE
Adjust workflow pinning again

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -39,8 +39,8 @@ jobs:
     strategy:
       matrix:
         arch:
-        - {id: amd64, builder-label: self-hosted-linux-amd64-jammy-large, tester-arch: AMD64, tester-size: large}
-        - {id: arm64, builder-label: self-hosted-linux-arm64-jammy-large, tester-arch: ARM64, tester-size: large}
+        - {id: amd64, builder-label: ubuntu-22.04, tester-arch: AMD64}  # built on azure
+        - {id: arm64, builder-label: ARM64,        tester-arch: ARM64}  # built on self-hosted
         suite: [k8s, etcd, ceph]
         exclude:
         - {arch: {id: arm64}, suite: ceph}
@@ -56,7 +56,7 @@ jobs:
       provider: lxd
       self-hosted-runner: true
       self-hosted-runner-arch: ${{ matrix.arch.tester-arch }}
-      self-hosted-runner-label: ${{ matrix.arch.tester-size }}
+      self-hosted-runner-label: large
       test-timeout: 120
       test-tox-env: integration-${{ matrix.suite }}
       trivy-fs-enabled: false


### PR DESCRIPTION
### Overview
Kind of backs out #203, builds were queuing up due to a lack of builders, and our workflows require quite a few builders.