### PR TITLE
Add worker bootstrap-node-taints setting

### DIFF
--- a/charms/worker/charmcraft.yaml
+++ b/charms/worker/charmcraft.yaml
@@ -60,6 +60,19 @@ bases:
 
 config:
   options:
+    bootstrap-node-taints:
+      type: string
+      default: ""
+      description: |
+        Space-separated list of taints to apply to this node at registration time.
+
+        This config is only used at bootstrap time when Kubelet first registers the
+        node with Kubernetes. To change node taints after deploy time, use kubectl
+        instead.
+
+        For more information, see the upstream Kubernetes documentation about
+        taints:
+        https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
     node-labels:
       default: ""
       type: string

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -815,6 +815,9 @@ class K8sCharm(ops.CharmBase):
             request.config = NodeJoinConfig()
             config.extra_args.craft(self.config, request.config, cluster_name)
 
+            bootstrap_node_taints = str(self.config["bootstrap-node-taints"] or "").strip().split()
+            config.extra_args.taint_worker(request.config, bootstrap_node_taints)
+
         self.api_manager.join_cluster(request)
         log.info("Joined %s(%s)", self.unit, node_name)
 

--- a/charms/worker/k8s/src/config/extra_args.py
+++ b/charms/worker/k8s/src/config/extra_args.py
@@ -4,7 +4,7 @@
 # Learn more at: https://juju.is/docs/sdk
 
 """Parse extra arguments for Kubernetes components."""
-from typing import Dict, Union
+from typing import Dict, List, Union
 
 import ops
 from charms.k8s.v0.k8sd_api_manager import (
@@ -71,12 +71,17 @@ def craft(
     cmd = _parse(src["kubelet-extra-args"])
     dest.extra_node_kubelet_args = cmd
 
-    is_worker_node = isinstance(dest, NodeJoinConfig) and not isinstance(
-        dest, ControlPlaneNodeJoinConfig
-    )
-    if is_worker_node:
-        # We'll only do this for worker nodes, control plane nodes are handled
-        # separately.
-        taints = str(src["bootstrap-node-taints"] or "").strip().split()
-        if taints:
-            dest.extra_node_kubelet_args["--register-with-taints"] = ",".join(taints)
+
+def taint_worker(dest: NodeJoinConfig, taints: List[str]):
+    """Apply the specified list of taints to the node join configuration.
+
+    Updates the following attributes of the `config` object:
+        - extra_node_kubelet_args: arguments for kubelet.
+
+    Args:
+        dest (NodeJoinConfig):
+            The configuration object to be updated with extra arguments.
+        taints (List[str]):
+            The list of taints to apply.
+    """
+    dest.extra_node_kubelet_args["--register-with-taints"] = ",".join(taints)

--- a/charms/worker/k8s/src/config/extra_args.py
+++ b/charms/worker/k8s/src/config/extra_args.py
@@ -70,3 +70,13 @@ def craft(
 
     cmd = _parse(src["kubelet-extra-args"])
     dest.extra_node_kubelet_args = cmd
+
+    is_worker_node = isinstance(dest, NodeJoinConfig) and not isinstance(
+        dest, ControlPlaneNodeJoinConfig
+    )
+    if is_worker_node:
+        # We'll only do this for worker nodes, control plane nodes are handled
+        # separately.
+        taints = str(src["bootstrap-node-taints"] or "").strip().split()
+        if taints:
+            dest.extra_node_kubelet_args["--register-with-taints"] = ",".join(taints)


### PR DESCRIPTION
The control-plane charm already allows defining node taints. We'll add the same for worker nodes.

Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
