### PR TITLE
Build per arch, test per module

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -39,19 +39,26 @@ jobs:
     strategy:
       matrix:
         arch:
-        - {id: amd64, builder-label: ubuntu-22.04, tester-arch: AMD64, tester-size: xlarge}  # built on azure, test on self-hosted
-        - {id: arm64, builder-label: ARM64,        tester-arch: ARM64, tester-size: large }  # built and test on on self-hosted
-        suite: [k8s, etcd, ceph, upgrade]
-        exclude:
-        - {arch: {id: arm64}, suite: ceph}
-        - {arch: {id: arm64}, suite: upgrade}
+        # built on azure, test on self-hosted
+        - id: amd64
+          builder-label: ubuntu-22.04
+          tester-arch: AMD64
+          tester-size: xlarge
+          modules: '["test_k8s", "test_etcd", "test_ceph", "test_upgrade"]'
+        # built and test on on self-hosted
+        - id: arm64
+          builder-label: ARM64
+          tester-arch: ARM64
+          tester-size: large
+          modules: '["test_k8s", "test_etcd"]'
     with:
-      identifier: ${{ matrix.arch.id }}-${{ matrix.suite }}
+      identifier: ${{ matrix.arch.id }}
       builder-runner-label: ${{ matrix.arch.builder-label }}
       charmcraft-channel: ${{ needs.charmcraft-channel.outputs.channel }}
       extra-arguments: >-
-        ${{needs.extra-args.outputs.args}} -k test_${{ matrix.suite }}
+        ${{needs.extra-args.outputs.args}}
         ${{ matrix.arch.id == 'arm64' && ' --lxd-containers --series=jammy' || '' }}
+      modules: ${{ matrix.arch.modules }}
       juju-channel: 3/stable
       load-test-enabled: false
       provider: lxd
@@ -59,7 +66,7 @@ jobs:
       self-hosted-runner-arch: ${{ matrix.arch.tester-arch }}
       self-hosted-runner-label: ${{ matrix.arch.tester-size }}
       test-timeout: 120
-      test-tox-env: integration-${{ matrix.suite }}
+      test-tox-env: integration
       trivy-fs-enabled: false
       trivy-image-config: "trivy.yaml"
       tmate-debug: true

--- a/.github/workflows/publish-charms.yaml
+++ b/.github/workflows/publish-charms.yaml
@@ -56,4 +56,4 @@ jobs:
       working-directory: ${{ matrix.charm.path }}
       charmcraft-channel: ${{ needs.charmcraft-channel.outputs.channel }}
       tag-prefix: ${{ matrix.charm.tagPrefix }}
-      identifier: ${{matrix.arch}}-k8s
+      identifier: ${{matrix.arch}}

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -28,40 +28,10 @@ from time import sleep
 from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
 
-import charms.contextual_status as status
-import charms.operator_libs_linux.v2.snap as snap_lib
 import config.extra_args
 import containerd
 import ops
 import yaml
-from charms.contextual_status import ReconcilerError, WaitingStatus, on_error
-from charms.grafana_agent.v0.cos_agent import COSAgentProvider
-from charms.interface_external_cloud_provider import ExternalCloudProvider
-from charms.k8s.v0.k8sd_api_manager import (
-    BootstrapConfig,
-    ControlPlaneNodeJoinConfig,
-    CreateClusterRequest,
-    DNSConfig,
-    GatewayConfig,
-    IngressConfig,
-    InvalidResponseError,
-    JoinClusterRequest,
-    K8sdAPIManager,
-    K8sdConnectionError,
-    LoadBalancerConfig,
-    LocalStorageConfig,
-    MetricsServerConfig,
-    NetworkConfig,
-    NodeJoinConfig,
-    UnixSocketConnectionFactory,
-    UpdateClusterConfigRequest,
-    UserFacingClusterConfig,
-    UserFacingDatastoreConfig,
-)
-from charms.kubernetes_libs.v0.etcd import EtcdReactiveRequires
-from charms.node_base import LabelMaker
-from charms.operator_libs_linux.v1 import systemd
-from charms.reconciler import Reconciler
 from cloud_integration import CloudIntegration
 from cos_integration import COSIntegration
 from endpoints import build_url
