### PR TITLE
Support Multiple Builds-on

### DIFF
--- a/.charmcraft-channel
+++ b/.charmcraft-channel
@@ -1,1 +1,1 @@
-2.x/stable
+3.x/stable

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -51,7 +51,7 @@ jobs:
       charmcraft-channel: ${{ needs.charmcraft-channel.outputs.channel }}
       extra-arguments: >-
         ${{needs.extra-args.outputs.args}} -k test_${{ matrix.suite }}
-        ${{ matrix.arch.id == 'arm64' && ' --lxd-containers --series=focal' || '' }}
+        ${{ matrix.arch.id == 'arm64' && ' --lxd-containers --series=jammy' || '' }}
       juju-channel: 3/stable
       load-test-enabled: false
       provider: lxd

--- a/charms/worker/charmcraft.yaml
+++ b/charms/worker/charmcraft.yaml
@@ -37,9 +37,19 @@ bases:
     - name: ubuntu
       channel: "20.04"
       architectures: [amd64]
+  - build-on:
     - name: ubuntu
       channel: "22.04"
       architectures: [amd64]
+    run-on:
+    - name: ubuntu
+      channel: "22.04"
+      architectures: [amd64]
+  - build-on:
+    - name: ubuntu
+      channel: "24.04"
+      architectures: [amd64]
+    run-on:
     - name: ubuntu
       channel: "24.04"
       architectures: [amd64]
@@ -51,9 +61,19 @@ bases:
     - name: ubuntu
       channel: "20.04"
       architectures: [arm64]
+  - build-on:
     - name: ubuntu
       channel: "22.04"
       architectures: [arm64]
+    run-on:
+    - name: ubuntu
+      channel: "22.04"
+      architectures: [arm64]
+  - build-on:
+    - name: ubuntu
+      channel: "24.04"
+      architectures: [arm64]
+    run-on:
     - name: ubuntu
       channel: "24.04"
       architectures: [arm64]

--- a/charms/worker/charmcraft.yaml
+++ b/charms/worker/charmcraft.yaml
@@ -28,55 +28,39 @@ assumes:
   - juju >= 3.3
 
 type: charm
-bases:
-  - build-on:
-    - name: ubuntu
-      channel: "20.04"
-      architectures: [amd64]
-    run-on:
-    - name: ubuntu
-      channel: "20.04"
-      architectures: [amd64]
-  - build-on:
-    - name: ubuntu
-      channel: "22.04"
-      architectures: [amd64]
-    run-on:
-    - name: ubuntu
-      channel: "22.04"
-      architectures: [amd64]
-  - build-on:
-    - name: ubuntu
-      channel: "24.04"
-      architectures: [amd64]
-    run-on:
-    - name: ubuntu
-      channel: "24.04"
-      architectures: [amd64]
-  - build-on:
-    - name: ubuntu
-      channel: "20.04"
-      architectures: [arm64]
-    run-on:
-    - name: ubuntu
-      channel: "20.04"
-      architectures: [arm64]
-  - build-on:
-    - name: ubuntu
-      channel: "22.04"
-      architectures: [arm64]
-    run-on:
-    - name: ubuntu
-      channel: "22.04"
-      architectures: [arm64]
-  - build-on:
-    - name: ubuntu
-      channel: "24.04"
-      architectures: [arm64]
-    run-on:
-    - name: ubuntu
-      channel: "24.04"
-      architectures: [arm64]
+platforms:
+  ubuntu-20.04-amd64:
+    build-on:
+      - ubuntu@20.04:amd64
+    build-for:
+      - ubuntu@20.04:amd64
+  ubuntu-20.04-arm64:
+    build-on:
+      - ubuntu@20.04:arm64
+    build-for:
+      - ubuntu@20.04:arm64
+
+  ubuntu-22.04-amd64:
+    build-on:
+      - ubuntu@22.04:amd64
+    build-for:
+      - ubuntu@22.04:amd64
+  ubuntu-22.04-arm64:
+    build-on:
+      - ubuntu@22.04:arm64
+    build-for:
+      - ubuntu@22.04:arm64
+
+  ubuntu-24.04-amd64:
+    build-on:
+      - ubuntu@24.04:amd64
+    build-for:
+      - ubuntu@24.04:amd64
+  ubuntu-24.04-arm64:
+    build-on:
+      - ubuntu@24.04:arm64
+    build-for:
+      - ubuntu@24.04:arm64
 
 config:
   options:

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -37,55 +37,39 @@ assumes:
   - juju >= 3.3
 
 type: charm
