### PR TITLE
Apply charm extra-args at runtime

### DIFF
--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -29,6 +29,7 @@ from time import sleep
 from typing import Dict, FrozenSet, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
+import config.arg_files
 import config.bootstrap
 import config.extra_args
 import containerd
@@ -94,6 +95,7 @@ from typing_extensions import Literal
 from upgrade import K8sDependenciesModel, K8sUpgrade
 
 import charms.contextual_status as status
+import charms.node_base.address as node_address
 import charms.operator_libs_linux.v2.snap as snap_lib
 from charms.contextual_status import ReconcilerError, on_error
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
@@ -452,6 +454,15 @@ class K8sCharm(ops.CharmBase):
                 dns_sans.add(san)
         return frozenset(ip_sans), frozenset(dns_sans)
 
+    def _get_node_ips(self) -> List[str]:
+        """Get the cluster node addresses for this unit.
+
+        Returns:
+            list[str]: A list containing up to two IP addresses for each IP
+                version.
+        """
+        return node_address.by_relation_preferred(self, CLUSTER_RELATION, True)
+
     def _get_extra_sans(self):
         """Retrieve the certificate extra SANs.
 
@@ -464,11 +475,9 @@ class K8sCharm(ops.CharmBase):
 
         # Add the ingress addresses of all units
         extra_sans.add(_get_juju_public_address())
-        binding = self.model.get_binding(CLUSTER_RELATION)
-        addresses = binding and binding.network.ingress_addresses
-        if addresses:
+        if addresses := node_address.by_relation(self, CLUSTER_RELATION, True):
             log.info("Adding ingress addresses to extra SANs")
-            extra_sans |= {str(addr) for addr in addresses}
+            extra_sans |= set(addresses)
 
         # Add the external load balancer address
         try:
@@ -497,7 +506,8 @@ class K8sCharm(ops.CharmBase):
         bootstrap_config.control_plane_taints = BOOTSTRAP_NODE_TAINTS.get(self).split()
         bootstrap_config.extra_sans = self._get_extra_sans()
         cluster_name = self.get_cluster_name()
-        config.extra_args.craft(self.config, bootstrap_config, cluster_name)
+        node_ips = self._get_node_ips()
+        config.extra_args.craft(self.config, bootstrap_config, cluster_name, node_ips)
         return bootstrap_config
 
     def _configure_external_load_balancer(self) -> None:
@@ -551,14 +561,14 @@ class K8sCharm(ops.CharmBase):
             log.info("K8s cluster already bootstrapped")
             return
 
-        status.add(ops.MaintenanceStatus("Bootstrapping Cluster"))
+        if not (node_ips := self._get_node_ips()):
+            log.info("Cannot cluster yet, no node IPs found")
+            raise ReconcilerError("No node IPs found")
 
-        binding = self.model.get_binding("cluster")
-        address = binding and binding.network.ingress_address
-        node_name = self.get_node_name()
+        status.add(ops.MaintenanceStatus("Bootstrapping Cluster"))
         payload = CreateClusterRequest(
-            name=node_name,
-            address=f"{address}:{K8SD_PORT}",
+            name=self.get_node_name(),
+            address=f"{node_ips[0]}:{K8SD_PORT}",
             config=self._assemble_bootstrap_config(),
         )
 
@@ -943,29 +953,27 @@ class K8sCharm(ops.CharmBase):
         with self.collector.recover_token(relation) as token:
             remote_cluster = self.collector.cluster_name(relation, False) if relation else ""
             self.cloud_integration.integrate(remote_cluster, event)
-            self._join_with_token(relation, token, remote_cluster)
+            self._join_with_token(token, remote_cluster)
 
-    def _join_with_token(self, relation: ops.Relation, token: str, cluster_name: str):
+    def _join_with_token(self, token: str, cluster_name: str):
         """Join the cluster with the given token.
 
         Args:
