### PR TITLE
[Backport 1.32] feat: Bump node-base to apply AZ node labels (#389)

### DIFF
--- a/.github/workflows/charm-analysis.yaml
+++ b/.github/workflows/charm-analysis.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   unit-tests:
-    uses: canonical/operator-workflows/.github/workflows/test.yaml@e848763f1e14d3169781fe95b4b896399a1a8a92
+    uses: canonical/operator-workflows/.github/workflows/test.yaml@20a9453a27acff804bebcad630cee0f07ef9e450
     secrets: inherit
     strategy:
       fail-fast: false

--- a/charms/worker/k8s/pyproject.toml
+++ b/charms/worker/k8s/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.8"
 dependencies = [
     "charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status@255dd4a23defc16dcdac832306e5f460a0f1200c",
     "charm-lib-interface-external-cloud-provider @ git+https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider@e9cadd749ff8e2a6c81fadb0268a8b10e26876be",
-    "charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@e35bbe08c1035849ed10a6838fa676c7847bc757#subdirectory=ops",
+    "charm-lib-node-base @ git+https://github.com/charmed-kubernetes/layer-kubernetes-node-base@1bd8506cf1fdfcb584c50388c7082cc23a5ee14f#subdirectory=ops",
     "charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@f818cc30d1a22be43ffdfecf7fbd9c3fd2967502",
     "ops-interface-kube-control==0.2.0",
     "ops.interface_aws @ git+https://github.com/charmed-kubernetes/interface-aws-integration@main#subdirectory=ops",

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -854,7 +854,7 @@ class K8sCharm(ops.CharmBase):
             "worker": self.model.relations.get(CLUSTER_WORKER_RELATION, []),
         }
 
-        waiting_units = {role: 0 for role in relation_config}
+        waiting_units = dict.fromkeys(relation_config, 0)
 
         for role, relations in relation_config.items():
             for relation in relations:

--- a/charms/worker/k8s/uv.lock
+++ b/charms/worker/k8s/uv.lock
@@ -87,7 +87,7 @@ dependencies = [
 [[package]]
 name = "charm-lib-node-base"
 version = "0.0.0"
-source = { git = "https://github.com/charmed-kubernetes/layer-kubernetes-node-base?subdirectory=ops&rev=e35bbe08c1035849ed10a6838fa676c7847bc757#e35bbe08c1035849ed10a6838fa676c7847bc757" }
+source = { git = "https://github.com/charmed-kubernetes/layer-kubernetes-node-base?subdirectory=ops&rev=1bd8506cf1fdfcb584c50388c7082cc23a5ee14f#1bd8506cf1fdfcb584c50388c7082cc23a5ee14f" }
 dependencies = [
     { name = "ops" },
 ]
@@ -396,7 +396,7 @@ unit = [
 requires-dist = [
     { name = "charm-lib-contextual-status", git = "https://github.com/charmed-kubernetes/charm-lib-contextual-status?rev=255dd4a23defc16dcdac832306e5f460a0f1200c" },
     { name = "charm-lib-interface-external-cloud-provider", git = "https://github.com/charmed-kubernetes/charm-lib-interface-external-cloud-provider?rev=e9cadd749ff8e2a6c81fadb0268a8b10e26876be" },
-    { name = "charm-lib-node-base", git = "https://github.com/charmed-kubernetes/layer-kubernetes-node-base?subdirectory=ops&rev=e35bbe08c1035849ed10a6838fa676c7847bc757" },
+    { name = "charm-lib-node-base", git = "https://github.com/charmed-kubernetes/layer-kubernetes-node-base?subdirectory=ops&rev=1bd8506cf1fdfcb584c50388c7082cc23a5ee14f" },
     { name = "charm-lib-reconciler", git = "https://github.com/charmed-kubernetes/charm-lib-reconciler?rev=f818cc30d1a22be43ffdfecf7fbd9c3fd2967502" },
     { name = "cosl" },
     { name = "httpx" },


### PR DESCRIPTION
### Overview
This PR bumps the node-base version to include the AZ node labels according to: https://github.com/charmed-kubernetes/layer-kubernetes-node-base/pull/14
Backports #389 