### PR TITLE
Allow renovate to update uv.lock

### DIFF
--- a/charms/worker/k8s/pyproject.toml
+++ b/charms/worker/k8s/pyproject.toml
@@ -5,10 +5,10 @@ description = "Charmed Operators for Canonical Kubernetes"
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status@255dd4a23defc16dcdac832306e5f460a0f1200c",
     "charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider@e9cadd749ff8e2a6c81fadb0268a8b10e26876be",
     "charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@e35bbe08c1035849ed10a6838fa676c7847bc757#subdirectory=ops",
-    "charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@d802829b5e71b2cbf974cd5c7c69d7ce2137b308",
+    "charms.contextual-status",
+    "charms.reconciler",
     "ops.interface_aws @ git+https://github.com/charmed-kubernetes/interface-aws-integration@main#subdirectory=ops",
     "ops.interface_gcp @ git+https://github.com/charmed-kubernetes/interface-gcp-integration@main#subdirectory=ops",
     "ops.interface_azure @ git+https://github.com/charmed-kubernetes/interface-azure-integration@main#subdirectory=ops",

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -77,7 +77,7 @@ from upgrade import K8sDependenciesModel, K8sUpgrade
 
 import charms.contextual_status as status
 import charms.operator_libs_linux.v2.snap as snap_lib
-from charms.contextual_status import ReconcilerError, WaitingStatus, on_error
+from charms.contextual_status import ReconcilerError, on_error
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 from charms.interface_external_cloud_provider import ExternalCloudProvider
 from charms.k8s.v0.k8sd_api_manager import (
@@ -402,7 +402,9 @@ class K8sCharm(ops.CharmBase):
         status.add(ops.MaintenanceStatus("Ensuring snap installation"))
         snap_management(self)
 
-    @on_error(WaitingStatus("Waiting to apply snap requirements"), subprocess.CalledProcessError)
+    @on_error(
+        ops.WaitingStatus("Waiting to apply snap requirements"), subprocess.CalledProcessError
+    )
     def _apply_snap_requirements(self):
         """Apply necessary snap requirements for the k8s snap.
 
@@ -414,7 +416,7 @@ class K8sCharm(ops.CharmBase):
         init_sh = "/snap/k8s/current/k8s/hack/init.sh"
         subprocess.check_call(shlex.split(init_sh))
 
-    @on_error(WaitingStatus("Waiting for k8sd"), InvalidResponseError, K8sdConnectionError)
+    @on_error(ops.WaitingStatus("Waiting for k8sd"), InvalidResponseError, K8sdConnectionError)
     def _check_k8sd_ready(self):
         """Check if k8sd is ready to accept requests."""
         log.info("Check if k8ds is ready")
@@ -804,7 +806,7 @@ class K8sCharm(ops.CharmBase):
             )
 
     @on_error(
-        WaitingStatus("Ensure that the cluster configuration is up-to-date"),
+        ops.WaitingStatus("Ensure that the cluster configuration is up-to-date"),
         ReconcilerError,
         InvalidResponseError,
         K8sdConnectionError,
@@ -955,7 +957,7 @@ class K8sCharm(ops.CharmBase):
         return "\n".join(proxy_settings)
 
     @on_error(
-        WaitingStatus("Waiting for Cluster token"),
+        ops.WaitingStatus("Waiting for Cluster token"),
         ReconcilerError,
         InvalidResponseError,
         K8sdConnectionError,
@@ -1009,7 +1011,7 @@ class K8sCharm(ops.CharmBase):
         self.api_manager.join_cluster(request)
         log.info("Joined %s(%s)", self.unit, node_name)
 
-    @on_error(WaitingStatus("Awaiting cluster removal"))
+    @on_error(ops.WaitingStatus("Awaiting cluster removal"))
     def _death_handler(self, event: ops.EventBase):
         """Reconcile end of unit's position in the cluster.
 

--- a/charms/worker/k8s/src/kube_control.py
+++ b/charms/worker/k8s/src/kube_control.py
@@ -12,14 +12,14 @@ from literals import APISERVER_PORT
 from protocols import K8sCharmProtocol
 
 import charms.contextual_status as status
-from charms.contextual_status import BlockedStatus, on_error
+from charms.contextual_status import on_error
 
 # Log messages can be retrieved using juju debug-log
 log = logging.getLogger(__name__)
 
 
 @on_error(
-    BlockedStatus("Invalid config on node-labels or bootstrap-node-taints"),
+    ops.BlockedStatus("Invalid config on node-labels or bootstrap-node-taints"),
     ValueError,
     TypeError,
 )

--- a/charms/worker/k8s/uv.lock
+++ b/charms/worker/k8s/uv.lock
@@ -149,14 +149,6 @@ wheels = [
 ]
 
 [[package]]
-name = "charm-lib-contextual-status"
-version = "0.0.0"
-source = { git = "https://github.com/charmed-kubernetes/charm-lib-contextual-status?rev=255dd4a23defc16dcdac832306e5f460a0f1200c#255dd4a23defc16dcdac832306e5f460a0f1200c" }
-dependencies = [
-    { name = "ops" },
-]
-
-[[package]]
 name = "charm-lib-interface-external-cloud-provider"
 version = "0.0.0"
 source = { git = "https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider?rev=e9cadd749ff8e2a6c81fadb0268a8b10e26876be#e9cadd749ff8e2a6c81fadb0268a8b10e26876be" }
@@ -173,12 +165,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "charm-lib-reconciler"
+name = "charms-contextual-status"
 version = "0.0.0"
-source = { git = "https://github.com/charmed-kubernetes/charm-lib-reconciler?rev=d802829b5e71b2cbf974cd5c7c69d7ce2137b308#d802829b5e71b2cbf974cd5c7c69d7ce2137b308" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "charm-lib-contextual-status" },
     { name = "ops" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/33/fea17ca3fc2f4d27df0b2047ad1c0da65f1accea5658cc2296b76d1abf07/charms_contextual_status-0.0.0.tar.gz", hash = "sha256:926722aaa2a61f119ba5c35a256bd47d7b18b2a3f718e11aed94ebcfca99c355", size = 43211 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ac/52e7a680f632573336227773e2115dd7941e213562b43530216dbdecd122/charms.contextual_status-0.0.0-py3-none-any.whl", hash = "sha256:1f6001309a13565693dd73e1fa3fa4b184dc3df56279ef5cc7ceec7097108d58", size = 9343 },
+]
+
+[[package]]
+name = "charms-reconciler"
+version = "0.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charms-contextual-status" },
+    { name = "ops" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/53/2ddeeae5fb18d24082f08666a6402243633e55f9af7dc80b1850a817e589/charms_reconciler-0.0.0.tar.gz", hash = "sha256:f644d00e204fbcd37e63659bf3100fae84bc74439478985ac2e1af2427aa84f6", size = 42315 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/d3/323f78d95e3a73d3ffe8cecf9a908f84266387ec2629d71759577d48c93a/charms.reconciler-0.0.0-py3-none-any.whl", hash = "sha256:324f4cfe06de66d921f3ae77798f1ea41c71deb6dcf54bad995721793d3c8842", size = 8060 },
 ]
 
 [[package]]