-            relation (ops.Relation): The relation to use for the token.
             token (str): The token to use for joining the cluster.
             cluster_name (str): The name of the cluster to join.
         """
-        binding = self.model.get_binding(relation.name)
-        address = binding and binding.network.ingress_address
+        node_ips = self._get_node_ips()
         node_name = self.get_node_name()
-        cluster_addr = f"{address}:{K8SD_PORT}"
+        cluster_addr = f"{node_ips[0]}:{K8SD_PORT}"
         log.info("Joining %s(%s) to %s...", self.unit, node_name, cluster_name)
         request = JoinClusterRequest(name=node_name, address=cluster_addr, token=SecretStr(token))
         if self.is_control_plane:
             request.config = ControlPlaneNodeJoinConfig()
             request.config.extra_sans = self._get_extra_sans()
-            config.extra_args.craft(self.config, request.config, cluster_name)
+            config.extra_args.craft(self.config, request.config, cluster_name, node_ips)
         else:
             request.config = NodeJoinConfig()
-            config.extra_args.craft(self.config, request.config, cluster_name)
+            config.extra_args.craft(self.config, request.config, cluster_name, node_ips)
 
             bootstrap_node_taints = BOOTSTRAP_NODE_TAINTS.get(self).strip().split()
             config.extra_args.taint_worker(request.config, bootstrap_node_taints)
@@ -1031,6 +1039,7 @@ class K8sCharm(ops.CharmBase):
         self._configure_cos_integration()
         self.update_status.run()
         self._apply_node_labels()
+        self._apply_extra_args()
         if self.is_control_plane:
             self._copy_internal_kubeconfig()
             self._expose_ports()
@@ -1105,6 +1114,15 @@ class K8sCharm(ops.CharmBase):
             log.info("Node %s labelled successfully", node)
         else:
             log.info("Node %s not yet labelled", node)
+
+    def _apply_extra_args(self):
+        """Apply extra args to the node."""
+        if cluster_name := self.get_cluster_name():
+            status.add(ops.MaintenanceStatus("Ensuring Kubernetes Extra Args"))
+            file_args_config = config.arg_files.FileArgsConfig()
+            node_ips = self._get_node_ips()
+            config.extra_args.craft(self.config, file_args_config, cluster_name, node_ips)
+            file_args_config.ensure()
 
     @property
     def kubeconfig(self) -> Path:

--- a/charms/worker/k8s/src/config/arg_files.py
+++ b/charms/worker/k8s/src/config/arg_files.py
@@ -1,0 +1,177 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Learn more at: https://juju.is/docs/sdk
+
+"""Configuration for kubernetes services.
+
+The format for each file is a set of key-value pairs, where each line contains a key and its value.
+"""
+
+import logging
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from literals import (
+    CHARM_SYSD_ARGS_FILE,
+    KUBE_APISERVER_ARGS_PATH,
+    KUBE_APISERVER_SYSD_PATH,
+    KUBE_CONTROLLER_MANAGER_ARGS_PATH,
+    KUBE_CONTROLLER_MANAGER_SYSD_PATH,
+    KUBE_PROXY_ARGS_PATH,
+    KUBE_PROXY_SYSD_PATH,
+    KUBE_SCHEDULER_ARGS_PATH,
+    KUBE_SCHEDULER_SYSD_PATH,
+    KUBELET_ARGS_PATH,
+    KUBELET_SYSD_PATH,
+    SNAP_NAME,
+    SNAP_SYSD_ARGS_FILE,
+)
+
+import charms.operator_libs_linux.v2.snap as snap
+
+log = logging.getLogger(__name__)
+FileArgs = Dict[str, Optional[str]]
+
+
+@dataclass
+class ServiceConfig:
+    """Configuration for a single Kubernetes service."""
+
+    name: str
+    args_path: Path
+    systemd_args_path: Path
+    extra_args: FileArgs
+
+
+class FileArgsConfig:
+    """Configuration for file arguments."""
+
+    def __init__(self):
+        self.extra_node_kube_apiserver_args = {}
+        self.extra_node_kube_controller_manager_args = {}
+        self.extra_node_kube_scheduler_args = {}
+        self.extra_node_kube_proxy_args = {}
+        self.extra_node_kubelet_args = {}
+
+        self._service_args: Dict[str, FileArgs] = {}
+        self._file_hashes: Dict[str, bytes] = {}
+        self._load()
+
+    def _get_service_configs(self) -> List[ServiceConfig]:
+        """Get the k8s service configurations."""
+        return [
+            ServiceConfig(
+                name="kube-apiserver",
+                args_path=KUBE_APISERVER_ARGS_PATH,
+                systemd_args_path=KUBE_APISERVER_SYSD_PATH / SNAP_SYSD_ARGS_FILE,
+                extra_args=self.extra_node_kube_apiserver_args,
+            ),
+            ServiceConfig(
+                name="kube-controller-manager",
+                args_path=KUBE_CONTROLLER_MANAGER_ARGS_PATH,
+                systemd_args_path=KUBE_CONTROLLER_MANAGER_SYSD_PATH / SNAP_SYSD_ARGS_FILE,
+                extra_args=self.extra_node_kube_controller_manager_args,
+            ),
+            ServiceConfig(
+                name="kube-scheduler",
+                args_path=KUBE_SCHEDULER_ARGS_PATH,
+                systemd_args_path=KUBE_SCHEDULER_SYSD_PATH / SNAP_SYSD_ARGS_FILE,
+                extra_args=self.extra_node_kube_scheduler_args,
+            ),
+            ServiceConfig(
+                name="kube-proxy",
+                args_path=KUBE_PROXY_ARGS_PATH,
+                systemd_args_path=KUBE_PROXY_SYSD_PATH / SNAP_SYSD_ARGS_FILE,
+                extra_args=self.extra_node_kube_proxy_args,
+            ),
+            ServiceConfig(
+                name="kubelet",
+                args_path=KUBELET_ARGS_PATH,
+                systemd_args_path=KUBELET_SYSD_PATH / SNAP_SYSD_ARGS_FILE,
+                extra_args=self.extra_node_kubelet_args,
+            ),
+        ]
+
+    def _get_effective_args_path(self, service: ServiceConfig) -> Path:
+        """Get the effective arguments file path for a service."""
+        if service.systemd_args_path.exists():
+            return service.systemd_args_path.parent / CHARM_SYSD_ARGS_FILE
+        return service.args_path
+
+    def _load_file(self, file_path: Path) -> Tuple[FileArgs, bytes]:
+        """Load the arguments from a file.
+
+        Args:
+            file_path: the path to the file containing the arguments.
+
+        Returns:
+            A dictionary of arguments and the hash of the file content.
+        """
+        args: FileArgs = {}
+        contents = file_path.read_text()
+        hash_val = sha256(contents.encode()).digest()
+        for line in contents.splitlines():
+            if line.startswith("--"):
+                key, value = line.split("=", 1)
+                args[key] = value.strip('"').strip("'")
+        return args, hash_val
+
+    def _generate_file_content(self, args: FileArgs) -> Tuple[str, bytes]:
+        """Generate the content for the file and its hash.
+
+        Args:
+            args: a dictionary of arguments to save.
+
+        Returns:
+            The content to save in the file and the hash of the content.
+        """
+        lines = []
+        # Sort the arguments to ensure consistent ordering
+        for key, value in sorted(args.items()):
+            # Drop argument values that may be None
+            if value is not None:
+                quoted = value.strip("'").strip('"')
+                lines.append(f'{key}="{quoted}"\n')
+        content = "".join(lines)
+        hash_val = sha256(content.encode()).digest()
+        return content, hash_val
+
+    def _restart_services(self, services: List[str]):
+        """Restart the k8s services.
+
+        Args:
+            services: the names of the services to restart.
+        """
+        if services:
+            cache = snap.SnapCache()
+            log.info("Restarting services: %s", ", ".join(services))
+            cache[SNAP_NAME].restart(services)
+
+    def _load(self):
+        """Load the arguments for each service from the files."""
+        for service in self._get_service_configs():
+            file_path = self._get_effective_args_path(service)
+            if file_path.exists():
+                args, file_hash = self._load_file(file_path)
+                self._service_args[service.name] = args
+                self._file_hashes[service.name] = file_hash
+
+    def ensure(self):
+        """Ensure the arguments of each file."""
+        adjusted_services: List[str] = []
+        for service in self._get_service_configs():
+            file_path = self._get_effective_args_path(service)
+            if not file_path.exists():
+                log.debug("Skipping non-existent arguments file: %s", file_path)
+                continue
+
+            updated_args = {**self._service_args[service.name], **service.extra_args}
+            content, hash_val = self._generate_file_content(updated_args)
+            if hash_val != self._file_hashes[service.name]:
+                log.info("Updating arguments for %s at %s", service.name, file_path)
+                file_path.write_text(content)
+                adjusted_services.append(service.name)
+        self._restart_services(adjusted_services)

--- a/charms/worker/k8s/src/config/arg_files.py
+++ b/charms/worker/k8s/src/config/arg_files.py
@@ -135,7 +135,7 @@ class FileArgsConfig:
             if value is not None:
                 quoted = value.strip("'").strip('"')
                 lines.append(f'{key}="{quoted}"\n')
-        content = "".join(lines)
+        content = "".join(sorted(lines))
         hash_val = sha256(content.encode()).digest()
         return content, hash_val
 
@@ -168,8 +168,18 @@ class FileArgsConfig:
                 log.debug("Skipping non-existent arguments file: %s", file_path)
                 continue
 
-            updated_args = {**self._service_args[service.name], **service.extra_args}
-            content, hash_val = self._generate_file_content(updated_args)
+            updated_args = self._service_args.get(service.name, {}).copy()
+            if service.extra_args:
+                updated_args.update(service.extra_args)
+
+            args_to_remove = {key.rstrip("-") for key in updated_args if key.endswith("-")}
+            filtered_args = {
+                arg: value
+                for arg, value in updated_args.items()
+                if arg not in args_to_remove and arg.rstrip("-") not in args_to_remove
+            }
+
+            content, hash_val = self._generate_file_content(filtered_args)
             if hash_val != self._file_hashes[service.name]:
                 log.info("Updating arguments for %s at %s", service.name, file_path)
                 file_path.write_text(content)

--- a/charms/worker/k8s/src/config/arg_files.py
+++ b/charms/worker/k8s/src/config/arg_files.py
@@ -168,15 +168,13 @@ class FileArgsConfig:
                 log.debug("Skipping non-existent arguments file: %s", file_path)
                 continue
 
-            updated_args = self._service_args.get(service.name, {}).copy()
-            if service.extra_args:
-                updated_args.update(service.extra_args)
+            updated_args = {**self._service_args.get(service.name, {}), **service.extra_args}
 
             args_to_remove = {key.rstrip("-") for key in updated_args if key.endswith("-")}
             filtered_args = {
                 arg: value
                 for arg, value in updated_args.items()
-                if arg not in args_to_remove and arg.rstrip("-") not in args_to_remove
+                if arg.rstrip("-") not in args_to_remove
             }
 
             content, hash_val = self._generate_file_content(filtered_args)

--- a/charms/worker/k8s/src/config/extra_args.py
+++ b/charms/worker/k8s/src/config/extra_args.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Union
 
 import literals
 import ops
+from config.arg_files import FileArgsConfig
 
 from charms.k8s.v0.k8sd_api_manager import (
     BootstrapConfig,
@@ -36,8 +37,9 @@ def _parse(config_data) -> Dict[str, str]:
 
 def craft(
     src: ops.ConfigData,
-    dest: Union[BootstrapConfig, ControlPlaneNodeJoinConfig, NodeJoinConfig],
+    dest: Union[BootstrapConfig, ControlPlaneNodeJoinConfig, FileArgsConfig, NodeJoinConfig],
     cluster_name: str,
+    node_ips: List[str],
 ):
     """Set extra arguments for Kubernetes components based on the provided configuration.
 
