### PR TITLE
Require tf users to specify a charm channel

### DIFF
--- a/charms/worker/k8s/terraform/variables.tf
+++ b/charms/worker/k8s/terraform/variables.tf
@@ -21,7 +21,6 @@ variable "base" {
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
-  default     = "1.30/edge"
 }
 
 variable "config" {

--- a/charms/worker/terraform/variables.tf
+++ b/charms/worker/terraform/variables.tf
@@ -21,7 +21,6 @@ variable "base" {
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
-  default     = "1.30/edge"
 }
 
 variable "config" {


### PR DESCRIPTION
### Overview

Don't default the charm channels to `1.30/edge` -- a channel which may be or is already closed. 
Instead, require the tf user to specify a channel

### Overview
* removes the default channel from the tf modules