### PR TITLE
deps: Bump k8s snap revision

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 3842
+  revision: 3890
 arm64:
 - install-type: store
   name: k8s
-  revision: 3845
+  revision: 3896


### PR DESCRIPTION
### Overview

This PR bumps k8s snap revision to the ones with the feature controller fix.

```
1.32-classic  amd64   stable                            v1.32.6    3803        -           -
                      candidate                         v1.32.6    3842        -           -
                      beta                              v1.32.6    3842        -           -
                      edge                              v1.32.6    3890        -           -
                      edge/hue-serialize-cilium         v1.32.6    3864        -           2025-08-07T00:00:00Z
                      edge/fix-helm-stuck-4100a         v1.32.6    3873        -           2025-08-08T00:00:00Z
                      candidate/fips-preview            v1.32.5    3685        -           2025-07-12T00:00:00Z
                      candidate/fips-early-release      v1.32.6    3816        -           2025-07-27T00:00:00Z
              arm64   stable                            v1.32.6    3806        -           -
                      candidate                         v1.32.6    3845        -           -
                      beta                              v1.32.6    3845        -           -
                      edge                              v1.32.6    3896        -           -
```