-bases:
-  - build-on:
-    - name: ubuntu
-      channel: "20.04"
-      architectures: [amd64]
-    run-on:
-    - name: ubuntu
-      channel: "20.04"
-      architectures: [amd64]
-  - build-on:
-    - name: ubuntu
-      channel: "22.04"
-      architectures: [amd64]
-    run-on:
-    - name: ubuntu
-      channel: "22.04"
-      architectures: [amd64]
-  - build-on:
-    - name: ubuntu
-      channel: "24.04"
-      architectures: [amd64]
-    run-on:
-    - name: ubuntu
-      channel: "24.04"
-      architectures: [amd64]
-  - build-on:
-    - name: ubuntu
-      channel: "20.04"
-      architectures: [arm64]
-    run-on:
-    - name: ubuntu
-      channel: "20.04"
-      architectures: [arm64]
-  - build-on:
-    - name: ubuntu
-      channel: "22.04"
-      architectures: [arm64]
-    run-on:
-    - name: ubuntu
-      channel: "22.04"
-      architectures: [arm64]
-  - build-on:
-    - name: ubuntu
-      channel: "24.04"
-      architectures: [arm64]
-    run-on:
-    - name: ubuntu
-      channel: "24.04"
-      architectures: [arm64]
+platforms:
+  ubuntu-20.04-amd64:
+    build-on:
+      - ubuntu@20.04:amd64
+    build-for:
+      - ubuntu@20.04:amd64
+  ubuntu-20.04-arm64:
+    build-on:
+      - ubuntu@20.04:arm64
+    build-for:
+      - ubuntu@20.04:arm64
+
+  ubuntu-22.04-amd64:
+    build-on:
+      - ubuntu@22.04:amd64
+    build-for:
+      - ubuntu@22.04:amd64
+  ubuntu-22.04-arm64:
+    build-on:
+      - ubuntu@22.04:arm64
+    build-for:
+      - ubuntu@22.04:arm64
+
+  ubuntu-24.04-amd64:
+    build-on:
+      - ubuntu@24.04:amd64
+    build-for:
+      - ubuntu@24.04:amd64
+  ubuntu-24.04-arm64:
+    build-on:
+      - ubuntu@24.04:arm64
+    build-for:
+      - ubuntu@24.04:arm64
 config:
   options:
     cluster-annotations:

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -46,9 +46,19 @@ bases:
     - name: ubuntu
       channel: "20.04"
       architectures: [amd64]
+  - build-on:
     - name: ubuntu
       channel: "22.04"
       architectures: [amd64]
+    run-on:
+    - name: ubuntu
+      channel: "22.04"
+      architectures: [amd64]
+  - build-on:
+    - name: ubuntu
+      channel: "24.04"
+      architectures: [amd64]
+    run-on:
     - name: ubuntu
       channel: "24.04"
       architectures: [amd64]
@@ -60,9 +70,19 @@ bases:
     - name: ubuntu
       channel: "20.04"
       architectures: [arm64]
+  - build-on:
     - name: ubuntu
       channel: "22.04"
       architectures: [arm64]
+    run-on:
+    - name: ubuntu
+      channel: "22.04"
+      architectures: [arm64]
+  - build-on:
+    - name: ubuntu
+      channel: "24.04"
+      architectures: [arm64]
+    run-on:
     - name: ubuntu
       channel: "24.04"
       architectures: [arm64]

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, Union
 import juju.application
 import juju.model
 import juju.unit
+import juju.utils
 import yaml
 from juju.url import URL
 from pytest_operator.plugin import OpsTest
@@ -436,21 +437,6 @@ class Bundle:
         """
         return any(app.get("trust", False) for app in self.applications.values())
 
-    def get_base_by_series(self) -> str:
-        """Get the base release for the series.
-
-        Returns:
-            str: base release for the series
-        """
-        if not self.series:
-            return "22.04"
-
-        return {
-            "focal": "20.04",
-            "jammy": "22.04",
-            "noble": "24.04",
-        }.get(self.series, "22.04")
-
     async def discover_charm_files(self, ops_test: OpsTest) -> Dict[str, Charm]:
         """Discover charm files for the applications in the bundle.
 
@@ -463,7 +449,9 @@ class Bundle:
         app_to_charm = {}
         for app in self.applications.values():
             if charm := Charm.find(app["charm"]):
-                await charm.resolve(ops_test, self.arch, self.get_base_by_series())
+                await charm.resolve(
+                    ops_test, self.arch, juju.utils.get_series_version(self.series)
+                )
                 app_to_charm[charm.name] = charm
         return app_to_charm
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -450,7 +450,7 @@ class Bundle:
         for app in self.applications.values():
             if charm := Charm.find(app["charm"]):
                 await charm.resolve(
-                    ops_test, self.arch, juju.utils.get_series_version(self.series)
+                    ops_test, self.arch, juju.utils.get_series_version(self.series or "jammy")
                 )
                 app_to_charm[charm.name] = charm
         return app_to_charm

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -392,7 +392,9 @@ class Bundle:
         arch = await cloud_arch(ops_test)
         assert arch, "Architecture must be known before customizing the bundle"
 
-        bundle = cls(path=path, arch=arch)
+        series = ops_test.request.config.getoption("--series")
+
+        bundle = cls(path=path, arch=arch, series=series)
         assert not all(
             _ in kwargs for _ in ("apps_local", "apps_channel")
         ), "Cannot use both apps_local and apps_channel"


### PR DESCRIPTION
## Overview
Upgrade the charmcraft.yaml to use `charmcraft: 3.x`, including platform configurations to target multiple bases and architectures.
## Rationale
To accomodate new binary dependencies like `cryptography` and `pydantic-core`, we are switching over `charmcraft 3.x`. This change allows us to build charms for each architecture/release for both the `k8s` and `k8s-worker` charms.