### PR TITLE
Streamline storage tests by using k8s python client

### DIFF
--- a/tests/integration/test_ceph.py
+++ b/tests/integration/test_ceph.py
@@ -8,6 +8,7 @@
 
 import pytest
 from juju import model
+from kubernetes.client import ApiClient
 
 from . import storage
 
@@ -17,7 +18,7 @@ pytestmark = [pytest.mark.bundle(file="test-bundle-ceph.yaml", apps_local=["k8s"
 
 
 @pytest.mark.abort_on_fail
-async def test_ceph_sc(kubernetes_cluster: model.Model):
+async def test_ceph_sc(kubernetes_cluster: model.Model, api_client: ApiClient):
     """Test that a ceph storage class is available and validate pv attachments."""
     manifests = storage.StorageProviderManifests(
         "ceph-xfs-pvc.yaml", "pv-writer-pod.yaml", "pv-reader-pod.yaml"
@@ -25,4 +26,4 @@ async def test_ceph_sc(kubernetes_cluster: model.Model):
     definition = storage.StorageProviderTestDefinition(
         "ceph", "ceph-xfs", "rbd.csi.ceph.com", kubernetes_cluster, manifests
     )
-    await storage.exec_storage_class(definition)
+    await storage.exec_storage_class(definition, api_client)

--- a/tests/integration/test_openstack.py
+++ b/tests/integration/test_openstack.py
@@ -44,7 +44,7 @@ async def test_provider_ids(api_client: ApiClient):
         assert node.spec.provider_id.startswith(f"{CLOUD_TYPE}://")
 
 
-async def test_cinder_pv(kubernetes_cluster: juju.model.Model):
+async def test_cinder_pv(kubernetes_cluster: juju.model.Model, api_client: ApiClient):
     """Test that a cinder storage class is available and validate pv attachments."""
     manifests = storage.StorageProviderManifests(
         "cinder-pvc.yaml", "pv-writer-pod.yaml", "pv-reader-pod.yaml"
@@ -52,4 +52,4 @@ async def test_cinder_pv(kubernetes_cluster: juju.model.Model):
     definition = storage.StorageProviderTestDefinition(
         "cinder", STORAGE_CLASS_NAME, "cinder.csi.openstack.org", kubernetes_cluster, manifests
     )
-    await storage.exec_storage_class(definition)
+    await storage.exec_storage_class(definition, api_client)


### PR DESCRIPTION
### Overview
* Replace copying manifest files into k8s cp container to run, with using the kubernetes client api


### Details
* Hopefully improves tests failures occurring with ceph tests