### PR TITLE
Adjust multiple workers related to k8s control-plane

### DIFF
--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -199,7 +199,7 @@ config:
       description: |
         Sets the IP address of the dns service. If omitted defaults to the IP address
         of the Kubernetes service created by the feature.
-        
+
         Can be used to point to an external dns server when feature is disabled.
     dns-upstream-nameservers:
       type: string
@@ -207,7 +207,7 @@ config:
       description: |
         Space-separated list of upstream nameservers used to forward queries for out-of-cluster
         endpoints.
-        
+
         If omitted defaults to `/etc/resolv.conf` and uses the nameservers on each node.
     gateway-enabled:
       type: boolean
@@ -392,7 +392,7 @@ config:
       type: string
       description: |
         Labels can be used to organize and to select subsets of nodes in the
-        cluster. Declare node labels in key=value format, separated by spaces.      
+        cluster. Declare node labels in key=value format, separated by spaces.
 
 resources:
   snap-installation:
@@ -401,7 +401,7 @@ resources:
     description: |
       Override charm defined snap installation script
 
-      This charm is designed to operate with a specific revision of snaps, overriding 
+      This charm is designed to operate with a specific revision of snaps, overriding
       with anything will indicate that the charm is running an unsupported configuration.
 
       Content Options:
@@ -469,6 +469,7 @@ requires:
     interface: azure-integration
   etcd:
     interface: etcd
+    limit: 1
   external-cloud-provider:
     interface: external_cloud_provider
   gcp:

--- a/charms/worker/k8s/uv.lock
+++ b/charms/worker/k8s/uv.lock
@@ -447,7 +447,7 @@ wheels = [
 
 [[package]]
 name = "loadbalancer-interface"
-version = "1.2.0"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cached-property" },
@@ -457,9 +457,9 @@ dependencies = [
     { name = "ops" },
     { name = "ops-reactive-interface" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/37/3d1dab153000e8dd1799da06f3ababf29a434ec4cb13ad03839bad068385/loadbalancer_interface-1.2.0.tar.gz", hash = "sha256:f2b31a5bf25b0435eee696685af78082c8a93fbe85336755bea5b17392a584bd", size = 17460 }
+sdist = { url = "https://files.pythonhosted.org/packages/af/0a/1cbd5ef5501be133f609b972d7c69efa4e4f86ee9b9f40985fd5936f9399/loadbalancer_interface-1.2.1.tar.gz", hash = "sha256:4a20b979122ed6e4e3f8d12feacdade2063415fbb40340ddd1fe0b1074a65e2b", size = 17699 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/6b/4ef4718014382676723c7c95dce41926c138ed65eb8a63f84cbcf7e88ec3/loadbalancer_interface-1.2.0-py3-none-any.whl", hash = "sha256:26a90cdac756e8a9cbed0a0068a30d572fd103a7dfdd9627d8a5f4288ba9bd19", size = 24385 },
+    { url = "https://files.pythonhosted.org/packages/8b/41/ca5eeef6e72f662ca2fd9fcbe0c128f9e3b43c201d9ed1defcdaf0046494/loadbalancer_interface-1.2.1-py3-none-any.whl", hash = "sha256:11e37ea8952278cc5da3be8eddbc85809b4e4fd57ca8efae8762451221391a04", size = 24464 },
 ]
 
 [[package]]
@@ -573,11 +573,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "24.2"
+version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
 ]
 
 [[package]]


### PR DESCRIPTION
BACKPORT of #438

Applicable spec: KU-3276, Resolves issue #437 

### Overview

Multiple worker applications join the kubernetes cluster via various provider side relations offered by the k8s control-plane charm.  When there are multiple applications present, the charm code on the control plane side cannot use `ops.Model.get_relation` because more than 1 exists. 

### Rationale

Update these scenarios to instead use `ops.relations[<rel>]` which ops guarantees that if no relation exists, it will return an empty list (ie there's no fear of a `KeyError`) so long as the relation is defined in the charm's metadata.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

