### PR TITLE
Upgrade tests must continue when k8s leader is ready for worker upgrades

### DIFF
--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -20,6 +20,7 @@ from tenacity import before_sleep_log, retry, stop_after_attempt, wait_fixed
 from .helpers import CHARMCRAFT_DIRS, Bundle, get_leader, get_rsc
 
 CHARM_UPGRADE_FROM = "1.32/beta"
+CONTROL_PLANE_APP = "k8s"
 log = logging.getLogger(__name__)
 
 
@@ -59,7 +60,7 @@ pytestmark = [
     pytest.mark.skipif(not_found, reason=not_found_reason),
     pytest.mark.bundle(
         file="test-bundle.yaml",
-        apps_channel={"k8s": CHARM_UPGRADE_FROM, "k8s-worker": CHARM_UPGRADE_FROM},
+        apps_channel={CONTROL_PLANE_APP: CHARM_UPGRADE_FROM, "k8s-worker": CHARM_UPGRADE_FROM},
     ),
 ]
 
@@ -78,19 +79,47 @@ async def test_upgrade(kubernetes_cluster: juju.model.Model, ops_test: OpsTest):
     }
     bundle, _ = await Bundle.create(ops_test)
     charms = await bundle.discover_charm_files(ops_test)
-    k8s: juju.application.Application = kubernetes_cluster.applications["k8s"]
+    k8s: juju.application.Application = kubernetes_cluster.applications[CONTROL_PLANE_APP]
 
     @retry(
         stop=stop_after_attempt(10),
         wait=wait_fixed(30),
         before_sleep=before_sleep_log(log, logging.WARNING),
     )
-    async def _wait_for_idle():
+    async def _wait_for_kube_system_pods():
         """Wait for the model to become idle."""
         kube_system_pods = await get_rsc(k8s.units[0], "pods", namespace="kube-system")
         assert all(
             p["status"]["phase"] == "Running" for p in kube_system_pods
         ), "Kube-system not yet ready"
+
+    @retry(
+        stop=stop_after_attempt(10),
+        wait=wait_fixed(30),
+        before_sleep=before_sleep_log(log, logging.WARNING),
+    )
+    async def _wait_for_upgrade_complete():
+        """Wait for the model to become idle."""
+        k8s_apps = {
+            k: v
+            for k, v in kubernetes_cluster.applications.items()
+            if v.startswith(CONTROL_PLANE_APP)
+        }
+        worker_apps = {k: v for k, v in k8s_apps.items() if k != CONTROL_PLANE_APP}
+        worker_count = sum(len(w.units) for w in worker_apps.values())
+        await kubernetes_cluster.wait_for_idle(apps=list(charms.keys()), timeout=60)
+
+        # Check unit status individually, as the k8s leader may be in a different state
+        leader_idx: int = await get_leader(k8s)
+        for name, app in k8s_apps.items():
+            for idx, unit in enumerate(app.units):
+                err = f"{unit.name} has not completed upgrade: {unit.agent_status_message}"
+                state, message = unit.agent_status, unit.agent_status_message
+                if name == CONTROL_PLANE_APP and idx == leader_idx and worker_count > 0:
+                    assert state in ["waiting", "active"], err
+                    assert message in [f"Waiting for {worker_count} Workers to upgrade", "Ready"], err
+                else:
+                    assert "active" == state, err
 
     async def _refresh(app_name: str):
         """Refresh the application.
@@ -110,12 +139,8 @@ async def test_upgrade(kubernetes_cluster: juju.model.Model, ops_test: OpsTest):
         assert action.status == "completed", with_fault
         assert action.results["return-code"] == 0, with_fault
         await app.refresh(path=charms[app_name].local_path, resources=local_resources)
-        await kubernetes_cluster.wait_for_idle(
-            apps=list(charms.keys()),
-            status="active",
-            timeout=30 * 60,
-        )
+        await _wait_for_upgrade_complete()
 
-    await _wait_for_idle()
+    await _wait_for_kube_system_pods()
     for app in charms:
         await _refresh(app)

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -103,7 +103,7 @@ async def test_upgrade(kubernetes_cluster: juju.model.Model, ops_test: OpsTest):
         k8s_apps = {
             k: v
             for k, v in kubernetes_cluster.applications.items()
-            if v.startswith(CONTROL_PLANE_APP)
+            if k.startswith(CONTROL_PLANE_APP)
         }
         worker_apps = {k: v for k, v in k8s_apps.items() if k != CONTROL_PLANE_APP}
         worker_count = sum(len(w.units) for w in worker_apps.values())

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -117,7 +117,10 @@ async def test_upgrade(kubernetes_cluster: juju.model.Model, ops_test: OpsTest):
                 state, message = unit.agent_status, unit.agent_status_message
                 if name == CONTROL_PLANE_APP and idx == leader_idx and worker_count > 0:
                     assert state in ["waiting", "active"], err
-                    assert message in [f"Waiting for {worker_count} Workers to upgrade", "Ready"], err
+                    assert message in [
+                        f"Waiting for {worker_count} Workers to upgrade",
+                        "Ready",
+                    ], err
                 else:
                     assert "active" == state, err
 


### PR DESCRIPTION
### Overview

Handle charm upgrades that might upgrade to a different snap version (ie 1.32.0 -> 1.32.1)

### Details
The k8s (control-plane) charm will upgrade first, and signal with a "waiting" status that the workers will need to be updated. 

if the snap revision changes but doesn't bump the patch version, the k8s units will all report "active/idle"
if the snap revision changes but the patch version is different, the leader k8s unit will report "waiting/idle" with a specific message. 

Either of these 2 cases is enough of a gate to allow for upgrades to continue