### PR TITLE
Dont bootstrap with containerd_base

### DIFF
--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -73,7 +73,6 @@ from literals import (
     APISERVER_PORT,
     CLUSTER_RELATION,
     CLUSTER_WORKER_RELATION,
-    CONTAINERD_BASE_PATH,
     CONTAINERD_HTTP_PROXY,
     CONTAINERD_RELATION,
     CONTAINERD_SERVICE_NAME,
@@ -420,7 +419,6 @@ class K8sCharm(ops.CharmBase):
         bootstrap_config.pod_cidr = str(self.config["bootstrap-pod-cidr"])
         bootstrap_config.control_plane_taints = str(self.config["bootstrap-node-taints"]).split()
         bootstrap_config.extra_sans = self._get_extra_sans()
-        bootstrap_config.containerd_base_dir = str(CONTAINERD_BASE_PATH)
         cluster_name = self.get_cluster_name()
         config.extra_args.craft(self.config, bootstrap_config, cluster_name)
         return bootstrap_config


### PR DESCRIPTION
When you bootstrap with a `containerd_base_path`, this is not the actual path used for containerd. 

the [k8s snap appends this path to another path](https://github.com/canonical/k8s-snap/blob/ea5f8853818984a7a0d766155b744e846d704653/src/k8s/pkg/k8sd/api/cluster_bootstrap.go#L45-L48), so the charms are still  not writing configs where you'd expect them to.

If we don't bootstrap with it -- we'll get the correct path by "luck" rather than being specific.  Until the snap bug is worked out, this is a workaround