### PR TITLE
feat: Bump node-base to apply AZ node labels

### DIFF
--- a/charms/worker/k8s/pyproject.toml
+++ b/charms/worker/k8s/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider@e9cadd749ff8e2a6c81fadb0268a8b10e26876be",
-    "charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@e35bbe08c1035849ed10a6838fa676c7847bc757#subdirectory=ops",
+    "charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@1bd8506cf1fdfcb584c50388c7082cc23a5ee14f#subdirectory=ops",
     "charms.contextual-status",
     "charms.reconciler",
     "ops.interface_aws @ git+https://github.com/charmed-kubernetes/interface-aws-integration@main#subdirectory=ops",

--- a/charms/worker/k8s/uv.lock
+++ b/charms/worker/k8s/uv.lock
@@ -160,7 +160,7 @@ dependencies = [
 [[package]]
 name = "charm-lib-node-base"
 version = "0.0.0"
-source = { git = "https://github.com/charmed-kubernetes/layer-kubernetes-node-base?subdirectory=ops&rev=e35bbe08c1035849ed10a6838fa676c7847bc757#e35bbe08c1035849ed10a6838fa676c7847bc757" }
+source = { git = "https://github.com/charmed-kubernetes/layer-kubernetes-node-base?subdirectory=ops&rev=1bd8506cf1fdfcb584c50388c7082cc23a5ee14f#1bd8506cf1fdfcb584c50388c7082cc23a5ee14f" }
 dependencies = [
     { name = "ops" },
 ]
@@ -531,7 +531,7 @@ unit = [
 [package.metadata]
 requires-dist = [
     { name = "charm-lib-interface-external-cloud-provider", git = "https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider?rev=e9cadd749ff8e2a6c81fadb0268a8b10e26876be" },
-    { name = "charm-lib-node-base", git = "https://github.com/charmed-kubernetes/layer-kubernetes-node-base?subdirectory=ops&rev=e35bbe08c1035849ed10a6838fa676c7847bc757" },
+    { name = "charm-lib-node-base", git = "https://github.com/charmed-kubernetes/layer-kubernetes-node-base?subdirectory=ops&rev=1bd8506cf1fdfcb584c50388c7082cc23a5ee14f" },
     { name = "charms-contextual-status" },
     { name = "charms-reconciler" },
     { name = "cosl" },


### PR DESCRIPTION
### Overview
This PR bumps the `node-base` dependency so that the AZ node labels will be applied according to the following PR:
- https://github.com/charmed-kubernetes/layer-kubernetes-node-base/pull/14

### Note to reviewer
The implementation and tests are done in the `layer-node-base` repo. But writing integration tests for this in the `k8s-operator` repo is impossible (for now). That’s because there’s no way to mock the `JUJU_AVAILABILITY_ZONE` environment variable and currently, the substrate that we’re running the tests on does not provide a `JUJU_AVAILABILITY_ZONE`. Maybe migrating to Openstack, AWS or MAAS will solve this issue. For now, I tested manually and deployed a charm on an AWS cloud with the latest changes and verified that we’re in fact setting the correct node labels. E.g.:
```
topology.kubernetes.io/zone=us-east-1a
```

The `layer-node-base` commit is based on the latest commit on main: https://github.com/charmed-kubernetes/layer-kubernetes-node-base/commit/1bd8506cf1fdfcb584c50388c7082cc23a5ee14f