### PR TITLE
Use registry image hosted from ghcr.io in test_registry

### DIFF
--- a/tests/integration/data/test_registries/test-bundle-docker-registry.yaml
+++ b/tests/integration/data/test_registries/test-bundle-docker-registry.yaml
@@ -14,3 +14,5 @@ applications:
     charm: docker-registry
     channel: latest/edge
     num_units: 1
+    options:
+      registry-image: ghcr.io/charmed-kubernetes/docker-registry:2


### PR DESCRIPTION
### Overview

By default `docker-registry` charm uses `docker.io/registry:2` for its registry image.  Swap this to `ghcr.io/charmed-kubernetes/docker-registry:2` which is just a mirror -- but shouldn't hit rate limit issues with github runners

### Details
* also swap out pulling `busybox:latest` from docker.io -- but rather use `rocks.canonical.com/cdk/busybox:1.36` to avoid the same kind of problem
