### PR TITLE
Read quoted argument for containerd config path

### DIFF
--- a/charms/worker/k8s/src/containerd.py
+++ b/charms/worker/k8s/src/containerd.py
@@ -41,7 +41,8 @@ def containerd_path() -> Path:
     """
     for line in CONTAINERD_ARGS.read_text().splitlines():
         if line.startswith("--config="):
-            return Path(line.split("=")[1]).parent
+            path = line.split("=")[1].strip('"').strip("'")
+            return Path(path).parent
     raise FileNotFoundError("Could not find containerd config path in args file.")
 
 


### PR DESCRIPTION
### Overview

With the quoted arguments in `/var/snap/k8s/common/args/containerd`, the charm needs to unquote them before using them as a path.

### Details
previously `/var/snap/k8s/common/args/containerd` contained

```
--config=/etc/containerd/config.toml
```

but now is:
```
--config="/etc/containerd/config.toml"
```

The charm should handle EITHER of these kinds of paths whether quoted or not.  So, we just need to strip any quotes