@@ -101,6 +71,37 @@ from snap import version as snap_version
 from token_distributor import ClusterTokenType, TokenCollector, TokenDistributor, TokenStrategy
 from typing_extensions import Literal
 from upgrade import K8sDependenciesModel, K8sUpgrade
+
+import charms.contextual_status as status
+import charms.operator_libs_linux.v2.snap as snap_lib
+from charms.contextual_status import ReconcilerError, WaitingStatus, on_error
+from charms.grafana_agent.v0.cos_agent import COSAgentProvider
+from charms.interface_external_cloud_provider import ExternalCloudProvider
+from charms.k8s.v0.k8sd_api_manager import (
+    BootstrapConfig,
+    ControlPlaneNodeJoinConfig,
+    CreateClusterRequest,
+    DNSConfig,
+    GatewayConfig,
+    IngressConfig,
+    InvalidResponseError,
+    JoinClusterRequest,
+    K8sdAPIManager,
+    K8sdConnectionError,
+    LoadBalancerConfig,
+    LocalStorageConfig,
+    MetricsServerConfig,
+    NetworkConfig,
+    NodeJoinConfig,
+    UnixSocketConnectionFactory,
+    UpdateClusterConfigRequest,
+    UserFacingClusterConfig,
+    UserFacingDatastoreConfig,
+)
+from charms.kubernetes_libs.v0.etcd import EtcdReactiveRequires
+from charms.node_base import LabelMaker
+from charms.operator_libs_linux.v1 import systemd
+from charms.reconciler import Reconciler
 
 # Log messages can be retrieved using juju debug-log
 log = logging.getLogger(__name__)

--- a/charms/worker/k8s/src/cloud_integration.py
+++ b/charms/worker/k8s/src/cloud_integration.py
@@ -6,12 +6,13 @@
 import logging
 from typing import Mapping, Optional, Union
 
-import charms.contextual_status as status
 import ops
 from ops.interface_aws.requires import AWSIntegrationRequires
 from ops.interface_azure.requires import AzureIntegrationRequires
 from ops.interface_gcp.requires import GCPIntegrationRequires
 from protocols import K8sCharmProtocol
+
+import charms.contextual_status as status
 
 log = logging.getLogger(__name__)
 

--- a/charms/worker/k8s/src/config/extra_args.py
+++ b/charms/worker/k8s/src/config/extra_args.py
@@ -7,12 +7,13 @@
 from typing import Dict, List, Union
 
 import ops
+from literals import CONTAINERD_BASE_PATH
+
 from charms.k8s.v0.k8sd_api_manager import (
     BootstrapConfig,
     ControlPlaneNodeJoinConfig,
     NodeJoinConfig,
 )
-from literals import CONTAINERD_BASE_PATH
 
 
 def _parse(config_data) -> Dict[str, str]:

--- a/charms/worker/k8s/src/events/update_status.py
+++ b/charms/worker/k8s/src/events/update_status.py
@@ -11,13 +11,14 @@ This handler is responsible for updating the unit's workload version and status
 import logging
 from typing import Optional
 
-import charms.contextual_status as status
 import ops
 import reschedule
 from inspector import ClusterInspector
 from protocols import K8sCharmProtocol
 from snap import version as snap_version
 from upgrade import K8sUpgrade
+
+import charms.contextual_status as status
 
 # Log messages can be retrieved using juju debug-log
 log = logging.getLogger(__name__)

--- a/charms/worker/k8s/src/kube_control.py
+++ b/charms/worker/k8s/src/kube_control.py
@@ -5,12 +5,13 @@
 import logging
 from base64 import b64decode
 
-import charms.contextual_status as status
 import ops
 import yaml
-from charms.contextual_status import BlockedStatus, on_error
 from literals import APISERVER_PORT
 from protocols import K8sCharmProtocol
