### PR TITLE
Adjust the default to expose to all cidrs

### DIFF
--- a/charms/worker/k8s/terraform/main.tf
+++ b/charms/worker/k8s/terraform/main.tf
@@ -13,9 +13,13 @@ resource "juju_application" "k8s" {
   }
 
   expose {
-    cidrs     = var.expose.cidrs
-    endpoints = var.expose.endpoints
-    spaces    = var.expose.spaces
+    # if var.expose doesn't have a cidrs key, default to "0.0.0.0/0"
+    # if var.expose.cidrs = null, don't expose the application
+    cidrs = contains(try(keys(var.expose), []), "cidrs") ? var.expose.cidrs : "0.0.0.0/0"
+    # if var.expose.endpoints exists, expose via endpoints
+    endpoints = try(var.expose.endpoints, null)
+    # if var.expose.spaces exists, expose via spaces
+    spaces    = try(var.expose.spaces, null)
   }
 
   config      = var.config

--- a/charms/worker/k8s/terraform/variables.tf
+++ b/charms/worker/k8s/terraform/variables.tf
@@ -60,10 +60,18 @@ variable "units" {
 
 variable "expose" {
   description = "How to expose the Kubernetes API endpoint"
-  type        = map(string)
-  default     = {
-    cidrs      = "0.0.0.0/0"
-    endpoints  = null
-    spaces     = null
+  type = object({
+    cidrs     = optional(string)
+    endpoints = optional(string)
+    spaces    = optional(string)
+  })
+  default     = null
+
+  validation {
+    condition = (
+      var.expose == null ||
+      can(var.expose.cidrs) || can(var.expose.endpoints) || can(var.expose.spaces)
+    )
+    error_message = "If provided, expose must be an object with any keys: cidrs, endpoints, spaces."
   }
 }

--- a/charms/worker/k8s/terraform/variables.tf
+++ b/charms/worker/k8s/terraform/variables.tf
@@ -62,7 +62,7 @@ variable "expose" {
   description = "How to expose the Kubernetes API endpoint"
   type        = map(string)
   default     = {
-    cidrs      = "0.0.0.0/32"
+    cidrs      = "0.0.0.0/0"
     endpoints  = null
     spaces     = null
   }

--- a/charms/worker/k8s/terraform/variables.tf
+++ b/charms/worker/k8s/terraform/variables.tf
@@ -60,18 +60,16 @@ variable "units" {
 
 variable "expose" {
   description = "How to expose the Kubernetes API endpoint"
-  type = object({
-    cidrs     = optional(string)
-    endpoints = optional(string)
-    spaces    = optional(string)
-  })
+  type        = map(string)
   default     = null
 
   validation {
     condition = (
+      # If expose is null, it's valid
       var.expose == null ||
-      can(var.expose.cidrs) || can(var.expose.endpoints) || can(var.expose.spaces)
+      # If expose is a map, it can only contain specific keys
+      length(setsubtract(keys(var.expose), ["cidrs", "endpoints", "spaces"])) == 0
     )
-    error_message = "If provided, expose must be an object with any keys: cidrs, endpoints, spaces."
+    error_message = "If provided, expose must only contain the keys: cidrs, endpoints, spaces."
   }
 }


### PR DESCRIPTION
By default, expose to all CIDR ranges

this is equivalent to 
```sh
juju expose k8s
```


See notes from `juju expose --help`

> If no additional options are specified, the command will, by default, allow
access from 0.0.0.0/0 to all ports opened by the application. For example, to
expose all ports opened by apache2, you can run:
