### PR TITLE
chore: safely set datastore in case of dqlite

### DIFF
--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -680,7 +680,8 @@ class K8sCharm(ops.CharmBase):
                 config.datastore.client_key = etcd_config.get("client_key", "")
                 log.info("etcd servers: %s", config.datastore.servers)
 
-        elif datastore == "dqlite":
+        elif datastore == "dqlite" and isinstance(config, BootstrapConfig):
+            config.datastore_type = "k8s-dqlite"
             log.info("Using dqlite as datastore")
 
     def _revoke_cluster_tokens(self, event: ops.EventBase):

--- a/charms/worker/k8s/tests/unit/test_base.py
+++ b/charms/worker/k8s/tests/unit/test_base.py
@@ -196,7 +196,7 @@ def test_configure_datastore_bootstrap_config_dqlite(harness):
     assert bs_config.datastore_client_cert is None
     assert bs_config.datastore_client_key is None
     assert bs_config.datastore_servers is None
-    assert bs_config.datastore_type is None
+    assert bs_config.datastore_type == "k8s-dqlite"
 
 
 def test_configure_datastore_bootstrap_config_etcd(harness):


### PR DESCRIPTION
This PR suggests charm actively set the datastore in the bootstrap config file. 