+
+import charms.contextual_status as status
+from charms.contextual_status import BlockedStatus, on_error
 
 # Log messages can be retrieved using juju debug-log
 log = logging.getLogger(__name__)

--- a/charms/worker/k8s/src/protocols.py
+++ b/charms/worker/k8s/src/protocols.py
@@ -6,11 +6,12 @@
 from typing import Dict, List
 
 import ops
+from inspector import ClusterInspector
+from ops.interface_kube_control import KubeControlProvides
+
 from charms.interface_external_cloud_provider import ExternalCloudProvider
 from charms.k8s.v0.k8sd_api_manager import K8sdAPIManager
 from charms.reconciler import Reconciler
-from inspector import ClusterInspector
-from ops.interface_kube_control import KubeControlProvides
 
 
 class K8sCharmProtocol(ops.CharmBase):

--- a/charms/worker/k8s/src/reschedule.py
+++ b/charms/worker/k8s/src/reschedule.py
@@ -4,6 +4,7 @@
 """EventTimer for scheduling dispatch of juju event on regular intervals."""
 
 import logging
+import os
 import subprocess
 from datetime import timedelta
 from pathlib import Path
@@ -14,31 +15,10 @@ import ops
 log = logging.getLogger(__name__)
 Period = timedelta  # Type aliasing
 BIN_SYSTEMCTL = "/usr/bin/systemctl"
