### PR TITLE
test: Add integration tests for Kubernetes docker-registry deployment

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -38,18 +38,18 @@ jobs:
     strategy:
       matrix:
         arch:
-        # built on azure, test on self-hosted
-        - id: amd64
-          builder-label: ubuntu-22.04
-          tester-arch: AMD64
-          tester-size: xlarge
-          modules: '["test_k8s", "test_etcd", "test_ceph", "test_upgrade", "test_external_certs", "test_registry"]'
-        # built and test on on self-hosted
-        - id: arm64
-          builder-label: ARM64
-          tester-arch: ARM64
-          tester-size: large
-          modules: '["test_k8s", "test_etcd"]'
+          # built on azure, test on self-hosted
+          - id: amd64
+            builder-label: ubuntu-22.04
+            tester-arch: AMD64
+            tester-size: xlarge
+            modules: '["test_k8s", "test_etcd", "test_ceph", "test_upgrade", "test_external_certs", "test_registry"]'
+          # built and test on on self-hosted
+          - id: arm64
+            builder-label: ARM64
+            tester-arch: ARM64
+            tester-size: large
+            modules: '["test_k8s", "test_etcd"]'
     with:
       identifier: ${{ matrix.arch.id }}
       builder-runner-label: ${{ matrix.arch.builder-label }}
@@ -64,7 +64,7 @@ jobs:
       self-hosted-runner: true
       self-hosted-runner-arch: ${{ matrix.arch.tester-arch }}
       self-hosted-runner-label: ${{ matrix.arch.tester-size }}
-      test-timeout: 120
+      test-timeout: 600
       test-tox-env: integration
       trivy-fs-enabled: false
       trivy-image-config: "trivy.yaml"

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,4 +1,3 @@
-
 name: Integration tests
 
 on:
@@ -28,9 +27,9 @@ jobs:
     outputs:
       channel: ${{ steps.charmcraft.outputs.channel }}
     steps:
-    - uses: actions/checkout@v4
-    - id: charmcraft
-      run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v4
+      - id: charmcraft
+        run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
 
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@a23cb8af2877316bd87af472b1732318386bd05c
@@ -44,7 +43,7 @@ jobs:
           builder-label: ubuntu-22.04
           tester-arch: AMD64
           tester-size: xlarge
-          modules: '["test_k8s", "test_etcd", "test_ceph", "test_upgrade", "test_external_certs"]'
+          modules: '["test_k8s", "test_etcd", "test_ceph", "test_upgrade", "test_external_certs", "test_registry"]'
         # built and test on on self-hosted
         - id: arm64
           builder-label: ARM64

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,7 +10,7 @@ import random
 import shlex
 import string
 from pathlib import Path
-from typing import Optional
+from typing import AsyncGenerator, Optional
 
 import juju.controller
 import juju.utils
@@ -224,7 +224,9 @@ async def deploy_model(
 
 
 @pytest_asyncio.fixture(scope="module")
-async def kubernetes_cluster(request: pytest.FixtureRequest, ops_test: OpsTest):
+async def kubernetes_cluster(
+    request: pytest.FixtureRequest, ops_test: OpsTest
+) -> AsyncGenerator[Model, None]:
     """Deploy kubernetes charms according to the bundle_marker."""
     model = "main"
     bundle, markings = await Bundle.create(ops_test)
@@ -232,6 +234,7 @@ async def kubernetes_cluster(request: pytest.FixtureRequest, ops_test: OpsTest):
     with ops_test.model_context(model) as the_model:
         if await is_deployed(the_model, bundle.path):
             log.info("Using existing model=%s.", the_model.uuid)
+            assert ops_test.model, "Model must be present"
             yield ops_test.model
             return
 

--- a/tests/integration/data/test_registries/pod.yaml
+++ b/tests/integration/data/test_registries/pod.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/tests/integration/data/test_registries/pod.yaml
+++ b/tests/integration/data/test_registries/pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+    - name: test-container
+      #image:
+      command: ["echo", "Success"]

--- a/tests/integration/data/test_registries/pod.yaml
+++ b/tests/integration/data/test_registries/pod.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   containers:
     - name: test-container
-      #image:
-      command: ["echo", "Success"]
+      #image: set by test
+      command: ["sleep", "100"]

--- a/tests/integration/data/test_registries/test-bundle-docker-registry.yaml
+++ b/tests/integration/data/test_registries/test-bundle-docker-registry.yaml
@@ -1,0 +1,16 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: integration-test-docker-registry
+description: |-
+  Used to deploy or refresh within an integration test model
+series: jammy
+applications:
+  k8s:
+    charm: k8s
+    constraints: cores=2 mem=8G root-disk=16G
+    num_units: 1
+  docker-registry:
+    charm: docker-registry
+    channel: latest/edge
+    num_units: 1

--- a/tests/integration/test_registry.py
+++ b/tests/integration/test_registry.py
@@ -59,9 +59,9 @@ async def test_custom_registry(kubernetes_cluster: model.Model, api_client):
     )
     test_pod_manifest[0]["metadata"]["name"] = random_pod_name
 
