### PR TITLE
Skip publishing libs and docs

### DIFF
--- a/.github/workflows/publish-charms.yaml
+++ b/.github/workflows/publish-charms.yaml
@@ -53,7 +53,9 @@ jobs:
     secrets: inherit
     with:
       channel: ${{needs.configure-channel.outputs.track}}/${{needs.configure-channel.outputs.risk}}
-      working-directory: ${{ matrix.charm.path }}
       charmcraft-channel: ${{ needs.charmcraft-channel.outputs.channel }}
-      tag-prefix: ${{ matrix.charm.tagPrefix }}
       identifier: ${{matrix.arch}}
+      publish-libs: false
+      publish-docs: false
+      tag-prefix: ${{ matrix.charm.tagPrefix }}
+      working-directory: ${{ matrix.charm.path }}


### PR DESCRIPTION
### Overview
* Don't try to publish the docs or libs from this repo automatically

### Depends on
* https://github.com/canonical/operator-workflows/pull/689