### PR TITLE
deps: Bump k8s snap revision

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 3725
+  revision: 3739
 arm64:
 - install-type: store
   name: k8s
-  revision: 3726
+  revision: 3745


### PR DESCRIPTION
### Overview
This PR bumps k8s snap revisions for both AMD and ARM.


```
1.33-classic  amd64   stable                                                                       v1.33.1    3739        -           -
                      candidate                                                                    v1.33.1    3739        -           -
                      beta                                                                         v1.33.1    3739        -           -
                      edge                                                                         v1.33.1    3739        -           -
              arm64   stable                                                                       v1.33.1    3745        -           -
                      candidate                                                                    v1.33.1    3745        -           -
                      beta                                                                         v1.33.1    3745        -           -
                      edge                                                                         v1.33.1    3745        -           -
```