@@ -52,9 +54,10 @@ def craft(
 
     Args:
         src (ops.ConfigData): the charm instance to get the configuration from.
-        dest (Union[BootstrapConfig, ControlPlaneNodeJoinConfig, NodeJoinConfig]):
+        dest (Union[BootstrapConfig, ControlPlaneNodeJoinConfig, FileArgsConfig, NodeJoinConfig]):
             The configuration object to be updated with extra arguments.
         cluster_name (str): the name of the cluster to override in the extra arguments.
+        node_ips (list[str]): the IP address of the node to override in the extra arguments.
     """
     if isinstance(dest, (BootstrapConfig, ControlPlaneNodeJoinConfig)):
         cmd = _parse(src["kube-apiserver-extra-args"])
@@ -81,6 +84,10 @@ def craft(
     dest.extra_node_kube_proxy_args = cmd
 
     cmd = _parse(src["kubelet-extra-args"])
+    if node_ips:
+        cmd.update(**{"--node-ip": ",".join(node_ips)})
+    else:
+        cmd.pop("--node-ip", None)
     dest.extra_node_kubelet_args = cmd
 
 

--- a/charms/worker/k8s/src/literals.py
+++ b/charms/worker/k8s/src/literals.py
@@ -18,7 +18,23 @@ VALID_LOG_LEVELS = ["info", "debug", "warning", "error", "critical"]
 
 # Charm
 SNAP_COMMON = "/var/snap/k8s/common"
-CONTAINERD_ARGS = Path(SNAP_COMMON) / "args/containerd"
+SERVICE_ARGS = Path(SNAP_COMMON) / "args"
+CONTAINERD_ARGS = SERVICE_ARGS / "containerd"
+K8S_DQLITE_ARGS = SERVICE_ARGS / "k8s-dqlite"
+K8SD_ARGS = SERVICE_ARGS / "k8sd"
+KUBE_APISERVER_ARGS_PATH = SERVICE_ARGS / "kube-apiserver"
+KUBE_CONTROLLER_MANAGER_ARGS_PATH = SERVICE_ARGS / "kube-controller-manager"
+KUBE_PROXY_ARGS_PATH = SERVICE_ARGS / "kube-proxy"
+KUBE_SCHEDULER_ARGS_PATH = SERVICE_ARGS / "kube-scheduler"
+KUBELET_ARGS_PATH = SERVICE_ARGS / "kubelet"
+# SystemD Args
+SNAP_SYSD_ARGS_FILE = "00-snap-managed"
+CHARM_SYSD_ARGS_FILE = "01-charm-managed"
+KUBE_APISERVER_SYSD_PATH = SERVICE_ARGS / "kube-apiserver.args.d"
+KUBE_CONTROLLER_MANAGER_SYSD_PATH = SERVICE_ARGS / "kube-controller-manager.args.d"
+KUBE_PROXY_SYSD_PATH = SERVICE_ARGS / "kube-proxy.args.d"
+KUBE_SCHEDULER_SYSD_PATH = SERVICE_ARGS / "kube-scheduler.args.d"
+KUBELET_SYSD_PATH = SERVICE_ARGS / "kubelet.args.d"
 CONTAINERD_SERVICE_NAME = "snap.k8s.containerd.service"
 CONTAINERD_HTTP_PROXY = Path(f"/etc/systemd/system/{CONTAINERD_SERVICE_NAME}.d/http-proxy.conf")
 ETC_KUBERNETES = Path("/etc/kubernetes")

--- a/tests/unit/config/test_cluster.py
+++ b/tests/unit/config/test_cluster.py
@@ -65,6 +65,9 @@ def test_configure_common_extra_args(harness):
 
     harness.disable_hooks()
     harness.add_relation("cluster", "remote", unit_data={"ingress-address": "1.2.3.4"})
+    harness.add_network(
+        "10.0.0.10", endpoint="cluster", ingress_addresses=("10.0.0.10", "2001:db8:10::a00:a")
+    )
     harness.update_config({"kubelet-extra-args": "v=3 foo=bar flag"})
     harness.update_config({"kube-proxy-extra-args": "v=4 foo=baz flog"})
 
@@ -74,6 +77,8 @@ def test_configure_common_extra_args(harness):
     assert bootstrap_config.extra_node_kubelet_args == {
         "--v": "3",
         "--foo": "bar",
+        # NOTE: (mateoflorido): IPv6 addrs are exploded.
+        "--node-ip": "10.0.0.10,2001:0db8:0010:0000:0000:0000:0a00:000a",
         "--flag": "true",
     }
     assert bootstrap_config.extra_node_kube_proxy_args == {

--- a/tests/unit/test_arg_files.py
+++ b/tests/unit/test_arg_files.py
@@ -61,3 +61,20 @@ def test_file_args_config_ensure_content(snap_cache, write_text):
     config.ensure()
     snap_cache()["k8s"].restart.assert_called_once_with(["kubelet"])
     write_text.assert_called_once_with('--some-arg="value"\n')
+
+
+@mock.patch("pathlib.Path.exists", mock.Mock(return_value=True))
+@mock.patch("pathlib.Path.read_text", mock.Mock(return_value='--remove-arg="bar"\n'))
+@mock.patch("pathlib.Path.write_text")
+@mock.patch("charms.operator_libs_linux.v2.snap.SnapCache")
+def test_file_args_config_ensure_content_removal(snap_cache, write_text: mock.MagicMock):
+    """Test the FileArgsConfig class with a file."""
+    config = FileArgsConfig()
+    config.extra_node_kubelet_args = {
+        "--some-arg": "value",
+        "--remove-arg-": "true",
+        "--alpha": "true",
+    }
+    config.ensure()
+    snap_cache()["k8s"].restart.assert_called_once_with(["kubelet"])
+    write_text.assert_called_once_with('--alpha="true"\n--some-arg="value"\n')

--- a/tests/unit/test_arg_files.py
+++ b/tests/unit/test_arg_files.py
@@ -1,0 +1,63 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Learn more about testing at: https://juju.is/docs/sdk/testing
+
+# pylint: disable=duplicate-code,missing-function-docstring
+"""Unit tests for config.arg_files."""
+
+import hashlib
+import unittest.mock as mock
+
+from config.arg_files import FileArgsConfig
+
+
+@mock.patch("pathlib.Path.exists", mock.Mock(return_value=False))
+def test_file_args_config():
+    """Test the FileArgsConfig class."""
+    config = FileArgsConfig()
+    assert config.extra_node_kube_apiserver_args == {}
+    assert config.extra_node_kube_controller_manager_args == {}
+    assert config.extra_node_kube_scheduler_args == {}
+    assert config.extra_node_kube_proxy_args == {}
+    assert config.extra_node_kubelet_args == {}
+    assert config._service_args == {}
+    assert config._file_hashes == {}
+
+
+@mock.patch("pathlib.Path.exists", mock.Mock(return_value=True))
+@mock.patch("pathlib.Path.read_text")
+def test_file_args_config_with_file(read_text):
+    """Test the FileArgsConfig class with a file."""
+    read_text.return_value = arg = '--some-arg="value"'
+    arg_hash = hashlib.sha256(arg.encode()).digest()
+    config = FileArgsConfig()
+    expected = {"--some-arg": "value"}
+
+    assert config._service_args == {
+        "kube-apiserver": expected,
+        "kube-controller-manager": expected,
+        "kube-scheduler": expected,
+        "kube-proxy": expected,
+        "kubelet": expected,
+    }
+    assert config._file_hashes == {
+        "kube-apiserver": arg_hash,
+        "kube-controller-manager": arg_hash,
+        "kube-scheduler": arg_hash,
+        "kube-proxy": arg_hash,
+        "kubelet": arg_hash,
+    }
+
+
+@mock.patch("pathlib.Path.exists", mock.Mock(return_value=True))
+@mock.patch("pathlib.Path.read_text", mock.Mock(return_value=""))
+@mock.patch("pathlib.Path.write_text")
+@mock.patch("charms.operator_libs_linux.v2.snap.SnapCache")
+def test_file_args_config_ensure_content(snap_cache, write_text):
+    """Test the FileArgsConfig class with a file."""
+    config = FileArgsConfig()
+    config.extra_node_kubelet_args = {"--some-arg": "value"}
+    config.ensure()
+    snap_cache()["k8s"].restart.assert_called_once_with(["kubelet"])
+    write_text.assert_called_once_with('--some-arg="value"\n')


### PR DESCRIPTION
Port of https://github.com/canonical/k8s-operator/pull/485

### Overview
* Support run-time adjustment of the extra-args on the kubernetes services
* Adds `node-ip` as a run-time setting based on the ip addresses bound to the `cluster` endpoint binding