### PR TITLE
fix: remove snaps during removal related events

### DIFF
--- a/charms/worker/k8s/pyproject.toml
+++ b/charms/worker/k8s/pyproject.toml
@@ -34,3 +34,6 @@ unit = [
     "pytest>=8.3.4",
     "pytest-sugar"
 ]
+
+[tool.pyright]
+extraPaths = ["src", "lib"]

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -1048,6 +1048,7 @@ class K8sCharm(ops.CharmBase):
             self._revoke_cluster_tokens(event)
         self.update_status.run()
         self._last_gasp()
+        snap_management(self, remove=True)
 
         relation = self.model.get_relation(CLUSTER_RELATION)
         local_cluster = self.get_cluster_name()

--- a/charms/worker/k8s/src/snap.py
+++ b/charms/worker/k8s/src/snap.py
@@ -277,11 +277,12 @@ def _parse_management_arguments(charm: ops.CharmBase) -> List[SnapArgument]:
     return args
 
 
-def management(charm: K8sCharmProtocol) -> None:
+def management(charm: K8sCharmProtocol, remove: bool = False) -> None:
     """Manage snap installations on this machine.
 
     Arguments:
         charm: The charm instance
+        remove: Whether to remove the snaps instead of installing/updating them
 
     Raises:
         SnapError: when the management issue cannot be resolved
@@ -289,6 +290,9 @@ def management(charm: K8sCharmProtocol) -> None:
     cache = snap_lib.SnapCache()
     for args in _parse_management_arguments(charm):
         which: snap_lib.Snap = cache[args.name]
+        if remove:
+            which.ensure(snap_lib.SnapState.Absent)
+            continue
         if block_refresh(which, args, charm.is_upgrade_granted):
             continue
         install_args = args.model_dump(exclude_none=True)


### PR DESCRIPTION
### Overview

The `k8s` and `k8s-worker` charms now remove installed snaps during charm removal.

### Rationale

Previously, installed snaps were not removed when tearing down the unit. This pull request adds support for the `management` method to ensure snaps are removed only during removal related events in Juju.

### Testing
Manual testing:
```
❯ juju remove-application k8s
WARNING This command will perform the following actions:
will remove application k8s
- will remove unit k8s/0

Continue [y/N]? y

Every 2.0s: snap list                                                                juju-1c33ed-1: Mon May  5 20:33:31 2025

Name    Version        Rev    Tracking       Publisher    Notes
core20  20230308       1852   latest/stable  canonical**  base
k8s     v1.33.0        3416   latest/edge    canonical**  classic,held
lxd     5.0.2-838e1b2  24322  5.0/stable/…   canonical**  -
snapd   2.59.1         18933  latest/stable  canonical**  snapd

Every 2.0s: snap list                                                                juju-1c33ed-1: Mon May  5 20:34:54 2025

Name    Version        Rev    Tracking       Publisher    Notes
core20  20230308       1852   latest/stable  canonical**  base
lxd     5.0.2-838e1b2  24322  5.0/stable/…   canonical**  -
snapd   2.59.1         18933  latest/stable  canonical**  snapd
```
