### PR TITLE
fix: drop focal

### DIFF
--- a/.github/workflows/download-charm.yaml
+++ b/.github/workflows/download-charm.yaml
@@ -13,7 +13,7 @@ on:
       charm-base:
         type: string
         description: The charm base to download
-        default: ubuntu@20.04
+        default: ubuntu@22.04
       charm-channel:
         type: string
         description: The charm channel to download

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ pip install 'tox>=4,<5'
 If you don't have `uv` installed, you can install it with:
 
 ```shell
-snap install astral-uv
+snap install astral-uv --classic
 ```
 
 You can create an environment for development with `uv`:
@@ -34,7 +34,7 @@ uv venv
 Or with an specific Python version:
 
 ```shell
-uv venv -p 3.8
+uv venv -p 3.10
 ```
 
 This will create a virtual environment in the `.venv` directory. You can

--- a/charms/worker/k8s/terraform/variables.tf
+++ b/charms/worker/k8s/terraform/variables.tf
@@ -13,8 +13,8 @@ variable "base" {
   default     = "ubuntu@24.04"
 
   validation {
-    condition     = contains(["ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"], var.base)
-    error_message = "Base must be one of ubuntu@20.04, ubuntu@22.04, ubuntu@24.04"
+    condition     = contains(["ubuntu@22.04", "ubuntu@24.04"], var.base)
+    error_message = "Base must be one of ubuntu@22.04, ubuntu@24.04"
   }
 }
 

--- a/charms/worker/terraform/variables.tf
+++ b/charms/worker/terraform/variables.tf
@@ -13,8 +13,8 @@ variable "base" {
   default     = "ubuntu@24.04"
 
   validation {
-    condition     = contains(["ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04"], var.base)
-    error_message = "Base must be one of ubuntu@20.04, ubuntu@22.04, ubuntu@24.04"
+    condition     = contains(["ubuntu@22.04", "ubuntu@24.04"], var.base)
+    error_message = "Base must be one of ubuntu@22.04, ubuntu@24.04"
   }
 }
 


### PR DESCRIPTION
### Overview

Focal is out of support, this PR drops it.
Tiny nit to the docs.

### Rationale

Focal is out of support.

### Juju Events Changes

NA

### Module Changes

NA

### Library Changes

NA

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