-    test_pod_manifest[0]["spec"]["containers"][0][
-        "image"
-    ] = f"{docker_registry_ip}:5000/busybox:latest"
+    test_pod_manifest[0]["spec"]["containers"][0]["image"] = (
+        f"{docker_registry_ip}:5000/busybox:latest"
+    )
 
     k8s_unit = kubernetes_cluster.applications["k8s"].units[0]
     try:

--- a/tests/integration/test_registry.py
+++ b/tests/integration/test_registry.py
@@ -35,12 +35,6 @@ def _get_data_file_path(name) -> Path:
 
 
 @pytest.mark.abort_on_fail
-async def test_nodes_ready(kubernetes_cluster: model.Model):
-    k8s_app = kubernetes_cluster.applications["k8s"]
-    await helpers.ready_nodes(k8s_app.units[0], 1)
-
-
-@pytest.mark.abort_on_fail
 async def test_custom_registry(kubernetes_cluster: model.Model, api_client):
     """Test that the charm configures the correct directory and can access a custom registry."""
     # List of resources created during the test
@@ -80,7 +74,7 @@ async def test_custom_registry(kubernetes_cluster: model.Model, api_client):
         await helpers.wait_pod_phase(k8s_unit, random_pod_name, "Running")
     finally:
         # Cleanup
-        for resource in reversed(created):
+        for resource in created:
             kind = resource.kind
             name = resource.metadata.name
             event = await k8s_unit.run(f"k8s kubectl delete {kind} {name}")

--- a/tests/integration/test_registry.py
+++ b/tests/integration/test_registry.py
@@ -35,11 +35,9 @@ def _get_data_file_path(name) -> Path:
 
 
 @pytest.mark.abort_on_fail
-async def test_ready_nodes(kubernetes_cluster: model.Model):
-    # Check that the units are ready
+async def test_nodes_ready(kubernetes_cluster: model.Model):
     k8s_app = kubernetes_cluster.applications["k8s"]
-
-    assert k8s_app
+    await helpers.ready_nodes(k8s_app.units[0], 1)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_registry.py
+++ b/tests/integration/test_registry.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# pylint: disable=duplicate-code
+"""Integration tests."""
+
+import logging
+import yaml
+import json
+
+import pytest
+from pathlib import Path
+from typing import List
+from juju import model
+from kubernetes.utils import create_from_yaml
+
+from . import helpers
+
+# This pytest mark configures the test environment to use the Canonical Kubernetes
+# bundle with ceph, for all the test within this module.
+pytestmark = [
+    pytest.mark.bundle(file="test_registries/test-bundle-docker-registry.yaml", apps_local=["k8s"])
+]
+
+log = logging.getLogger(__name__)
+
+
+def _get_data_file_path(name) -> Path:
+    """Retrieve the full path of the specified test data file."""
+    return Path(__file__).parent / "data" / "test_registries" / name
+
+
+@pytest.mark.abort_on_fail
+async def test_ready_nodes(kubernetes_cluster: model.Model):
+    # Check that the units are ready
+    k8s_app = kubernetes_cluster.applications["k8s"]
+
+    assert k8s_app
+
+
+@pytest.mark.abort_on_fail
+async def test_custom_registry(kubernetes_cluster: model.Model, api_client):
+    """Test that the charm configures the correct directory and can access a custom registry."""
+    created: List = []
+
+    # Get the IP of the machine hosting the docker registry charm
+    docker_registry_unit = kubernetes_cluster.applications["docker-registry"].units[0]
+    docker_registry_ip = await docker_registry_unit.get_public_address()
+
+    # Define the custom registry configuration
+    config_string = json.dumps(
+        [{"url": f"http://{docker_registry_ip}:5000", "host": f"{docker_registry_ip}:5000"}]
+    )
+
+    custom_registry_config = {"containerd-custom-registries": config_string}
+
+    # Apply the custom registry configuration to the k8s charm
+    await kubernetes_cluster.applications["k8s"].set_config(custom_registry_config)
+    await kubernetes_cluster.wait_for_idle(status="active")
+
+    # Run Docker commands in the Docker registry unit
+    action = await docker_registry_unit.run_action("push", image="busybox:latest", pull=True)
+    await action.wait()
+
+    # Create a pod that uses the busybox image from the custom registry
+    # Image: {docker_registry_ip}:5000/busybox:latest
+    test_pod_manifest = list(yaml.safe_load_all(_get_data_file_path("pod.yaml").open()))
+
+    # Add image
+    test_pod_manifest[0]["spec"]["containers"][0][
+        "image"
+    ] = f"{docker_registry_ip}:5000/busybox:latest"
+
+    k8s_unit = kubernetes_cluster.applications["k8s"].units[0]
+    try:
+        created.extend(*create_from_yaml(api_client, yaml_objects=test_pod_manifest))
+        await helpers.wait_pod_phase(k8s_unit, "test-pod", "Succeeded")
+    finally:
+        # Cleanup
+        for resource in reversed(created):
+            kind = resource.kind
+            name = resource.metadata.name
+            event = await k8s_unit.run(f"k8s kubectl delete {kind} {name}")
+            result = await event.wait()


### PR DESCRIPTION
Adds a test that deploys the docker-registry charm, pulls an image to the registry, tags it with a unique name, and finally tries to pull the image from the registry.

This validates that the charm sets the custom_containerd_config from charm configuration in the right place on the filesystem.