### PR TITLE
Pin `kube-control` dependency

### DIFF
--- a/charms/worker/k8s/requirements.txt
+++ b/charms/worker/k8s/requirements.txt
@@ -2,7 +2,7 @@ charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-li
 charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider@e9cadd749ff8e2a6c81fadb0268a8b10e26876be
 charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@e35bbe08c1035849ed10a6838fa676c7847bc757#subdirectory=ops
 charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@f818cc30d1a22be43ffdfecf7fbd9c3fd2967502
-ops-interface-kube-control @ git+https://github.com/charmed-kubernetes/interface-kube-control.git@main#subdirectory=ops
+ops.interface-kube-control==0.2.0
 ops.interface_aws @ git+https://github.com/charmed-kubernetes/interface-aws-integration@main#subdirectory=ops
 ops.interface_gcp @ git+https://github.com/charmed-kubernetes/interface-gcp-integration@main#subdirectory=ops
 ops.interface_azure @ git+https://github.com/charmed-kubernetes/interface-azure-integration@main#subdirectory=ops

--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -27,6 +27,10 @@ pytestmark = [
     pytest.mark.bundle(file="test-bundle.yaml", apps_local=["k8s", "k8s-worker"]),
 ]
 
+pinned_revision = "latest/edge" not in Path(
+    "charms/worker/k8s/templates/snap_installation.yaml"
+).read_text("utf-8")
+
 
 @pytest_asyncio.fixture
 async def preserve_charm_config(kubernetes_cluster: juju.model.Model):
@@ -172,6 +176,7 @@ async def test_remove_leader_control_plane(kubernetes_cluster: juju.model.Model)
     await ready_nodes(follower, expected_nodes)
 
 
+@pytest.mark.skipif(pinned_revision, reason="only run on latest/edge channel")
 async def test_override_snap_resource(kubernetes_cluster: juju.model.Model, request):
     """
     Override the snap resource on a Kubernetes cluster application and revert it after the test.


### PR DESCRIPTION
## Overview
`kube-control` is now a Python package, let's pin it to the current working version.