### PR TITLE
fix: Upgrade pip before e2e tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,8 @@ commands =
 
 [testenv:{integration,integration-k8s,integration-etcd,integration-ceph,integration-upgrade}]
 description = Run integration tests
+commands_pre = 
+    python3 -m pip install --upgrade pip
 deps = -r test_requirements.txt
 commands =
     pytest -v --tb native \


### PR DESCRIPTION
### Overview
This PR aims to fix the following error in the "charm e2e test" job of k8s-snap:
```
File "/home/ubuntu/actions-runner/_work/k8s-snap/k8s-snap/k8s-operator/.tox/integration/lib/python3.10/site-packages/pip/_internal/commands/install.py", line 389, in run
    to_install = resolver.get_installation_order(requirement_set)
  File "/home/ubuntu/actions-runner/_work/k8s-snap/k8s-snap/k8s-operator/.tox/integration/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 188, in get_installation_order
    weights = get_topological_weights(
  File "/home/ubuntu/actions-runner/_work/k8s-snap/k8s-snap/k8s-operator/.tox/integration/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 276, in get_topological_weights
    assert len(weights) == expected_node_count
AssertionError
```
Seems like it's related to pip version:
- https://github.com/pypa/pip/issues/10851
- https://stackoverflow.com/questions/72060948/pip-fails-to-install-long-requirements-txt-on-22-04-kubuntu-ubuntu
- https://github.com/readthedocs/readthedocs.org/issues/8864