### PR TITLE
fix: await public ip address to confirm its not the LB ip address

### DIFF
--- a/tests/integration/terraform/default-manifest.yaml
+++ b/tests/integration/terraform/default-manifest.yaml
@@ -2,12 +2,12 @@
 # See LICENSE file for licensing details.
 
 k8s:
-    units: 3
-    base: ubuntu@24.04
-    constraints: arch=amd64 cores=2 mem=4096M root-disk=16384M
-    channel: latest/edge
-k8s_worker:
-    units: 2
-    base: ubuntu@24.04
-    constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
-    channel: latest/edge
+  units: 3
+  base: ubuntu@24.04
+  constraints: arch=amd64 cores=2 mem=4096M root-disk=16384M
+  channel: latest/edge
+k8s-worker:
+  units: 2
+  base: ubuntu@24.04
+  constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
+  channel: latest/edge

--- a/tests/integration/terraform/openstack-manifest.yaml
+++ b/tests/integration/terraform/openstack-manifest.yaml
@@ -1,0 +1,16 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+k8s:
+  units: 1
+  base: ubuntu@22.04
+  constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M
+  channel: latest/edge
+openstack-integrator:
+  units: 1
+  channel: latest/edge
+  base: ubuntu@22.04
+cinder-csi:
+  channel: latest/edge
+openstack-cloud-controller:
+  channel: latest/edge

--- a/tests/integration/test_openstack.py
+++ b/tests/integration/test_openstack.py
@@ -54,8 +54,12 @@ async def test_cinder_pv(kubernetes_cluster: juju.model.Model, api_client: ApiCl
     await storage.exec_storage_class(definition, api_client)
 
 
-async def test_external_load_balancer(kubernetes_cluster: juju.model.Model, api_client: ApiClient):
-    """Test external load balancer."""
+async def test_k8s_api_load_balancer(kubernetes_cluster: juju.model.Model, api_client: ApiClient):
+    """Test k8s api load balancer.
+
+    This test checks that the Kubernetes API server is accessible via a load balancer managed
+    by the OpenStack through the openstack-integrator.
+    """
     k8s = kubernetes_cluster.applications["k8s"]
 
     # Get the server endpoint

--- a/tests/integration/test_openstack.py
+++ b/tests/integration/test_openstack.py
@@ -72,7 +72,8 @@ async def test_external_load_balancer(kubernetes_cluster: juju.model.Model, api_
     server_endpoint = server_endpoint.strip("]")
 
     for unit in k8s.units:
-        assert unit.get_public_address() != server_endpoint, "External lb not configured"
+        addr = await unit.get_public_address()
+        assert addr != server_endpoint, "External lb not configured"
 
     api_client.configuration.host = kubeconfig_yaml["clusters"][0]["cluster"]["server"]
     v1 = CoreV1Api(api_client)

--- a/tox.ini
+++ b/tox.ini
@@ -118,7 +118,8 @@ commands =
 
 [testenv:deploy-terraform]
 description = Deploy a k8s-operator cluster with terraform
-deps = {[testenv:integration]deps}
+runner = uv-venv-lock-runner
+dependency_groups = integration
 commands = python3 {toxinidir}/tests/integration/terraform/setup.py  {posargs}
 passenv = TF_VAR_*
 


### PR DESCRIPTION
### Overview
* need to await a juju method to get the pubilc ip address of the openstack instance to compare against the load-balancer address

### Details
* this previously produced a warning but not a test failure.

````
tests/integration/test_openstack.py::test_external_load_balancer
  /home/ubuntu/actions-runner/_work/sqa-cloud-deployment-pipeline/sqa-cloud-deployment-pipeline/canonicalk8s_test_openstack/tests/integration/test_openstack.py:86: RuntimeWarning: coroutine 'Unit.get_***_address' was never awaited
    assert unit.get_***_address() != server_endpoint, "External lb not configured"
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

During handling of the above exception, another exception occurred:
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```