### PR TITLE
deps: Bump k8s snap revision to candidate

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 3592
+  revision: 3707
 arm64:
 - install-type: store
   name: k8s
-  revision: 3594
+  revision: 3705


### PR DESCRIPTION
### Overview
This PR bumps k8s snap revision to the latest available in candidate.
```
1.33-classic  amd64   stable                                                                       v1.33.1    3592        -           -
                      candidate                                                                    v1.33.1    3707        -           -
                      beta                                                                         v1.33.1    3707        -           -
                      edge                                                                         v1.33.1    3707        -           -
              arm64   stable                                                                       v1.33.1    3594        -           -
                      candidate                                                                    v1.33.1    3705        -           -
                      beta                                                                         v1.33.1    3705        -           -
                      edge                                                                         v1.33.1    3705        -           -
```