### PR TITLE
chore: pin `operator-workflows` version

### DIFF
--- a/.github/workflows/auto-update-libs-k8s-worker.yaml
+++ b/.github/workflows/auto-update-libs-k8s-worker.yaml
@@ -15,7 +15,7 @@ jobs:
       run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
   auto-update-libs:
     needs: [charmcraft-channel]
-    uses: canonical/operator-workflows/.github/workflows/auto_update_charm_libs.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/auto_update_charm_libs.yaml@81409b668682e5b66e1a714e582d9aac850a32e8
     secrets: inherit
     with:
       working-directory:  ./charms/worker/k8s

--- a/.github/workflows/bot_pr_approval.yaml
+++ b/.github/workflows/bot_pr_approval.yaml
@@ -5,5 +5,5 @@ on:
 
 jobs:
   bot_pr_approval:
-    uses: canonical/operator-workflows/.github/workflows/bot_pr_approval.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/bot_pr_approval.yaml@81409b668682e5b66e1a714e582d9aac850a32e8
     secrets: inherit

--- a/.github/workflows/charm-analysis.yaml
+++ b/.github/workflows/charm-analysis.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   unit-tests:
-    uses: canonical/operator-workflows/.github/workflows/test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/test.yaml@81409b668682e5b66e1a714e582d9aac850a32e8
     secrets: inherit
     strategy:
       fail-fast: false

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   comment-on-pr:
-    uses: canonical/operator-workflows/.github/workflows/comment.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/comment.yaml@81409b668682e5b66e1a714e582d9aac850a32e8
     secrets: inherit

--- a/.github/workflows/comment_contributing.yaml
+++ b/.github/workflows/comment_contributing.yaml
@@ -9,5 +9,5 @@ on:
 
 jobs:
   comment-on-pr:
-    uses: canonical/operator-workflows/.github/workflows/comment_contributing.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/comment_contributing.yaml@81409b668682e5b66e1a714e582d9aac850a32e8
     secrets: inherit

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -33,7 +33,7 @@ jobs:
       run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
 
   integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@81409b668682e5b66e1a714e582d9aac850a32e8
     needs: [charmcraft-channel, extra-args]
     secrets: inherit
     strategy:

--- a/.github/workflows/load_test.yaml
+++ b/.github/workflows/load_test.yaml
@@ -15,7 +15,7 @@ jobs:
       run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
 
   load-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@81409b668682e5b66e1a714e582d9aac850a32e8
     needs: [charmcraft-channel]
     secrets: inherit
     with:

--- a/.github/workflows/promote-charms.yaml
+++ b/.github/workflows/promote-charms.yaml
@@ -72,7 +72,7 @@ jobs:
         arch:
         - amd64
         - arm64
-    uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@81409b668682e5b66e1a714e582d9aac850a32e8
     with:
       base-architecture: ${{ matrix.arch }}
       charm-directory: ${{ matrix.charm.path }}

--- a/.github/workflows/publish-charms.yaml
+++ b/.github/workflows/publish-charms.yaml
@@ -41,7 +41,7 @@ jobs:
         run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
   publish-to-edge:
     needs: [configure-channel, charmcraft-channel]
-    uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@81409b668682e5b66e1a714e582d9aac850a32e8
     strategy:
       matrix:
         charm:


### PR DESCRIPTION
## Overview
Pin the `operator-workflows` to the latest SHA instead of main.
