### PR TITLE
Enhance Upgrade Status

### DIFF
--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -729,10 +729,14 @@ class K8sCharm(ops.CharmBase):
         if not local_version:
             raise ReconcilerError("k8s-snap is not installed")
 
-        peer = self.model.get_relation(CLUSTER_RELATION)
-        worker = self.model.get_relation(CLUSTER_WORKER_RELATION)
+        relations = (
+            self.model.get_relation(CLUSTER_RELATION),
+            self.model.get_relation(CLUSTER_WORKER_RELATION),
+        )
+        relation_types = ("peer", "worker")
+        waiting_units = {rtype: 0 for rtype in relation_types}
 
-        for relation in (peer, worker):
+        for relation, relation_type in zip(relations, relation_types):
             if not relation:
                 continue
             units = (unit for unit in relation.units if unit.name != self.unit.name)
@@ -741,10 +745,18 @@ class K8sCharm(ops.CharmBase):
                 if not unit_version:
                     raise ReconcilerError(f"Waiting for version from {unit.name}")
                 if unit_version != local_version:
-                    # NOTE: Add a check to validate if we are doing an upgrade
-                    status.add(ops.WaitingStatus("Upgrading the cluster"))
-                    return
+                    waiting_units[relation_type] += 1
             relation.data[self.app]["version"] = local_version
+
+        if any(waiting_units.values()):
+            waiting_parts = []
+            if waiting_units["peer"]:
+                waiting_parts.append(f"{waiting_units['peer']} Control Plane")
+            if waiting_units["worker"]:
+                waiting_parts.append(f"{waiting_units['worker']} Worker")
+            status_msg = ", ".join(waiting_parts)
+            status.add(ops.WaitingStatus(f"Waiting {status_msg} to upgrade"))
+            raise ReconcilerError("Waiting for all units to upgrade")
 
     def _get_proxy_env(self) -> Dict[str, str]:
         """Retrieve the Juju model config proxy values.

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -759,7 +759,7 @@ class K8sCharm(ops.CharmBase):
         }
 
         waiting_parts = [
-            f"{count} {role_names[role]}{"s" if count > 1 else ""}"
+            f"{count} {role_names[role]}{'s' if count > 1 else ''}"
             for role, count in waiting_units.items()
             if count
         ]


### PR DESCRIPTION
## Overview  
Enhance status visibility during cluster upgrades.  

## Rationale  
To better surface the current state of the cluster upgrade, this pull request introduces an improvement for the `k8s` leader unit to track and report the upgrade status. This includes showing how many control plane and worker units are still pending upgrade in the unit status message.

## Example
```
Model        Controller      Cloud/Region         Version  SLA          Timestamp
k8s-cluster  lxd-controller  localhost/localhost  3.6.1    unsupported  14:53:30-05:00

App         Version  Status   Scale  Charm       Channel  Rev  Exposed  Message
k8s         1.31.3   waiting      2  k8s                    2  no       Upgrading 2 Worker units
k8s-worker  1.31.2   active       2  k8s-worker             0  no       Ready

Unit           Workload  Agent  Machine  Public address                          Ports     Message
k8s-worker/0*  active    idle   2        10.65.65.88                                       Ready
k8s-worker/1   active    idle   3        10.65.65.188                                      Ready
k8s/0*         waiting   idle   0        10.65.65.233                            6443/tcp  Upgrading 2 Worker units
k8s/1          active    idle   1        fd42:4317:5983:ea1c:216:3eff:fe98:be57  6443/tcp  Ready

Machine  State    Address                                 Inst id        Base          AZ  Message
0        started  10.65.65.233                            juju-dca78a-0  ubuntu@24.04      Running
1        started  fd42:4317:5983:ea1c:216:3eff:fe98:be57  juju-dca78a-1  ubuntu@24.04      Running
2        started  10.65.65.88                             juju-dca78a-2  ubuntu@24.04      Running
3        started  10.65.65.188                            juju-dca78a-3  ubuntu@24.04      Running
```