### PR TITLE
Expose k8s application config via terraform

### DIFF
--- a/charms/worker/k8s/terraform/main.tf
+++ b/charms/worker/k8s/terraform/main.tf
@@ -12,6 +12,12 @@ resource "juju_application" "k8s" {
     base     = var.base
   }
 
+  expose {
+    cidrs     = var.expose.cidrs
+    endpoints = var.expose.endpoints
+    spaces    = var.expose.spaces
+  }
+
   config      = var.config
   constraints = var.constraints
   units       = var.units

--- a/charms/worker/k8s/terraform/variables.tf
+++ b/charms/worker/k8s/terraform/variables.tf
@@ -57,3 +57,13 @@ variable "units" {
   type        = number
   default     = 1
 }
+
+variable "expose" {
+  description = "How to expose the Kubernetes API endpoint"
+  type        = map(string)
+  default     = {
+    cidrs      = "0.0.0.0/32"
+    endpoints  = null
+    spaces     = null
+  }
+}


### PR DESCRIPTION
### Overview

The k8s api endpoints are exposed via firewall rules on some substrates through `k8s expose`.  This makes the default to expose the endpoint everywhere by default. 


### Details
The expose block can be configured according to the [juju provider TF docs](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application#nestedblock--expose)