### PR TITLE
deps: Bump k8s snap revision

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 3739
+  revision: 3840
 arm64:
 - install-type: store
   name: k8s
-  revision: 3745
+  revision: 3841


### PR DESCRIPTION
### Overview

This PR bumps k8s revisions to 1.33-classic/edge.

```
1.33-classic  amd64   stable                                                                       v1.33.1    3739        -           -
                      candidate                                                                    v1.33.2    3804        -           -
                      beta                                                                         v1.33.2    3819        -           -
                      edge                                                                         v1.33.2    3840        -           -
              arm64   stable                                                                       v1.33.1    3745        -           -
                      candidate                                                                    v1.33.1    3745        -           -
                      beta                                                                         v1.33.2    3820        -           -
                      edge                                                                         v1.33.2    3841        -           -
                      edge/louise-embedded-etcd-1.33.2                                             v1.33.2    3815        -           2025-07-27T00:00:00Z
                      edge/louise-embedded-etcd                                                    v1.33.1    3797        -           2025-07-25T00:00:00Z
```