### PR TITLE
fix: Use ops_test.fast_forwards to urge along tests quicker

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -25,6 +25,7 @@ from juju.tag import untag
 from juju.url import URL
 from kubernetes import config as k8s_config
 from kubernetes.client import ApiClient, Configuration, CoreV1Api
+from literals import ONE_MIN
 from pytest_operator.plugin import OpsTest
 
 log = logging.getLogger(__name__)
@@ -222,7 +223,7 @@ async def deploy_model(
         )
     with ops_test.model_context(model_name) as the_model:
         await cloud_profile(ops_test)
-        async with ops_test.fast_forward("60s"):
+        async with ops_test.fast_forward(ONE_MIN):
             bundle_yaml = bundle.render(ops_test.tmp_path)
             await the_model.deploy(bundle_yaml, trust=bundle.needs_trust)
             await the_model.wait_for_idle(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -209,6 +209,7 @@ async def deploy_model(
         model object
     """
     config: Optional[dict] = {}
+    at_least_60 = max(60, ops_test.request.config.option.timeout)
     if ops_test.request.config.option.model_config:
         config = ops_test.read_model_config(ops_test.request.config.option.model_config)
     credential_name = ops_test.cloud_name
@@ -227,7 +228,7 @@ async def deploy_model(
             await the_model.wait_for_idle(
                 apps=list(bundle.applications),
                 status="active",
-                timeout=60 * 60,
+                timeout=at_least_60 * 60,
             )
         try:
             yield the_model

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -14,7 +14,6 @@ from itertools import chain
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
 
-import juju.application
 import juju.model
 import juju.unit
 import juju.utils

--- a/tests/integration/literals.py
+++ b/tests/integration/literals.py
@@ -1,0 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""literal definitions for integration test."""
+
+# Durations
+ONE_MIN = "1m"

--- a/tests/integration/test_ceph.py
+++ b/tests/integration/test_ceph.py
@@ -27,7 +27,7 @@ CEPH_CSI_MISSING_NS = re.compile(r"Missing namespace '(\S+)'")
 
 @pytest_asyncio.fixture(scope="module")
 async def ready_csi_apps(
-    ops_test: OpsTest, kubernetes_cluster: model.Model, api_client: ApiClient
+    ops_test: OpsTest, kubernetes_cluster: model.Model, api_client: ApiClient, timeout: int
 ) -> None:
     """Wait for the CSI apps to be ready."""
     v1 = CoreV1Api(api_client)
@@ -45,7 +45,7 @@ async def ready_csi_apps(
 
     async with ops_test.fast_forward():
         await kubernetes_cluster.wait_for_idle(
-            apps=[app.name for app in csi_apps], status="active", timeout=60 * 5
+            apps=[app.name for app in csi_apps], status="active", timeout=timeout * 60
         )
 
 

--- a/tests/integration/test_ceph.py
+++ b/tests/integration/test_ceph.py
@@ -14,6 +14,7 @@ import storage
 from juju import model
 from kubernetes.client import ApiClient, CoreV1Api, StorageV1Api
 from kubernetes.client import models as k8s_models
+from literals import ONE_MIN
 from pytest_operator.plugin import OpsTest
 
 # This pytest mark configures the test environment to use the Canonical Kubernetes
@@ -43,7 +44,7 @@ async def ready_csi_apps(
                 )
                 break
 
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward(ONE_MIN):
         await kubernetes_cluster.wait_for_idle(
             apps=[app.name for app in csi_apps], status="active", timeout=timeout * 60
         )

--- a/tests/integration/test_etcd.py
+++ b/tests/integration/test_etcd.py
@@ -40,14 +40,15 @@ async def test_etcd_datastore(kubernetes_cluster: model.Model):
 
 
 @pytest.mark.abort_on_fail
-async def test_update_etcd_cluster(kubernetes_cluster: model.Model):
+async def test_update_etcd_cluster(kubernetes_cluster: model.Model, timeout: int):
     """Test that adding etcd clusters are propagated to the k8s cluster."""
     k8s: unit.Unit = kubernetes_cluster.applications["k8s"].units[0]
     etcd = kubernetes_cluster.applications["etcd"]
     count = 3 - len(etcd.units)
     if count > 0:
         await etcd.add_unit(count=count)
-    await kubernetes_cluster.wait_for_idle(status="active", timeout=20 * 60)
+    at_least_twenty = max(20, timeout)
+    await kubernetes_cluster.wait_for_idle(status="active", timeout=at_least_twenty * 60)
 
     expected_servers = []
     for u in etcd.units:

--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -9,13 +9,13 @@ import asyncio
 import logging
 from pathlib import Path
 
-import juju.application
 import juju.model
 import juju.unit
 import pytest
 import pytest_asyncio
 from grafana import Grafana
 from helpers import get_leader, get_rsc, ready_nodes, wait_pod_phase
+from literals import ONE_MIN
 from prometheus import Prometheus
 from tenacity import retry, stop_after_attempt, wait_fixed
 
@@ -34,8 +34,8 @@ pinned_revision = (
 @pytest_asyncio.fixture
 async def preserve_charm_config(ops_test, kubernetes_cluster: juju.model.Model, timeout: int):
     """Preserve the charm config changes from a test."""
-    k8s = kubernetes_cluster.applications["k8s"]
-    worker = kubernetes_cluster.applications["k8s-worker"]
+    apps = ["k8s", "k8s-worker"]
+    k8s, worker = (kubernetes_cluster.applications[a] for a in apps)
     pre = await asyncio.gather(k8s.get_config(), worker.get_config())
     yield pre
     post = await asyncio.gather(k8s.get_config(), worker.get_config())
@@ -47,15 +47,15 @@ async def preserve_charm_config(ops_test, kubernetes_cluster: juju.model.Model, 
                 app_after[key]["default"] if key not in app_before else app_before[key]["value"]
             )
 
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward(ONE_MIN):
         await asyncio.gather(k8s.set_config(pre[0]), worker.set_config(pre[1]))
-        await kubernetes_cluster.wait_for_idle(status="active", timeout=timeout * 60)
+        await kubernetes_cluster.wait_for_idle(apps=apps, status="active", timeout=timeout * 60)
 
 
 async def test_nodes_ready(kubernetes_cluster: juju.model.Model):
     """Deploy the charm and wait for active/idle status."""
-    k8s = kubernetes_cluster.applications["k8s"]
-    worker = kubernetes_cluster.applications["k8s-worker"]
+    apps = ["k8s", "k8s-worker"]
+    k8s, worker = (kubernetes_cluster.applications[a] for a in apps)
     expected_nodes = len(k8s.units) + len(worker.units)
     await ready_nodes(k8s.units[0], expected_nodes)
 
@@ -70,8 +70,8 @@ async def test_kube_system_pods(kubernetes_cluster: juju.model.Model):
 
 async def test_verbose_config(kubernetes_cluster: juju.model.Model):
     """Test verbose config."""
-    k8s = kubernetes_cluster.applications["k8s"]
-    worker = kubernetes_cluster.applications["k8s-worker"]
+    apps = ["k8s", "k8s-worker"]
+    k8s, worker = (kubernetes_cluster.applications[a] for a in apps)
     all_units = k8s.units + worker.units
 
     unit_events = await asyncio.gather(*(u.run("ps axf | grep kube") for u in all_units))
@@ -92,14 +92,14 @@ async def test_nodes_labelled(
 ):
     """Test the charms label the nodes appropriately."""
     testname: str = request.node.name
-    k8s: juju.application.Application = kubernetes_cluster.applications["k8s"]
-    worker: juju.application.Application = kubernetes_cluster.applications["k8s-worker"]
+    apps = ["k8s", "k8s-worker"]
+    k8s, worker = (kubernetes_cluster.applications[a] for a in apps)
 
     # Set a VALID node-label on both k8s and worker
     label_config = {"node-labels": f"{testname}="}
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward(ONE_MIN):
         await asyncio.gather(k8s.set_config(label_config), worker.set_config(label_config))
-        await kubernetes_cluster.wait_for_idle(status="active", timeout=timeout * 60)
+        await kubernetes_cluster.wait_for_idle(apps=apps, status="active", timeout=timeout * 60)
 
     nodes = await get_rsc(k8s.units[0], "nodes")
     labelled = [n for n in nodes if testname in n["metadata"]["labels"]]
@@ -113,20 +113,19 @@ async def test_nodes_labelled(
 
     # Set an INVALID node-label on both k8s and worker
     label_config = {"node-labels": f"{testname}=invalid="}
-    async with ops_test.fast_forward():
-        await asyncio.gather(k8s.set_config(label_config), worker.set_config(label_config))
-        await kubernetes_cluster.wait_for_idle(timeout=timeout * 60)
     leader_idx = await get_leader(k8s)
+    await asyncio.gather(k8s.set_config(label_config), worker.set_config(label_config))
+    await kubernetes_cluster.wait_for_idle(apps=apps, timeout=timeout * 60)
     leader: juju.unit.Unit = k8s.units[leader_idx]
     assert leader.workload_status == "blocked", "Leader not blocked"
     assert "node-labels" in leader.workload_status_message, "Leader had unexpected warning"
 
     # Test resetting all label config
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward(ONE_MIN):
         await asyncio.gather(
             k8s.reset_config(list(label_config)), worker.reset_config(list(label_config))
         )
-        await kubernetes_cluster.wait_for_idle(status="active", timeout=timeout * 60)
+        await kubernetes_cluster.wait_for_idle(apps=apps, status="active", timeout=timeout * 60)
     nodes = await get_rsc(k8s.units[0], "nodes")
     labelled = [n for n in nodes if testname in n["metadata"]["labels"]]
     juju_nodes = [n for n in nodes if "juju-charm" in n["metadata"]["labels"]]
@@ -143,32 +142,31 @@ async def test_prevent_bootstrap_config_changes(
     expected_nodes = len(k8s.units) + len(worker.units)
     await ready_nodes(k8s.units[0], expected_nodes)
     new_config = {"bootstrap-node-taints": "new-taint"}
-    async with ops_test.fast_forward():
-        await asyncio.gather(k8s.set_config(new_config), worker.set_config(new_config))
-        await kubernetes_cluster.wait_for_idle(apps=apps, status="blocked", timeout=timeout * 60)
+    await asyncio.gather(k8s.set_config(new_config), worker.set_config(new_config))
+    await kubernetes_cluster.wait_for_idle(apps=apps, status="blocked", timeout=timeout * 60)
 
 
 async def test_remove_worker(kubernetes_cluster: juju.model.Model, timeout: int):
     """Deploy the charm and wait for active/idle status."""
-    k8s = kubernetes_cluster.applications["k8s"]
-    worker = kubernetes_cluster.applications["k8s-worker"]
+    apps = ["k8s", "k8s-worker"]
+    k8s, worker = (kubernetes_cluster.applications[a] for a in apps)
     expected_nodes = len(k8s.units) + len(worker.units)
     await ready_nodes(k8s.units[0], expected_nodes)
 
     # Remove a worker
     log.info("Remove unit %s", worker.units[0].name)
     await worker.units[0].destroy()
-    await kubernetes_cluster.wait_for_idle(status="active", timeout=timeout * 60)
+    await kubernetes_cluster.wait_for_idle(apps=apps, status="active", timeout=timeout * 60)
     await ready_nodes(k8s.units[0], expected_nodes - 1)
     await worker.add_unit()
-    await kubernetes_cluster.wait_for_idle(status="active", timeout=timeout * 60)
+    await kubernetes_cluster.wait_for_idle(apps=apps, status="active", timeout=timeout * 60)
     await ready_nodes(k8s.units[0], expected_nodes)
 
 
 async def test_remove_non_leader_control_plane(kubernetes_cluster: juju.model.Model, timeout: int):
     """Deploy the charm and wait for active/idle status."""
-    k8s = kubernetes_cluster.applications["k8s"]
-    worker = kubernetes_cluster.applications["k8s-worker"]
+    apps = ["k8s", "k8s-worker"]
+    k8s, worker = (kubernetes_cluster.applications[a] for a in apps)
     expected_nodes = len(k8s.units) + len(worker.units)
     leader_idx = await get_leader(k8s)
     leader = k8s.units[leader_idx]
@@ -178,17 +176,17 @@ async def test_remove_non_leader_control_plane(kubernetes_cluster: juju.model.Mo
     # Remove a control-plane
     log.info("Remove unit %s", follower.name)
     await follower.destroy()
-    await kubernetes_cluster.wait_for_idle(status="active", timeout=timeout * 60)
+    await kubernetes_cluster.wait_for_idle(apps=apps, status="active", timeout=timeout * 60)
     await ready_nodes(leader, expected_nodes - 1)
     await k8s.add_unit()
-    await kubernetes_cluster.wait_for_idle(status="active", timeout=timeout * 60)
+    await kubernetes_cluster.wait_for_idle(apps=apps, status="active", timeout=timeout * 60)
     await ready_nodes(leader, expected_nodes)
 
 
 async def test_remove_leader_control_plane(kubernetes_cluster: juju.model.Model, timeout: int):
     """Deploy the charm and wait for active/idle status."""
-    k8s = kubernetes_cluster.applications["k8s"]
-    worker = kubernetes_cluster.applications["k8s-worker"]
+    apps = ["k8s", "k8s-worker"]
+    k8s, worker = (kubernetes_cluster.applications[a] for a in apps)
     expected_nodes = len(k8s.units) + len(worker.units)
     leader_idx = await get_leader(k8s)
     leader = k8s.units[leader_idx]
@@ -198,10 +196,10 @@ async def test_remove_leader_control_plane(kubernetes_cluster: juju.model.Model,
     # Remove a control-plane
     log.info("Remove unit %s", leader.name)
     await leader.destroy()
-    await kubernetes_cluster.wait_for_idle(status="active", timeout=timeout * 60)
+    await kubernetes_cluster.wait_for_idle(apps=apps, status="active", timeout=timeout * 60)
     await ready_nodes(follower, expected_nodes - 1)
     await k8s.add_unit()
-    await kubernetes_cluster.wait_for_idle(status="active", timeout=timeout * 60)
+    await kubernetes_cluster.wait_for_idle(apps=apps, status="active", timeout=timeout * 60)
     await ready_nodes(follower, expected_nodes)
 
 

--- a/tests/integration/test_openstack.py
+++ b/tests/integration/test_openstack.py
@@ -87,14 +87,15 @@ async def test_k8s_api_load_balancer(kubernetes_cluster: juju.model.Model, api_c
     assert node_list.items, "No nodes found"
 
 
-async def test_extra_sans(kubernetes_cluster: juju.model.Model):
+async def test_extra_sans(ops_test, kubernetes_cluster: juju.model.Model, timeout: int):
     """Test extra sans config."""
     k8s = kubernetes_cluster.applications["k8s"]
 
     extra_san = "test.example.com"
     sans_config = {"kube-apiserver-extra-sans": extra_san}
-    await asyncio.gather(k8s.set_config(sans_config))
-    await kubernetes_cluster.wait_for_idle(status="active", timeout=5 * 60)
+    async with ops_test.fast_forward():
+        await asyncio.gather(k8s.set_config(sans_config))
+        await kubernetes_cluster.wait_for_idle(status="active", timeout=timeout * 60)
 
     # Get the server endpoint
     action = await k8s.units[0].run_action("get-kubeconfig")

--- a/tests/integration/test_openstack.py
+++ b/tests/integration/test_openstack.py
@@ -12,6 +12,7 @@ import storage
 import yaml
 from kubernetes.client import ApiClient, AppsV1Api, CoreV1Api
 from kubernetes.client.models import V1DaemonSet, V1DaemonSetList, V1NodeList
+from literals import ONE_MIN
 
 CLOUD_TYPE = "openstack"
 CONTROLLER_NAME = "openstack-cloud-controller-manager"
@@ -93,7 +94,7 @@ async def test_extra_sans(ops_test, kubernetes_cluster: juju.model.Model, timeou
 
     extra_san = "test.example.com"
     sans_config = {"kube-apiserver-extra-sans": extra_san}
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward(ONE_MIN):
         await asyncio.gather(k8s.set_config(sans_config))
         await kubernetes_cluster.wait_for_idle(status="active", timeout=timeout * 60)
 

--- a/tests/integration/test_registry.py
+++ b/tests/integration/test_registry.py
@@ -18,6 +18,7 @@ import pytest
 import yaml
 from juju import model
 from kubernetes.utils import create_from_yaml
+from literals import ONE_MIN
 
 pytestmark = [
     pytest.mark.bundle(
@@ -56,7 +57,7 @@ async def test_custom_registry(
     custom_registry_config = {"containerd-custom-registries": config_string}
     tagged_image = f"{docker_registry_ip}:5000/{TEST_IMAGE}"
 
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward(ONE_MIN):
         await kubernetes_cluster.applications["k8s"].set_config(custom_registry_config)
         await kubernetes_cluster.wait_for_idle(status="active", timeout=timeout * 60)
 


### PR DESCRIPTION
### Overview
* Use configurable timeout for all tests
* Use `ops_test.fast_forward` to speed up tests (by adjusting the update-status rate to 10s)