### PR TITLE
actions: Add Tiobe TICS cron job

### DIFF
--- a/.github/workflows/tiobe-tics-cron.yaml
+++ b/.github/workflows/tiobe-tics-cron.yaml
@@ -1,0 +1,66 @@
+name: TICS nightly quality scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 10 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  TICS:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # Latest branches
+          - { branch: main }
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - name: Checking out repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{matrix.branch}}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Go for Cobertura Coverage Converter
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Run Tests With Coverage
+        run: |
+          set -eux -o pipefail
+
+          # tox required for running the unit tests with coverage:
+          pip install tox
+          tox -e unit,coverage-xml
+
+          # TiCS expects the report to be under a "$(pwd)/cover" directory.
+          mkdir -p "$GITHUB_WORKSPACE/cover"
+          GENERATED_COVERAGE_XML="$GITHUB_WORKSPACE/charms/worker/k8s/coverage.xml"
+          mv "$GENERATED_COVERAGE_XML" cover/coverage.xml
+
+      - name: Run TICS
+        run: |
+          export TICSAUTHTOKEN=${{ secrets.TICSAUTHTOKEN }}
+
+          # NOTE(aznashwan): TiCS install script doesn't define defaults; cannot '-u'
+          set -ex -o pipefail
+
+          # Install the TiCS and staticcheck
+          go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
+          . <(curl --silent --show-error 'https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/')
+
+          TICSQServer -project k8s-operator -tmpdir /tmp/tics -branchdir "$GITHUB_WORKSPACE"

--- a/charms/worker/k8s/tox.ini
+++ b/charms/worker/k8s/tox.ini
@@ -43,6 +43,13 @@ deps =
 commands =
     coverage report
 
+[testenv:coverage-xml]
+description = Create test coverage XML report
+deps =
+    coverage[xml]
+commands =
+    coverage xml
+
 [testenv:update-dashboards]
 description = Run the Grafana dashboards update script
 deps = pyyaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ target-version = ["py38"]
 [tool.coverage.report]
 show_missing = true
 
+[tool.coverage.xml]
+output = "coverage.xml"
+
 # Linting tools configuration
 [tool.flake8]
 max-line-length = 99

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, unit, static, coverage-report
+envlist = lint, unit, static, coverage-report, coverage-xml
 
 [vars]
 lib_path = {toxinidir}/charms/worker/k8s/lib
@@ -76,6 +76,11 @@ commands =
 allowlist_externals = tox
 commands =
     tox -c {toxinidir}/charms/worker/k8s -e coverage-report
+
+[testenv:coverage-xml]
+allowlist_externals = tox
+commands =
+    tox -c {toxinidir}/charms/worker/k8s -e coverage-xml
 
 [testenv:static]
 description = Run static analysis tests


### PR DESCRIPTION
### Overview

<!-- A high level overview of the change -->
This commit adds:

- the necessary tox env targets for generating Cobertura coverage report XML format
- a GitHub Workflow which runs the unit tests with coverage enabled, and calls the `TICSServer` to upload the analysis results

### Rationale

<!-- The reason the change is needed -->
Workflow will allow for daily automatic code quality report uploads to Tiobe

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A

### Library Changes

<!-- Any changes to charm libraries -->
N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
