### PR TITLE
bug: Address issues where mulitple worker application join a k8s cluster

### DIFF
--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -510,8 +510,10 @@ requires:
     interface: azure-integration
   certificates:
     interface: tls-certificates
+    limit: 1
   etcd:
     interface: etcd
+    limit: 1
   external-cloud-provider:
     interface: external_cloud_provider
   gcp:


### PR DESCRIPTION
Applicable spec: KU-3276, Resolves issue #437 

### Overview

Multiple worker applications join the kubernetes cluster via various provider side relations offered by the k8s control-plane charm.  When there are multiple applications present, the charm code on the control plane side cannot use `ops.Model.get_relation` because more than 1 exists. 

### Rationale

Update these scenarios to instead use `ops.relations[<rel>]` which ops guarantees that if no relation exists, it will return an empty list (ie there's no fear of a `KeyError`) so long as the relation is defined in the charm's metadata.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

