### PR TITLE
deps: Bump k8s snap revision

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 3840
+  revision: 3897
 arm64:
 - install-type: store
   name: k8s
-  revision: 3841
+  revision: 3900


### PR DESCRIPTION
### Overview

This PR bumps k8s snap revision to the ones with the feature controller fix.

```
1.33-classic  amd64   stable                            v1.33.2    3804        -           -
                      candidate                         v1.33.2    3840        -           -
                      beta                              v1.33.2    3840        -           -
                      edge                              v1.33.2    3897        -           -
              arm64   stable                            v1.33.1    3745        -           -
                      candidate                         v1.33.2    3841        -           -
                      beta                              v1.33.2    3841        -           -
                      edge                              v1.33.2    3900        -           -
                      edge/louise-refresh-fix-2         v1.33.2    3859        -           2025-08-07T00:00:00Z
                      edge/louise-refresh-fix           v1.33.2    3858        -           2025-08-07T00:00:00Z
                      edge/louise-embedded-etcd-1.33.2  v1.33.2    3815        -           2025-07-27T00:00:00Z
                      edge/louise-embedded-etcd         v1.33.1    3797        -           2025-07-25T00:00:00Z

```