-SYSTEMD_SERVICE = """
-[Unit]
-Description=Dispatch the {event} event on {app}/{unit_num}
 
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/timeout {timeout} /usr/bin/bash -c '/usr/bin/juju-exec "{app}/{unit_num}" "JUJU_DISPATCH_PATH={event} ./dispatch"'
-
-[Install]
-WantedBy=multi-user.target
-"""
-SYSTEMD_TIMER = """
-[Unit]
-Description=Timer to dispatch {event} event periodically
-Requires={app}.{event}.service
-
-[Timer]
-Unit={app}.{event}.service
-OnUnitInactiveSec={interval}s
-RandomizedDelaySec={random_delay}s
-
-[Install]
-WantedBy=timers.target
-"""
-
+CHARM_DIR = Path(os.environ.get("CHARM_DIR") or Path(__file__).parent.parent)
+SYSTEMD_SERVICE = (CHARM_DIR / "templates/reschedule.service").read_text()
+SYSTEMD_TIMER = (CHARM_DIR / "templates/reschedule.timer").read_text()
 
 def _execute_command(args: Sequence[str], check_exit: bool = True) -> int:
     """Subprocess run wrapper.

--- a/charms/worker/k8s/src/snap.py
+++ b/charms/worker/k8s/src/snap.py
@@ -16,13 +16,14 @@ import tarfile
 from pathlib import Path
 from typing import List, Literal, Optional, Tuple, Union
 
-import charms.operator_libs_linux.v2.snap as snap_lib
 import ops
 import yaml
 from literals import SUPPORT_SNAP_INSTALLATION_OVERRIDE
 from protocols import K8sCharmProtocol
 from pydantic import BaseModel, Field, ValidationError, parse_obj_as, validator
 from typing_extensions import Annotated
+
+import charms.operator_libs_linux.v2.snap as snap_lib
 
 # Log messages can be retrieved using juju debug-log
 log = logging.getLogger(__name__)

--- a/charms/worker/k8s/src/token_distributor.py
+++ b/charms/worker/k8s/src/token_distributor.py
@@ -9,8 +9,11 @@ import re
 from enum import Enum, auto
 from typing import Dict, Generator, Optional, Union
 
-import charms.contextual_status as status
 import ops
+from protocols import K8sCharmProtocol
+from pydantic import SecretStr
+
+import charms.contextual_status as status
 from charms.contextual_status import ReconcilerError
 from charms.k8s.v0.k8sd_api_manager import (
     ErrorCodes,
@@ -18,8 +21,6 @@ from charms.k8s.v0.k8sd_api_manager import (
     K8sdAPIManager,
     K8sdConnectionError,
 )
-from protocols import K8sCharmProtocol
-from pydantic import SecretStr
 
 log = logging.getLogger(__name__)
 

--- a/charms/worker/k8s/src/upgrade.py
+++ b/charms/worker/k8s/src/upgrade.py
@@ -6,17 +6,8 @@
 import logging
 from typing import List, Union
 
-import charms.contextual_status as status
 import ops
 import reschedule
-from charms.data_platform_libs.v0.upgrade import (
-    ClusterNotReadyError,
-    DataUpgrade,
-    DependencyModel,
-    UpgradeGrantedEvent,
-    verify_requirements,
-)
-from charms.operator_libs_linux.v2.snap import SnapError
 from inspector import ClusterInspector
 from literals import (
     K8S_CONTROL_PLANE_SERVICES,
@@ -30,6 +21,16 @@ from pydantic import BaseModel
 from snap import management as snap_management
 from snap import start, stop
 from snap import version as snap_version
+
+import charms.contextual_status as status
+from charms.data_platform_libs.v0.upgrade import (
+    ClusterNotReadyError,
+    DataUpgrade,
+    DependencyModel,
+    UpgradeGrantedEvent,
+    verify_requirements,
+)
+from charms.operator_libs_linux.v2.snap import SnapError
 
 log = logging.getLogger(__name__)
 
@@ -106,9 +107,10 @@ class K8sUpgrade(DataUpgrade):
         unready_nodes = nodes or []
 
         if unready_nodes:
+            joined = ', '.join([node.metadata.name for node in unready_nodes])
             raise ClusterNotReadyError(
                 message="Cluster is not ready for an upgrade",
-                cause=f"Nodes not ready: {', '.join(node.metadata.name for node in unready_nodes)}",
+                cause=f"Nodes not ready: {joined}",
                 resolution="""Node(s) may be in a bad state.
                     Please check the node(s) for more information.""",
             )

--- a/charms/worker/k8s/templates/reschedule.service
+++ b/charms/worker/k8s/templates/reschedule.service
@@ -1,0 +1,12 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+[Unit]
+Description=Dispatch the {event} event on {app}/{unit_num}
+ 
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/timeout {timeout} /usr/bin/bash -c '/usr/bin/juju-exec "{app}/{unit_num}" "JUJU_DISPATCH_PATH={event} ./dispatch"'
+ 
+[Install]
+WantedBy=multi-user.target

--- a/charms/worker/k8s/templates/reschedule.timer
+++ b/charms/worker/k8s/templates/reschedule.timer
@@ -1,0 +1,14 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+[Unit]
+Description=Timer to dispatch {event} event periodically
+Requires={app}.{event}.service
+ 
+[Timer]
+Unit={app}.{event}.service
+OnUnitInactiveSec={interval}s
+RandomizedDelaySec={random_delay}s
+ 
+[Install]
+WantedBy=timers.target

--- a/charms/worker/k8s/tests/unit/test_base.py
+++ b/charms/worker/k8s/tests/unit/test_base.py
@@ -15,6 +15,7 @@ import ops
 import ops.testing
 import pytest
 from charm import K8sCharm
+
 from charms.k8s.v0.k8sd_api_manager import BootstrapConfig, UpdateClusterConfigRequest
 
 

--- a/charms/worker/k8s/tests/unit/test_k8sd_api_manager.py
+++ b/charms/worker/k8s/tests/unit/test_k8sd_api_manager.py
@@ -140,7 +140,7 @@ class TestK8sdAPIManager(unittest.TestCase):
     """Test K8sdAPIManager."""
 
     def setUp(self):
-        """Setup environment."""
+        """Set up environment."""
         self.mock_factory = MagicMock()
         self.api_manager = K8sdAPIManager(factory=self.mock_factory)
 

--- a/charms/worker/k8s/tests/unit/test_upgrade.py
+++ b/charms/worker/k8s/tests/unit/test_upgrade.py
@@ -7,12 +7,13 @@ import unittest
 from unittest.mock import MagicMock
 
 import ops
-from charms.data_platform_libs.v0.upgrade import ClusterNotReadyError
 from inspector import ClusterInspector
 from lightkube.models.core_v1 import Node
 from lightkube.models.meta_v1 import ObjectMeta
 from literals import UPGRADE_RELATION
 from upgrade import K8sDependenciesModel, K8sUpgrade
+
+from charms.data_platform_libs.v0.upgrade import ClusterNotReadyError
 
 
 class TestK8sUpgrade(unittest.TestCase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,11 @@ minversion = "6.0"
 # Linting tools configuration
 [tool.ruff]
 line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info"]
+
+[tool.ruff.lint]
 select = ["E", "W", "F", "C", "N", "D", "I001"]
-extend-ignore = [
+ignore = [
     "D203",
     "D204",
     "D213",
@@ -77,12 +80,13 @@ extend-ignore = [
     "D408",
     "D409",
     "D413",
+    "D107",
+    "N805",
+#    "E503",
 ]
-ignore = ["E501", "D107"]
-extend-exclude = ["__pycache__", "*.egg_info"]
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
 [tool.codespell]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -104,7 +104,7 @@ def pytest_collection_modifyitems(config, items):
 
 
 async def cloud_proxied(ops_test: OpsTest):
-    """Setup a cloud proxy settings if necessary
+    """Set up a cloud proxy settings if necessary.
 
     If ghcr.io is reachable through a proxy apply expected proxy config to juju model.
 
@@ -123,7 +123,7 @@ async def cloud_proxied(ops_test: OpsTest):
 
 
 async def cloud_profile(ops_test: OpsTest):
-    """Apply Cloud Specific Settings to the model
+    """Apply Cloud Specific Settings to the model.
 
     Args:
         ops_test (OpsTest): ops_test plugin
@@ -216,7 +216,7 @@ async def kubernetes_cluster(request: pytest.FixtureRequest, ops_test: OpsTest):
 
 
 def valid_namespace_name(s: str) -> str:
-    """Creates a valid kubernetes namespace name.
+    """Create a valid kubernetes namespace name.
 
     Args:
         s: The string to sanitize.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -28,7 +28,8 @@ CHARMCRAFT_DIRS = {"k8s": Path("charms/worker/k8s"), "k8s-worker": Path("charms/
 
 
 async def is_deployed(model: juju.model.Model, bundle_path: Path) -> bool:
-    """Checks if model has apps defined by the bundle.
+    """Check if model has apps defined by the bundle.
+
     If all apps are deployed, wait for model to be active/idle
 
     Args:
@@ -85,7 +86,7 @@ async def get_unit_cidrs(model: juju.model.Model, app_name: str, unit_num: int) 
             continue
         if cidr.prefixlen < 32:
             local_cidrs.add(str(cidr))
-    return list(sorted(local_cidrs))
+    return sorted(local_cidrs)
 
 
 async def get_rsc(k8s, resource, namespace=None, labels=None) -> List[Dict[str, Any]]:
@@ -404,7 +405,7 @@ class Bundle:
 
     @property
     def content(self) -> Dict[str, Any]:
-        """Yaml content of the bundle loaded into a dict
+        """Yaml content of the bundle loaded into a dict.
 
         Returns:
             Dict: bundle content
@@ -557,7 +558,7 @@ class Bundle:
 
 
 async def cloud_arch(ops_test: OpsTest) -> str:
-    """Return current architecture of the selected controller
+    """Return current architecture of the selected controller.
 
     Args:
         ops_test (OpsTest): ops_test plugin
@@ -576,7 +577,7 @@ async def cloud_arch(ops_test: OpsTest) -> str:
 
 
 async def cloud_type(ops_test: OpsTest) -> Tuple[str, bool]:
-    """Return current cloud type of the selected controller
+    """Return current cloud type of the selected controller.
 
     Args:
         ops_test (OpsTest): ops_test plugin

--- a/tests/integration/terraform_setup.py
+++ b/tests/integration/terraform_setup.py
@@ -2,8 +2,8 @@
 
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
-"""
-Deploy a Kubernetes cluster using the Juju Terraform provider and a manifest as input.
+"""Deploy a Kubernetes cluster using the Juju Terraform provider and a manifest as input.
+
 See https://github.com/canonical/k8s-bundles/blob/main/terraform/README.md
 """
 
