### PR TITLE
fix: change local-storage description

### DIFF
--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -375,9 +375,9 @@ config:
       default: true
       description: |
         Enable local storage provisioning. This will create a storage class
-        named "local-storage" that uses the hostPath provisioner. This is
-        useful for development and testing purposes. It is not recommended for
-        production use.
+        named "local-storage" that uses the hostPath provisioner. Local storage
+        will not survive node removal, so it may not be suitable for certain
+        setups, such as production multi-node clusters.
     local-storage-local-path:
       type: string
       default: "/var/snap/k8s/common/rawfile-storage"

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -375,7 +375,7 @@ config:
       default: true
       description: |
         Enable local storage provisioning. This will create a storage class
-        named "local-storage" that uses the hostPath provisioner. Local storage
+        named "local-storage" that uses the rawfile-localpv provisioner. Local storage
         will not survive node removal, so it may not be suitable for certain
         setups, such as production multi-node clusters.
     local-storage-local-path:


### PR DESCRIPTION
### Overview

https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/storage/storage/ says:

> Local storage will not survive node removal, so it may not be suitable for certain setups, such as production multi-node clusters.

whereas https://charmhub.io/k8s/configurations#local-storage-enabled  says (for local-storage-enabled):

> This is useful for development and testing purposes. It is not recommended for production use.

The latter is inconsistent and confusing for users.