### PR TITLE
Improve external load balancer endpoint testing

### DIFF
--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -147,6 +147,7 @@ class K8sCharm(ops.CharmBase):
         lead_control_plane: true if this is a control-plane unit and its the leader
         is_upgrade_granted: true if the upgrade has been granted
         datastore: the datastore used for Kubernetes
+        external_load_balancer_address: the external load balancer address, if available
     """
 
     _stored = ops.StoredState()
@@ -187,7 +188,6 @@ class K8sCharm(ops.CharmBase):
         )
         self._upgrade_snap = False
         self._stored.set_default(is_dying=False, cluster_name=str(), upgrade_granted=False)
-        self._external_load_balancer_address = ""
 
         self.cos_agent = COSAgentProvider(
             self,
@@ -207,6 +207,32 @@ class K8sCharm(ops.CharmBase):
             self.kube_control = KubeControlProvides(self, endpoint="kube-control")
             self.framework.observe(self.on.get_kubeconfig_action, self._get_external_kubeconfig)
             self.external_load_balancer = LBProvider(self, EXTERNAL_LOAD_BALANCER_RELATION)
+
+    @property
+    def external_load_balancer_address(self) -> str:
+        """Return the external load balancer address.
+
+        Raises:
+            LookupError: If the loadbalancer response has errors.
+        """
+        if not self.is_control_plane:
+            log.warning("External load balancer is only configured for control-plane units.")
+            return ""
+
+        if not self.external_load_balancer.is_available:
+            log.warning(
+                "External load balancer relation is not available but the address was requested."
+            )
+            return ""
+
+        resp = self.external_load_balancer.get_response(EXTERNAL_LOAD_BALANCER_RESPONSE_NAME)
+        if not resp:
+            log.error("No response from external load balancer")
+            return ""
+        if resp.error:
+            raise LookupError(f"External load balancer error: {resp.error}")
+
+        return resp.address
 
     def _k8s_info(self, event: ops.EventBase):
         """Send cluster information on the kubernetes-info relation.
@@ -387,7 +413,11 @@ class K8sCharm(ops.CharmBase):
         self.api_manager.check_k8sd_ready()
 
     def _get_extra_sans(self):
-        """Retrieve the certificate extra SANs."""
+        """Retrieve the certificate extra SANs.
+
+        Raises:
+            ReconcilerError: If it fails to get the external load balancer address.
+        """
         # Get the extra SANs from the configuration
         extra_sans_str = str(self.config.get("kube-apiserver-extra-sans") or "")
         extra_sans = set(extra_sans_str.strip().split())
@@ -401,9 +431,12 @@ class K8sCharm(ops.CharmBase):
             extra_sans |= {str(addr) for addr in addresses}
 
         # Add the external load balancer address
-        if self._external_load_balancer_address:
-            log.info("Adding external load balancer address to extra SANs")
-            extra_sans.add(self._external_load_balancer_address)
+        try:
+            if lb_addr := self.external_load_balancer_address:
+                log.info("Adding external load balancer address to extra SANs")
+                extra_sans.add(lb_addr)
+        except LookupError as e:
+            raise ReconcilerError(f"Failed to get external load balancer address: {e}")
 
         return sorted(extra_sans)
 
@@ -461,7 +494,7 @@ class K8sCharm(ops.CharmBase):
             status.add(ops.BlockedStatus(msg))
             raise ReconcilerError(msg)
 
