### PR TITLE
Pin snap_installations to 1.32-classic stables

### DIFF
--- a/.github/workflows/update-snap-revision.py
+++ b/.github/workflows/update-snap-revision.py
@@ -13,7 +13,7 @@ import yaml
 
 logging.basicConfig(format="%(levelname)-8s: %(message)s", level=logging.INFO)
 log = logging.getLogger("update-snap-revision")
-TRACK = "1.31-classic"
+TRACK = "1.32-classic"
 RISK = "stable"
 ROOT = Path(__file__).parent / ".." / ".."
 INSTALLATION = ROOT / "charms/worker/k8s/templates/snap_installation.yaml"

--- a/charms/worker/k8s/src/literals.py
+++ b/charms/worker/k8s/src/literals.py
@@ -27,6 +27,7 @@ COS_TOKENS_RELATION = "cos-tokens"
 COS_TOKENS_WORKER_RELATION = "cos-worker-tokens"
 COS_RELATION = "cos-agent"
 ETCD_RELATION = "etcd"
+UPGRADE_RELATION = "upgrade"
 
 # Kubernetes services
 K8S_COMMON_SERVICES = [

--- a/charms/worker/k8s/src/literals.py
+++ b/charms/worker/k8s/src/literals.py
@@ -19,6 +19,9 @@ K8SD_SNAP_SOCKET = "/var/snap/k8s/common/var/lib/k8sd/state/control.socket"
 K8SD_PORT = 6400
 SUPPORTED_DATASTORES = ["dqlite", "etcd"]
 
+# Features
+SUPPORT_SNAP_INSTALLATION_OVERRIDE = False
+
 # Relations
 CLUSTER_RELATION = "cluster"
 CLUSTER_WORKER_RELATION = "k8s-cluster"

--- a/charms/worker/k8s/src/snap.py
+++ b/charms/worker/k8s/src/snap.py
@@ -279,10 +279,9 @@ def management(charm: K8sCharmProtocol) -> None:
         if isinstance(args, SnapFileArgument) and which.revision != "x1":
             snap_lib.install_local(**install_args)
         elif isinstance(args, SnapStoreArgument) and args.revision:
-            if which.revision != args.revision:
-                log.info("Ensuring %s snap revision=%s", args.name, args.revision)
-                which.ensure(**install_args)
-                which.hold()
+            log.info("Ensuring %s snap revision=%s", args.name, args.revision)
+            which.ensure(**install_args)
+            which.hold()
         elif isinstance(args, SnapStoreArgument):
             log.info("Ensuring %s snap channel=%s", args.name, args.channel)
             which.ensure(**install_args)

--- a/charms/worker/k8s/src/snap.py
+++ b/charms/worker/k8s/src/snap.py
@@ -19,6 +19,7 @@ from typing import List, Literal, Optional, Tuple, Union
 import charms.operator_libs_linux.v2.snap as snap_lib
 import ops
 import yaml
+from literals import SUPPORT_SNAP_INSTALLATION_OVERRIDE
 from protocols import K8sCharmProtocol
 from pydantic import BaseModel, Field, ValidationError, parse_obj_as, validator
 from typing_extensions import Annotated
@@ -184,6 +185,11 @@ def _select_snap_installation(charm: ops.CharmBase) -> Path:
     Raises:
         SnapError: when the management issue cannot be resolved
     """
+
+    if not SUPPORT_SNAP_INSTALLATION_OVERRIDE:
+        log.error("Unavailable feature: overriding 'snap-installation' resource.")
+        return _default_snap_installation()
+
     try:
         resource_path = charm.model.resources.fetch("snap-installation")
     except (ops.ModelError, NameError):

--- a/charms/worker/k8s/src/snap.py
+++ b/charms/worker/k8s/src/snap.py
@@ -185,7 +185,6 @@ def _select_snap_installation(charm: ops.CharmBase) -> Path:
     Raises:
         SnapError: when the management issue cannot be resolved
     """
-
     if not SUPPORT_SNAP_INSTALLATION_OVERRIDE:
         log.error("Unavailable feature: overriding 'snap-installation' resource.")
         return _default_snap_installation()

--- a/charms/worker/k8s/src/upgrade.py
+++ b/charms/worker/k8s/src/upgrade.py
@@ -19,11 +19,11 @@ from charms.data_platform_libs.v0.upgrade import (
 from charms.operator_libs_linux.v2.snap import SnapError
 from inspector import ClusterInspector
 from literals import (
-    CLUSTER_RELATION,
     K8S_CONTROL_PLANE_SERVICES,
     K8S_DQLITE_SERVICE,
     K8S_WORKER_SERVICES,
     SNAP_NAME,
+    UPGRADE_RELATION,
 )
 from protocols import K8sCharmProtocol
 from pydantic import BaseModel
@@ -226,7 +226,7 @@ class K8sUpgrade(DataUpgrade):
         Returns:
             A list of unit numbers to upgrade in order.
         """
-        relation = self.charm.model.get_relation(CLUSTER_RELATION)
+        relation = self.charm.model.get_relation(UPGRADE_RELATION)
         if not relation:
             return [int(self.charm.unit.name.split("/")[-1])]
 

--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,10 +4,8 @@
 amd64:
   - name: k8s
     install-type: store
-    classic: true
     revision: 1843
 arm64:
   - name: k8s
     install-type: store
-    classic: true
     revision: 1844

--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,10 +4,10 @@
 amd64:
   - name: k8s
     install-type: store
-    channel: edge
     classic: true
+    revision: 1843
 arm64:
   - name: k8s
     install-type: store
-    channel: edge
     classic: true
+    revision: 1844

--- a/charms/worker/k8s/tests/unit/test_snap.py
+++ b/charms/worker/k8s/tests/unit/test_snap.py
@@ -212,6 +212,7 @@ def _create_gzip_tar_string(file_data_dict):
     return gzip_buffer.getvalue()
 
 
+@mock.patch("snap.SUPPORT_SNAP_INSTALLATION_OVERRIDE", True)
 def test_resource_supplied_installation_by_channel(harness):
     """Test resource installs by store channel."""
     arch = snap._local_arch()
@@ -226,6 +227,7 @@ def test_resource_supplied_installation_by_channel(harness):
     assert args[0].install_type == "store"
 
 
+@mock.patch("snap.SUPPORT_SNAP_INSTALLATION_OVERRIDE", True)
 def test_resource_supplied_installation_by_filename(harness, resource_snap_installation):
     """Test resource installs by included filename."""
     arch = snap._local_arch()
@@ -251,6 +253,7 @@ def test_resource_supplied_installation_by_filename(harness, resource_snap_insta
     assert args[0].classic
 
 
+@mock.patch("snap.SUPPORT_SNAP_INSTALLATION_OVERRIDE", True)
 def test_resource_supplied_snap(harness, resource_snap_installation):
     """Test resource installs by snap only."""
     file_data = {"./k8s_xxxx.snap": ""}

--- a/charms/worker/k8s/tests/unit/test_snap.py
+++ b/charms/worker/k8s/tests/unit/test_snap.py
@@ -339,12 +339,7 @@ def test_management_installs_store_from_revision(cache, install_local, args, rev
     args.return_value = [snap.SnapStoreArgument(name="k8s", revision=123)]
     snap.management(harness.charm)
     install_local.assert_not_called()
-    if revision == "123":
-        k8s_snap.ensure.assert_not_called()
-    else:
-        k8s_snap.ensure.assert_called_once_with(
-            state=snap.snap_lib.SnapState.Present, revision="123"
-        )
+    k8s_snap.ensure.assert_called_once_with(state=snap.snap_lib.SnapState.Present, revision="123")
 
 
 @mock.patch("subprocess.check_output")

--- a/charms/worker/k8s/tests/unit/test_upgrade.py
+++ b/charms/worker/k8s/tests/unit/test_upgrade.py
@@ -11,7 +11,7 @@ from charms.data_platform_libs.v0.upgrade import ClusterNotReadyError
 from inspector import ClusterInspector
 from lightkube.models.core_v1 import Node
 from lightkube.models.meta_v1 import ObjectMeta
-from literals import CLUSTER_RELATION
+from literals import UPGRADE_RELATION
 from upgrade import K8sDependenciesModel, K8sUpgrade
 
 
@@ -103,7 +103,7 @@ class TestK8sUpgrade(unittest.TestCase):
         result = self.upgrade.build_upgrade_stack()
 
         self.assertEqual(result, [0])
-        self.charm.model.get_relation.assert_called_once_with(CLUSTER_RELATION)
+        self.charm.model.get_relation.assert_called_once_with(UPGRADE_RELATION)
 
     def test_build_upgrade_stack_with_relation(self):
         """Test build_upgrade_stack with cluster relation."""
@@ -119,7 +119,7 @@ class TestK8sUpgrade(unittest.TestCase):
         result = self.upgrade.build_upgrade_stack()
 
         self.assertEqual(sorted(result), [0, 1, 2])
-        self.charm.model.get_relation.assert_called_once_with(CLUSTER_RELATION)
+        self.charm.model.get_relation.assert_called_once_with(UPGRADE_RELATION)
 
     def test_verify_worker_versions_compatible(self):
         """Test _verify_worker_versions returns True when worker versions is compatible."""

--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -153,13 +153,13 @@ async def override_snap_on_k8s(kubernetes_cluster: model.Model, request):
 
     with override.open("rb") as obj:
         k8s.attach_resource("snap-installation", override, obj)
-        await kubernetes_cluster.wait_for_idle(status="active", timeout=1 * 60)
+        await kubernetes_cluster.wait_for_idle(status="active", timeout=5 * 60)
 
     yield k8s
 
     with revert.open("rb") as obj:
         k8s.attach_resource("snap-installation", revert, obj)
-        await kubernetes_cluster.wait_for_idle(status="active", timeout=1 * 60)
+        await kubernetes_cluster.wait_for_idle(status="active", timeout=5 * 60)
 
 
 async def test_verbose_config(kubernetes_cluster: model.Model):
@@ -181,6 +181,7 @@ async def test_verbose_config(kubernetes_cluster: model.Model):
 
 
 @pytest.mark.abort_on_fail
+@pytest.mark.skip("Currently broken feature")
 async def test_override_snap_resource(override_snap_on_k8s: application.Application):
     """Override snap resource."""
     k8s = override_snap_on_k8s

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -22,7 +22,7 @@ from .helpers import Bundle, get_leader, get_rsc
 # deploying charms from the edge channels, then upgrading them to the built charm.
 pytestmark = [
     pytest.mark.bundle(
-        file="test-bundle.yaml", apps_channel={"k8s": "edge", "k8s-worker": "edge"}
+        file="test-bundle.yaml", apps_channel={"k8s": "1.32/beta", "k8s-worker": "1.32/beta"}
     ),
 ]
 


### PR DESCRIPTION
### Overview
Pin the revisions based on `snapcraft status k8s`

```
1.32-classic  amd64   stable            v1.32.0       1843        -           -
                      candidate         v1.32.0       1843        -           -
                      beta              v1.32.0       1848        -           -
                      edge              v1.32.0       1848        -           -
              arm64   stable            v1.32.0       1844        -           -
                      candidate         v1.32.0       1849        -           -
                      beta              v1.32.0       1871        -           -
                      edge              v1.32.0       1871        -           -
```

### Details
* Quite a bit of work here to improve charm upgrades when no suitable source channels exist to upgrade from.
* Removal of the snap installation override feature b/c upgrading all control plane nodes simultaneously doesn't go well
* ensure we run the pre-upgrade-check on workers before upgrading