### PR TITLE
Catch a broader httpx exception to signal a failure cluster inspection

### DIFF
--- a/charms/worker/k8s/src/inspector.py
+++ b/charms/worker/k8s/src/inspector.py
@@ -78,7 +78,7 @@ class ClusterInspector:
                 )
 
             return [node for node in client.list(Node, labels=labels) if is_node_not_ready(node)]
-        except (ApiError, httpx.ConnectError) as e:
+        except (ApiError, httpx.HTTPError) as e:
             raise ClusterInspector.ClusterInspectorError(f"Failed to get nodes: {e}") from e
 
     def verify_pods_running(self, namespaces: List[str]) -> Optional[str]:
@@ -104,7 +104,7 @@ class ClusterInspector:
                         failing_pods.append(f"{namespace}/{pod.metadata.name}")  # type: ignore
             if failing_pods:
                 return ", ".join(failing_pods)
-        except (ApiError, httpx.ConnectError) as e:
+        except (ApiError, httpx.HTTPError) as e:
             raise ClusterInspector.ClusterInspectorError(f"Failed to get pods: {e}") from e
         return None
 


### PR DESCRIPTION
Backport #586 

### Overview
* `httpx.ConnectError` is too narrow of an issue to catch for cluster inspection.  It should more use the more broad exception `httpx.HTTPError`.  if anything goes wrong checking the api server, that should be noted as a `ClusterInspectorError`. 

### Details
* seen in an integration tests run where the client threw another error, and the charm went into ERROR state.
* For anyone curious (or future reference), here's the hierarchy of HTTPX exceptions: https://www.python-httpx.org/exceptions/


