### PR TITLE
chore: safely set datastore in case of dqlite (#560)

### DIFF
--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -751,7 +751,8 @@ class K8sCharm(ops.CharmBase):
                 config.datastore.client_key = etcd_config.get("client_key", "")
                 log.info("etcd servers: %s", config.datastore.servers)
 
-        elif datastore == "dqlite":
+        elif datastore == "dqlite" and isinstance(config, BootstrapConfig):
+            config.datastore_type = "k8s-dqlite"
             log.info("Using dqlite as datastore")
 
     def _revoke_cluster_tokens(self, event: ops.EventBase):

--- a/charms/worker/k8s/tests/unit/test_base.py
+++ b/charms/worker/k8s/tests/unit/test_base.py
@@ -196,7 +196,7 @@ def test_configure_datastore_bootstrap_config_dqlite(harness):
     assert bs_config.datastore_client_cert is None
     assert bs_config.datastore_client_key is None
     assert bs_config.datastore_servers is None
-    assert bs_config.datastore_type is None
+    assert bs_config.datastore_type == "k8s-dqlite"
 
 
 def test_configure_datastore_bootstrap_config_etcd(harness):


### PR DESCRIPTION
### Overview

This PR backports https://github.com/canonical/k8s-operator/pull/560 so that charm e2e tests on k8s-snap 1.33 branch will pass.