@@ -84,7 +84,8 @@ def ensure_terraform(expected_version: str) -> None:
         sys.exit(1)
     else:
         print(
-            f"Terraform is already installed and matches the expected version: {installed_version}."
+            "Terraform is already installed and "
+            f"matches the expected version: {installed_version}."
         )
 
 
@@ -155,7 +156,7 @@ async def ensure_model_exists(model_name: str, lxd_profile_path: Union[Path, str
 
 
 async def main() -> None:
-    """Main entry point for setting up Terraform and Juju."""
+    """Set up entry point for Terraform and Juju."""
     script_dir = Path(__file__).resolve().parent
 
     parser = argparse.ArgumentParser(description="Terraform and Juju setup script.")

--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -174,8 +174,7 @@ async def test_remove_leader_control_plane(kubernetes_cluster: juju.model.Model)
 
 @pytest_asyncio.fixture()
 async def override_snap_on_k8s(kubernetes_cluster: juju.model.Model, request):
-    """
-    Override the snap resource on a Kubernetes cluster application and revert it after the test.
+    """Override the snap resource on a Kubernetes cluster application and revert it after the test.
 
     This coroutine function overrides the snap resource of the "k8s" application in the given
     Kubernetes cluster with a specified override file, waits for the cluster to become idle,

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -27,7 +27,7 @@ log = logging.getLogger(__name__)
 
 
 def charm_channel_missing(charms: Iterable[str], channel: str) -> Tuple[bool, str]:
-    """Run to test if a given channel has charms for deployment
+    """Run to test if a given channel has charms for deployment.
 
     Args:
         charms: The list of charms to check

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, unit, static, coverage-report, coverage-xml
+envlist = lint-mock, lint, unit, static, coverage-report, coverage-xml
 
 [vars]
 lib_path = {toxinidir}/charms/worker/k8s/lib
@@ -25,47 +25,33 @@ passenv =
 allowlist_externals = tox
 description = Apply coding style standards to code
 deps =
-    black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
-    black {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
+[testenv:lint-mock]
+description = Provide mock lint commands to use ruff instead
+commands =
+    python -c "'pydocstyle'"
+    python -c "'codespell'"
+    python -c "'flake8'"
+    python -c "'black'"
+    python -c "'mypy'"
+    python -c "'isort'"
+    python -c "'pylint'"
+    python -c "'flake8-docstrings'"
+    python -c "'flake8-docstrings-complete'"
+    python -c "'flake8-builtins'"
+    python -c "'flake8-test-docs'"
+    python -c "'pep8-naming'"
 
 [testenv:lint]
 description = Check code against coding style standards
 setenv =
   PYTHONPATH = {envdir}{:}{[vars]lib_path}
-deps =
-    black
-    codespell
-    flake8
-    flake8-builtins
-    flake8-copyright
-    flake8-docstrings>=1.6.0
-    flake8-docstrings-complete>=1.0.3
-    flake8-test-docs>=1.0
-    mypy
-    pep8-naming
-    pydocstyle>=2.10
-    pylint
-    pyproject-flake8
-    types-PyYAML
-    types-requests
-    -r{toxinidir}/test_requirements.txt
-    -r{toxinidir}/charms/worker/k8s/requirements.txt
+deps = ruff
 commands =
-    pydocstyle {[vars]src_path}
-    codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
-      --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
-      --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
-    black --check --diff {[vars]all_path}
-    mypy {[vars]all_path} --check-untyped-defs
-    pylint {[vars]all_path}
-
+    ruff check {[vars]all_path}
 
 [testenv:unit]
 allowlist_externals = tox


### PR DESCRIPTION
Shrink the number of builds performed on the charms to enable testing from 6 -> 2

* Rather than testing each module with a different set of builds, we can build once per architecture and test with multiple modules
* format and lint with ruff