### PR TITLE
[release-1.32] fix: improve cluster name logic

### DIFF
--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -356,17 +356,23 @@ class K8sCharm(ops.CharmBase):
         """
         unit, node = self.unit.name, self.get_node_name()
         if self._stored.cluster_name == "":
-            if self.lead_control_plane and self.api_manager.is_cluster_bootstrapped():
+            if self.lead_control_plane:
+                log.info("Lead control plane node %s generating unique cluster name.", node)
                 self._stored.cluster_name = self._generate_unique_cluster_name()
             elif not (relation := self.model.get_relation(CLUSTER_RELATION)):
-                pass
-            elif any(
-                [
-                    self.is_control_plane and self.api_manager.is_cluster_bootstrapped(),
-                    k8s.node.present(self.kubeconfig, node) == k8s.node.Presence.AVAILABLE,
-                ]
-            ):
+                log.warning(
+                    "Node %s has no '%s' relation, cannot determine cluster name.",
+                    node,
+                    CLUSTER_RELATION,
+                )
+            elif (
+                result := k8s.node.present(self.kubeconfig, node)
+            ) != k8s.node.Presence.AVAILABLE:
+                log.warning("Node %s, is not available in cluster (status %s).", node, result)
+            elif self.is_worker or self.api_manager.is_cluster_bootstrapped():
                 self._stored.cluster_name = self.collector.cluster_name(relation, True)
+            else:
+                log.warning("Node %s isn't bootstrapped, skipping cluster name.", node)
 
         log.info("%s(%s) current cluster-name=%s", unit, node, self._stored.cluster_name)
         return str(self._stored.cluster_name)


### PR DESCRIPTION
### Overview

Set the cluster name during bootstrap and use it to bootstrap the cluster.

### Rationale

The original logic for handling the cluster name wasn't working correctly, leading to an empty cluster name during bootstrap. Also, the logic has been improved to prevent a node from being marked as bootstrapped prematurely, using the node list as a safeguard. The PR also includes some improvements to the logging, in order to surface these conditions to the debug log.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
