### PR TITLE
Manually set from 1.32-classic/stable

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -2,12 +2,10 @@
 # See LICENSE file for licensing details.
 
 amd64:
-  - name: k8s
-    install-type: store
-    classic: true
-    channel: latest/edge
+- name: k8s
+  install-type: store
+  revision: 2187
 arm64:
-  - name: k8s
-    install-type: store
-    classic: true
-    channel: latest/edge
+- name: k8s
+  install-type: store
+  revision: 2196


### PR DESCRIPTION
* Set the snap revisions to be fixed which was over-written in #286 
```
1.32-classic  amd64   stable                              v1.32.1          2187        -           -
                      candidate                           v1.32.1          2187        -           -
                      beta                                v1.32.1          2187        -           -
                      edge                                v1.32.1          2187        -           -
              arm64   stable                              v1.32.1          2196        -           -
                      candidate                           v1.32.1          2196        -           -
                      beta                                v1.32.1          2196        -           -
                      edge                                v1.32.1          2196        -           -
```