### PR TITLE
actions: Adds missing dependencies for TICS job

### DIFF
--- a/.github/workflows/tiobe-tics-cron.yaml
+++ b/.github/workflows/tiobe-tics-cron.yaml
@@ -44,7 +44,12 @@ jobs:
           set -eux -o pipefail
 
           # tox required for running the unit tests with coverage:
-          pip install tox
+          # pylint and flake8 are required by TICSQServer
+          # pylint requires the packages to be installed.
+          pip install tox pylint flake8
+          pip install -r charms/worker/k8s/requirements.txt
+          pip install -r test_requirements.txt
+
           tox -e unit,coverage-xml
 
           # TiCS expects the report to be under a "$(pwd)/cover" directory.


### PR DESCRIPTION
### Overview

TICS will try to use pylint and flake8 to analyze the project's code. We need to install them beforehand.

### Rationale

Errors are present in the TICS job:

```
2025-01-16T10:19:31.9465876Z [ERROR 5073] The following error(s) occurred while 'pylint' was running: '/opt/hostedtoolcache/Python/3.12.8/x64/bin/python: No module named pylint
2025-01-16T10:19:42.7100405Z [ERROR 5073] The following error(s) occurred while 'flake8' was running: '/opt/hostedtoolcache/Python/3.12.8/x64/bin/python: No module named flake8
```

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
