### PR TITLE
fix: Use TIOBE TiCS action

### DIFF
--- a/.github/workflows/tiobe-tics-cron.yaml
+++ b/.github/workflows/tiobe-tics-cron.yaml
@@ -1,10 +1,10 @@
 name: TICS nightly quality scan
 
 on:
-  pull_request:
   workflow_dispatch:
-  schedule:
-    - cron: '0 10 * * *'
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Use the upstream TIOBE action.