@@ -478,10 +486,10 @@ name = "k8s"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "charm-lib-contextual-status" },
     { name = "charm-lib-interface-external-cloud-provider" },
     { name = "charm-lib-node-base" },
-    { name = "charm-lib-reconciler" },
+    { name = "charms-contextual-status" },
+    { name = "charms-reconciler" },
     { name = "cosl" },
     { name = "cryptography" },
     { name = "httpx" },
@@ -512,10 +520,10 @@ unit = [
 
 [package.metadata]
 requires-dist = [
-    { name = "charm-lib-contextual-status", git = "https://github.com/charmed-kubernetes/charm-lib-contextual-status?rev=255dd4a23defc16dcdac832306e5f460a0f1200c" },
     { name = "charm-lib-interface-external-cloud-provider", git = "https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider?rev=e9cadd749ff8e2a6c81fadb0268a8b10e26876be" },
     { name = "charm-lib-node-base", git = "https://github.com/charmed-kubernetes/layer-kubernetes-node-base?subdirectory=ops&rev=e35bbe08c1035849ed10a6838fa676c7847bc757" },
-    { name = "charm-lib-reconciler", git = "https://github.com/charmed-kubernetes/charm-lib-reconciler?rev=d802829b5e71b2cbf974cd5c7c69d7ce2137b308" },
+    { name = "charms-contextual-status" },
+    { name = "charms-reconciler" },
     { name = "cosl" },
     { name = "cryptography", specifier = ">=44.0.0" },
     { name = "httpx" },

--- a/renovate.json
+++ b/renovate.json
@@ -1,32 +1,23 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
-  "regexManagers": [
-    {
-      "fileMatch": ["(^|/)rockcraft.yaml$"],
-      "description": "Update base image references",
-      "matchStringsStrategy": "any",
-      "matchStrings": ["# renovate: build-base:\\s+(?<depName>[^:]*):(?<currentValue>[^\\s@]*)(@(?<currentDigest>sha256:[0-9a-f]*))?",
-      "# renovate: base:\\s+(?<depName>[^:]*):(?<currentValue>[^\\s@]*)(@(?<currentDigest>sha256:[0-9a-f]*))?"],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "ubuntu"
-    }
-  ],
+  "extends": ["config:base"],
+  "enabled": true,
   "packageRules": [
     {
-      "enabled": true,
-      "matchDatasources": [
-        "docker"
+      "matchManagers": ["pip_requirements"],
+      "matchPaths": [
+        "charms/worker/k8s/uv.lock",
+        "charms/worker/k8s/pyproject.toml"
       ],
-      "pinDigests": true
-    },
-    {
-      "matchFiles": ["rockcraft.yaml"],
-      "matchUpdateTypes": ["major", "minor", "patch"],
-      "enabled": false
+      "groupName": "python dependencies",
+      "enabled": true
     }
-  ]
+  ],
+  "pip_requirements": {
+    "fileMatch": ["uv.lock"]
+  },
+  "lockFileMaintenance": {
+    "enabled": true
+  }
 }
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,21 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
+  "baseBranches": ["main", "/^release-.*$/"],
   "enabled": true,
+  "labels": ["dependencies"],
   "packageRules": [
     {
-      "matchManagers": ["pip_requirements"],
-      "matchPaths": [
-        "charms/worker/k8s/uv.lock",
-        "charms/worker/k8s/pyproject.toml"
-      ],
-      "groupName": "python dependencies",
-      "enabled": true
+      "matchManagers": ["pep621"],
+      "groupName": "Python dependencies"
     }
   ],
-  "pip_requirements": {
-    "fileMatch": ["uv.lock"]
-  },
   "lockFileMaintenance": {
     "enabled": true
   }


### PR DESCRIPTION
With the switch UV, dependency updating is halted due to dependabot failing to handle uv.lock files. 

Switch to dep updates by renovate.