-        self._external_load_balancer_address = resp.address
+        log.info("External load balancer is configured with address %s", resp.address)
 
     @on_error(
         ops.WaitingStatus("Waiting to bootstrap k8s snap"),
@@ -1153,7 +1186,12 @@ class K8sCharm(ops.CharmBase):
             if not server:
                 log.info("No server requested, use public address")
 
-                server = self._get_public_address()
+                try:
+                    server = self._get_public_address()
+                except LookupError as e:
+                    event.fail(f"Failed to get public address: {e}")
+                    return
+
                 if not server:
                     event.fail("Failed to get public address. Check logs for details.")
                     return
@@ -1182,10 +1220,16 @@ class K8sCharm(ops.CharmBase):
 
         Returns:
             str: The public ip address of the unit.
+
+        Raises:
+            LookupError: If it fails to get the external load balancer address.
         """
-        if self._external_load_balancer_address:
-            log.info("Using external load balancer address as the public address")
-            return self._external_load_balancer_address
+        try:
+            if lb_addr := self.external_load_balancer_address:
+                log.info("Using external load balancer address as the public address")
+                return lb_addr
+        except LookupError as e:
+            raise LookupError(f"Failed to get external load balancer address: {e}")
 
         log.info("Using juju public address as the public address")
         return _get_juju_public_address()
@@ -1215,11 +1259,12 @@ class K8sCharm(ops.CharmBase):
 
         missing_sans = [san for san in extra_sans if san not in all_cert_sans]
         if missing_sans:
+            all_sans = sorted(set(all_cert_sans) | set(extra_sans))
             log.info(
-                "%s not in cert SANs. Refreshing certs with new SANs: %s", missing_sans, extra_sans
+                "%s not in cert SANs. Refreshing certs with new SANs: %s", missing_sans, all_sans
             )
             status.add(ops.MaintenanceStatus("Refreshing Certificates"))
-            self.api_manager.refresh_certs(extra_sans)
+            self.api_manager.refresh_certs(all_sans)
             log.info("Certificates have been refreshed")
 
         log.info("Certificate SANs are up-to-date")

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -436,7 +436,7 @@ class K8sCharm(ops.CharmBase):
                 log.info("Adding external load balancer address to extra SANs")
                 extra_sans.add(lb_addr)
         except LookupError as e:
-            raise ReconcilerError(f"Failed to get external load balancer address: {e}")
+            raise ReconcilerError(f"Failed to get external load balancer address: {e}") from e
 
         return sorted(extra_sans)
 
@@ -1229,7 +1229,7 @@ class K8sCharm(ops.CharmBase):
                 log.info("Using external load balancer address as the public address")
                 return lb_addr
         except LookupError as e:
-            raise LookupError(f"Failed to get external load balancer address: {e}")
+            raise LookupError(f"Failed to get external load balancer address: {e}") from e
 
         log.info("Using juju public address as the public address")
         return _get_juju_public_address()

--- a/charms/worker/k8s/tests/unit/mocks.py
+++ b/charms/worker/k8s/tests/unit/mocks.py
@@ -1,0 +1,126 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Learn more about testing at: https://juju.is/docs/sdk/testing
+"""Mocks for unit tests."""
+
+from typing import Optional, TypedDict
+
+
+class MockELBRequest:
+    """Mock ELB request."""
+
+    class Protocols:
+        """Mock Protocols.
+
+        Attributes:
+            tcp: tcp
+            https: https
+        """
+
+        tcp = "tcp"
+        https = "https"
+
+    def __init__(self, protocols: Protocols):
+        """Initialize ELB request.
+
+        Args:
+            protocols: request protocols mock
+        """
+
+        class HealthCheck(TypedDict):
+            """Health check.
+
+            Attributes:
+                protocol: the used protocol
+                port: the port to health check
+                path: the path to health check
+            """
+
+            protocol: str
+            port: int
+            path: str
+
+        self.name = ""
+        self.protocol = ""
+        self.protocols = protocols
+        self.port_mapping: dict[int, int] = {}
+        self.public = False
+        self.health_checks: list[HealthCheck] = []
+
+    def add_health_check(self, protocol: str, port: int, path: str):
+        """Add health check.
+
+        Args:
+            protocol: the used protocol
+            port: the port to health check
+            path: the path to health check
+        """
+        self.health_checks.append({"protocol": protocol, "port": port, "path": path})
+
+
+class MockELBResponse:
+    """Mock ELB response."""
+
+    def __init__(self, addr: str):
+        """Initialize ELB response.
+
+        Args:
+            addr: the lb address
+        """
+        self.error: str = ""
+        self.address: str = addr
+
+
+class MockEvent:
+    """Mock event."""
+
+    class Params:
+        """Mock params."""
+
+        def __init__(self, kv: Optional[dict] = None):
+            """Initialize params.
+
+            Args:
+                kv: key-value pairs
+            """
+            self.kv = kv if kv else {}
+
+        def get(self, key: str):
+            """Get value.
+
+            Args:
+                key: the key to get
+
+            Returns:
+                the value for the key or "X_default_value"
+            """
+            return self.kv.get(key, "X_default_value")
+
+    def __init__(self, params: Params):
+        """Initialize event.
+
+        Args:
+            params: event parameters mock
+        """
+        self.params = params
+        self.failed = False
+        self.failed_msg = ""
+        self.results = {}  # type: ignore
+
+    def fail(self, msg: str):
+        """Fail event.
+
+        Args:
+            msg: the failure message
+        """
+        self.failed = True
+        self.failed_msg = msg
+
+    def set_results(self, results: dict):
+        """Set results.
+
+        Args:
+            results: the results
+        """
+        self.results = results

--- a/charms/worker/k8s/tests/unit/test_base.py
+++ b/charms/worker/k8s/tests/unit/test_base.py
@@ -16,6 +16,7 @@ import ops
 import ops.testing
 import pytest
 from charm import K8sCharm
+from mocks import MockELBRequest, MockELBResponse, MockEvent  # pylint: disable=import-error
 
 from charms.k8s.v0.k8sd_api_manager import BootstrapConfig, UpdateClusterConfigRequest
 
@@ -59,7 +60,6 @@ def mock_reconciler_handlers(harness):
     }
     if harness.charm.is_control_plane:
         handler_names |= {
-            "_configure_external_load_balancer",
             "_bootstrap_k8s_snap",
             "_create_cluster_tokens",
             "_create_cos_tokens",
@@ -69,7 +69,6 @@ def mock_reconciler_handlers(harness):
             "_ensure_cluster_config",
             "_expose_ports",
             "_announce_kubernetes_version",
-            "_ensure_cert_sans",
         }
 
     mocked = [mock.patch(f"charm.K8sCharm.{name}") for name in handler_names]
@@ -110,6 +109,7 @@ def test_set_leader(harness):
         harness: the harness under test
     """
     harness.charm.reconciler.stored.reconciled = False  # Pretended to not be reconciled
+    harness.charm._ensure_cert_sans = mock.MagicMock()
     with mock_reconciler_handlers(harness) as handlers:
         handlers["_evaluate_removal"].return_value = False
         harness.set_leader(True)
@@ -211,9 +211,14 @@ def test_configure_bootstrap_extra_sans(harness):
     if harness.charm.is_worker:
         pytest.skip("Not applicable on workers")
 
+    harness.charm._ensure_cert_sans = mock.MagicMock()
     cfg_extra_sans = ["mykubernetes", "mykubernetes.local"]
     public_addr = "11.12.13.14"
-    harness.add_relation("cluster", "remote", unit_data={"ingress-address": public_addr})
+    remote_addr = "11.12.13.15"
+    harness.add_network(
+        public_addr, endpoint="cluster", ingress_addresses=[public_addr, remote_addr]
+    )
+    harness.add_relation("cluster", "remote")
     harness.update_config({"kube-apiserver-extra-sans": " ".join(cfg_extra_sans)})
 
     with mock.patch("charm._get_juju_public_address") as m:
@@ -222,7 +227,8 @@ def test_configure_bootstrap_extra_sans(harness):
 
     # We expect the resulting SANs to include the configured addresses as well
     # as the unit address.
-    exp_extra_sans = cfg_extra_sans + [public_addr]
+    exp_extra_sans = cfg_extra_sans + [public_addr, remote_addr]
+    assert len(exp_extra_sans) == len(bs_config.extra_sans)
     for san in exp_extra_sans:
         assert san in bs_config.extra_sans
 
@@ -258,3 +264,119 @@ def test_config_containerd_registries(mock_ensure_registry_configs, harness):
     expected = containerd.parse_registries(cfg_data)
     mock_ensure_registry_configs.assert_called_once_with(expected)
     assert app_data == harness.get_relation_data(rel, "k8s")
+
+
+def test_get_public_address_with_external_lb(harness):
+    """Test getting the public address with an external load balancer.
+
+    Args:
+        harness: the harness under test
+    """
+    if harness.charm.is_worker:
+        pytest.skip("Not applicable on workers")
+
+    lb_address = "1.2.3.4"
+
+    with (
+        mock.patch.object(harness.charm, "external_load_balancer") as mock_elb,
+    ):
+        mock_elb.is_available = True
+        mock_elb.get_response.return_value = MockELBResponse(addr=lb_address)
+        public_addr = harness.charm._get_public_address()
+
+    assert public_addr == lb_address
+
+
+def test_get_public_address_without_external_lb(harness):
+    """Test getting the public address without an external load balancer.
+
+    Args:
+        harness: the harness under test
+    """
+    if harness.charm.is_worker:
+        pytest.skip("Not applicable on workers")
+
+    exp_public_addr = "1.2.3.4"
+    with mock.patch("charm._get_juju_public_address", return_value=exp_public_addr):
+        public_addr = harness.charm._get_public_address()
+    assert public_addr == exp_public_addr
+
+
+def test_ensure_cert_sans(harness):
+    """Test ensuring certificate SANs are up-to-date.
+
+    Args:
+        harness: the harness under test
+    """
+    if harness.charm.is_worker:
+        pytest.skip("Not applicable on workers")
+
+    with (
+        mock.patch.object(harness.charm, "_get_extra_sans") as mock_extra_sans,
+        mock.patch("charm.get_certificate_sans", return_value=(["sans1"], ["1.2.3.4"])),
+        mock.patch.object(harness.charm.api_manager, "refresh_certs") as mock_api_manager,
+    ):
+        mock_extra_sans.return_value = ["sans1", "sans2"]
+        harness.charm._ensure_cert_sans()
+        mock_api_manager.assert_called_once_with(["1.2.3.4", "sans1", "sans2"])
+
+
+def test_get_external_kubeconfig(harness):
+    """Test getting the external kubeconfig.
+
+    Args:
+        harness: the harness under test
+    """
+    if harness.charm.is_worker:
+        pytest.skip("Not applicable on workers")
+
+    public_addr = "1.2.3.4"
+    with (
+        mock.patch.object(harness.charm, "_get_public_address"),
+        mock.patch.object(harness.charm.api_manager, "get_kubeconfig") as mock_api_manager,
+    ):
+        event = MockEvent(MockEvent.Params())
+        mock_api_manager.return_value = {"server": public_addr}
+        harness.charm._get_external_kubeconfig(event)
+        assert event.results == {"kubeconfig": {"server": public_addr}}
+
+        custom_addr = "10.20.30.40"
+        mock_api_manager.return_value = {"server": custom_addr}
+        event = MockEvent(MockEvent.Params({"server": custom_addr}))
+        harness.charm._get_external_kubeconfig(event)
+        assert event.results == {"kubeconfig": {"server": custom_addr}}
+
+
+def test_configure_external_load_balancer(harness):
+    """Test that the external load balancer is configured correctly.
+
+    Args:
+        harness (ops.testing.Harness): The test harness
+    """
+    if harness.charm.is_worker:
+        pytest.skip("Not applicable on workers")
+
+    exp_addr = "1.2.3.4"
+    with mock.patch.object(harness.charm, "external_load_balancer") as mock_elb:
+        mock_elb.is_available = True
+        mock_elb.get_request.return_value = MockELBRequest(MockELBRequest.Protocols())
+        mock_elb.get_response = mock.MagicMock()
+        mock_elb.get_response.return_value = MockELBResponse(exp_addr)
+        harness.charm._configure_external_load_balancer()
+        mock_elb.get_response.assert_called_once()
+
+
+def test_external_load_balancer_address(harness):
+    """Test that the external load balancer address is returned correctly.
+
+    Args:
+        harness (ops.testing.Harness): The test harness
+    """
+    if harness.charm.is_worker:
+        pytest.skip("Not applicable on workers")
+
+    with mock.patch.object(harness.charm, "external_load_balancer") as mock_elb:
+        lb_addr = "1.2.3.4"
+        mock_elb.is_available = True
+        mock_elb.get_response.return_value = MockELBResponse(lb_addr)
+        assert harness.charm.external_load_balancer_address == lb_addr

--- a/tests/integration/data/test-bundle-openstack.yaml
+++ b/tests/integration/data/test-bundle-openstack.yaml
@@ -28,3 +28,4 @@ relations:
   - [openstack-cloud-controller:external-cloud-provider, k8s:external-cloud-provider]
   - [openstack-cloud-controller:openstack,               openstack-integrator:clients]
   - [cinder-csi:openstack,                               openstack-integrator:clients]
+  - [k8s:external-load-balancer,                         openstack-integrator:lb-consumers]


### PR DESCRIPTION
### Overview
This PR improves testing around external load balancer endpoint.

The actual integration with an external load balancer is also tested in the current Openstack e2e tests. That's because we've added the relation to the test bundle and in the e2e tests we retrieve the kubeconfig by running the `get-kubeconfig` action. A test for that action is added to make sure it returns the external load balancer endpoint when it's available. So the e2e tests intrinsically test the reachability of the cluster via the external lb endpoint.