### PR TITLE
Bootstrap & join with a fixed containerd-base-dir

### DIFF
--- a/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
+++ b/charms/worker/k8s/lib/charms/k8s/v0/k8sd_api_manager.py
@@ -45,7 +45,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 
@@ -360,6 +360,10 @@ class BootstrapConfig(BaseModel):
         extra_node_kube_scheduler_args ([Dict[str,str]]): key-value service args
         extra_node_kube_proxy_args ([Dict[str,str]]): key-value service args
         extra_node_kubelet_args ([Dict[str,str]]): key-value service args
+        extra_node_containerd_args ([Dict[str,str]]): key-value service args
+        extra_node_k8s_dqlite_args ([Dict[str,str]]): key-value service args
+        extra_node_containerd_config ([Dict[str,Any]]): key-value config args
+        containerd_base_dir (str): The base directory for containerd.
     """
 
     cluster_config: Optional[UserFacingClusterConfig] = Field(default=None, alias="cluster-config")
@@ -390,6 +394,16 @@ class BootstrapConfig(BaseModel):
     extra_node_kubelet_args: Optional[Dict[str, str]] = Field(
         default=None, alias="extra-node-kubelet-args"
     )
+    extra_node_containerd_args: Optional[Dict[str, str]] = Field(
+        default=None, alias="extra-node-containerd-args"
+    )
+    extra_node_k8s_dqlite_args: Optional[Dict[str, str]] = Field(
+        default=None, alias="extra-node-k8s-dqlite-args"
+    )
+    extra_node_containerd_config: Optional[Dict[str, Any]] = Field(
+        default=None, alias="extra-node-containerd-config"
+    )
+    containerd_base_dir: Optional[str] = Field(default=None, alias="containerd-base-dir")
 
 
 class CreateClusterRequest(BaseModel):
@@ -426,6 +440,10 @@ class NodeJoinConfig(BaseModel, allow_population_by_field_name=True):
         kubelet_key (str): node's certificate key
         extra_node_kube_proxy_args (Dict[str, str]): key-value service args
         extra_node_kubelet_args (Dict[str, str]): key-value service args
+        extra_node_containerd_args ([Dict[str,str]]): key-value service args
+        extra_node_containerd_config ([Dict[str,Any]]): key-value config args
+        containerd_base_dir (str): The base directory for containerd.
+
     """
 
     kubelet_crt: Optional[str] = Field(default=None, alias="kubelet-crt")
@@ -436,6 +454,13 @@ class NodeJoinConfig(BaseModel, allow_population_by_field_name=True):
     extra_node_kubelet_args: Optional[Dict[str, str]] = Field(
         default=None, alias="extra-node-kubelet-args"
     )
+    extra_node_containerd_args: Optional[Dict[str, str]] = Field(
+        default=None, alias="extra-node-containerd-args"
+    )
+    extra_node_containerd_config: Optional[Dict[str, Any]] = Field(
+        default=None, alias="extra-node-containerd-config"
+    )
+    containerd_base_dir: Optional[str] = Field(default=None, alias="containerd-base-dir")
 
 
 class ControlPlaneNodeJoinConfig(NodeJoinConfig, allow_population_by_field_name=True):
@@ -450,6 +475,7 @@ class ControlPlaneNodeJoinConfig(NodeJoinConfig, allow_population_by_field_name=
         extra_node_kube_apiserver_args (Dict[str, str]): key-value service args
         extra_node_kube_controller_manager_args (Dict[str, str]): key-value service args
         extra_node_kube_scheduler_args (Dict[str, str]): key-value service args
+        extra_node_k8s_dqlite_args ([Dict[str,str]]): key-value service args
     """
 
     extra_sans: Optional[List[str]] = Field(default=None, alias="extra-sans")
@@ -466,6 +492,9 @@ class ControlPlaneNodeJoinConfig(NodeJoinConfig, allow_population_by_field_name=
     )
     extra_node_kube_scheduler_args: Optional[Dict[str, str]] = Field(
         default=None, alias="extra-node-kube-scheduler-args"
+    )
+    extra_node_k8s_dqlite_args: Optional[Dict[str, str]] = Field(
+        default=None, alias="extra-node-k8s-dqlite-args"
     )
 
 

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -69,6 +69,7 @@ from kube_control import configure as configure_kube_control
 from literals import (
     CLUSTER_RELATION,
     CLUSTER_WORKER_RELATION,
+    CONTAINERD_BASE_PATH,
     CONTAINERD_RELATION,
     COS_RELATION,
     COS_TOKENS_RELATION,
@@ -379,6 +380,7 @@ class K8sCharm(ops.CharmBase):
         bootstrap_config.pod_cidr = str(self.config["bootstrap-pod-cidr"])
         bootstrap_config.control_plane_taints = str(self.config["bootstrap-node-taints"]).split()
         bootstrap_config.extra_sans = self._get_extra_sans()
+        bootstrap_config.containerd_base_dir = str(CONTAINERD_BASE_PATH)
         cluster_name = self.get_cluster_name()
         config.extra_args.craft(self.config, bootstrap_config, cluster_name)
         return bootstrap_config

--- a/charms/worker/k8s/src/config/extra_args.py
+++ b/charms/worker/k8s/src/config/extra_args.py
@@ -12,6 +12,7 @@ from charms.k8s.v0.k8sd_api_manager import (
     ControlPlaneNodeJoinConfig,
     NodeJoinConfig,
 )
+from literals import CONTAINERD_BASE_PATH
 
 
 def _parse(config_data) -> Dict[str, str]:
@@ -70,6 +71,8 @@ def craft(
 
     cmd = _parse(src["kubelet-extra-args"])
     dest.extra_node_kubelet_args = cmd
+
+    dest.containerd_base_dir = str(CONTAINERD_BASE_PATH)
 
 
 def taint_worker(dest: NodeJoinConfig, taints: List[str]):

--- a/charms/worker/k8s/src/containerd.py
+++ b/charms/worker/k8s/src/containerd.py
@@ -23,9 +23,9 @@ from typing import Any, Dict, List, Optional
 import ops
 import pydantic
 import tomli_w
+from literals import HOSTSD_PATH
 
 log = logging.getLogger(__name__)
-HOSTSD_PATH = Path("/var/snap/k8s/common/etc/containerd/hosts.d/")
 
 
 def _ensure_file(

--- a/charms/worker/k8s/src/literals.py
+++ b/charms/worker/k8s/src/literals.py
@@ -12,7 +12,9 @@ SNAP_NAME = "k8s"
 VALID_LOG_LEVELS = ["info", "debug", "warning", "error", "critical"]
 
 # Charm
+CONTAINERD_BASE_PATH = Path("/etc/containerd")
 ETC_KUBERNETES = Path("/etc/kubernetes")
+HOSTSD_PATH = CONTAINERD_BASE_PATH / "hosts.d/"
 KUBECONFIG = Path.home() / ".kube/config"
 KUBECTL_PATH = Path("/snap/k8s/current/bin/kubectl")
 K8SD_SNAP_SOCKET = "/var/snap/k8s/common/var/lib/k8sd/state/control.socket"


### PR DESCRIPTION
Applicable spec: https://github.com/canonical/k8s-operator/issues/238

### Overview

Bootstraps, and joins nodes using the charm specified containerd base path

### Rationale

The snap config now allows the charm to specify a containerd-base-dir, Lets use that to make sure it doesn't move again.

### Library Changes

Updated the k8s library to accommodate new API config

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
