### PR TITLE
The promote-charm action needs the checked-out code for access to metadata

### DIFF
--- a/.github/workflows/promote-charms.yaml
+++ b/.github/workflows/promote-charms.yaml
@@ -80,6 +80,7 @@ jobs:
       matrix:
         charm: ${{ fromJson(needs.select-charms.outputs.charms) }}
     steps:
+    - uses: actions/checkout@v4
     - uses: canonical/charming-actions/promote-charm@2.7.0
       with:
         credentials: ${{ secrets.CHARMHUB_TOKEN }}


### PR DESCRIPTION
Without access to the `charmcraft.yaml`, the promote-charm action cannot perform metadata inspection from the charm file. 

So, we must checkout