### PR TITLE
Bypass operator-workflows promote

### DIFF
--- a/.github/workflows/promote-charms.yaml
+++ b/.github/workflows/promote-charms.yaml
@@ -26,6 +26,15 @@ on:
         - stable
 
 jobs:
+  charmcraft-channel:
+    runs-on: ubuntu-latest
+    outputs:
+      channel: ${{ steps.charmcraft.outputs.channel }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read charmcraft version file
+        id: charmcraft
+        run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
   configure-track:
     runs-on: ubuntu-latest
     outputs:
@@ -65,18 +74,16 @@ jobs:
             echo 'charms=[{"name": "k8s-worker", "path": "charms/worker"}]' >> "$GITHUB_OUTPUT"
           fi
   promote-charm:
-    needs: [configure-track, select-charms]
+    needs: [charmcraft-channel, configure-track, select-charms]
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         charm: ${{ fromJson(needs.select-charms.outputs.charms) }}
-        arch:
-        - amd64
-        - arm64
-    uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@608b77a2a0649584f18711b2f3e3af104781a9d8
-    with:
-      base-architecture: ${{ matrix.arch }}
-      charm-directory: ${{ matrix.charm.path }}
-      destination-channel: ${{needs.configure-track.outputs.track}}/${{ inputs.destination-risk }}
-      origin-channel: ${{needs.configure-track.outputs.track}}/${{ inputs.origin-risk }}
-      tag-prefix: ${{ matrix.charm.name }}
-    secrets: inherit
+    steps:
+    - uses: canonical/charming-actions/promote-charm@2.7.0
+      with:
+        credentials: ${{ secrets.CHARMHUB_TOKEN }}
+        charm-path: ${{ matrix.charm.path }}
+        charmcraft-channel: ${{ needs.charmcraft-channel.outputs.channel }}
+        destination-channel: ${{needs.configure-track.outputs.track}}/${{ inputs.destination-risk }}
+        origin-channel: ${{needs.configure-track.outputs.track}}/${{ inputs.origin-risk }}


### PR DESCRIPTION
fix:  charm promotion job needs to be more aware of all the revisions of the charms to promote

### Details

The operator-workflows are limited in how it promotes charms.  It can only promote one series/arch revision to the target channel rather than ALL of the revisions in a certain channel.

The workflows do allow one to specify which series/arch they wish to promote, but fails to "validate" that series and arch as it expects a charmcraft 2.x style "bases" header in the charmcraft.yaml rather than the charmcraft 3.x style. 

By switching to the `charming-actions/promote-charm` workflow, it does a better job of just publishing whatever charms are in the the origin channel to the destination channel along with the charm revisions.  It's all wee really need here. 