### PR TITLE
fix: Use ops_test.fast_forwards to urge along tests quicker (#596)

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -14,7 +14,6 @@ from itertools import chain
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, Union
 
-import juju.application
 import juju.model
 import juju.unit
 import juju.utils

--- a/tests/integration/literals.py
+++ b/tests/integration/literals.py
@@ -1,0 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""literal definitions for integration test."""
+
+# Durations
+ONE_MIN = "1m"

--- a/tests/integration/test_etcd.py
+++ b/tests/integration/test_etcd.py
@@ -41,14 +41,15 @@ async def test_etcd_datastore(kubernetes_cluster: model.Model):
 
 
 @pytest.mark.abort_on_fail
-async def test_update_etcd_cluster(kubernetes_cluster: model.Model):
+async def test_update_etcd_cluster(kubernetes_cluster: model.Model, timeout: int):
     """Test that adding etcd clusters are propagated to the k8s cluster."""
     k8s: unit.Unit = kubernetes_cluster.applications["k8s"].units[0]
     etcd = kubernetes_cluster.applications["etcd"]
     count = 3 - len(etcd.units)
     if count > 0:
         await etcd.add_unit(count=count)
-    await kubernetes_cluster.wait_for_idle(status="active", timeout=20 * 60)
+    at_least_twenty = max(20, timeout)
+    await kubernetes_cluster.wait_for_idle(status="active", timeout=at_least_twenty * 60)
 
     expected_servers = []
     for u in etcd.units:

--- a/tests/integration/test_openstack.py
+++ b/tests/integration/test_openstack.py
@@ -13,6 +13,7 @@ from kubernetes.client import ApiClient, AppsV1Api, CoreV1Api
 from kubernetes.client.models import V1DaemonSet, V1DaemonSetList, V1NodeList
 
 from . import storage
+from .literals import ONE_MIN
 
 CLOUD_TYPE = "openstack"
 CONTROLLER_NAME = "openstack-cloud-controller-manager"
@@ -97,14 +98,15 @@ async def test_api_load_balancer(kubernetes_cluster: juju.model.Model, api_clien
     assert node_list.items, "No nodes found"
 
 
-async def test_extra_sans(kubernetes_cluster: juju.model.Model):
+async def test_extra_sans(ops_test, kubernetes_cluster: juju.model.Model, timeout: int):
     """Test extra sans config."""
     k8s = kubernetes_cluster.applications["k8s"]
 
     extra_san = "test.example.com"
     sans_config = {"kube-apiserver-extra-sans": extra_san}
-    await asyncio.gather(k8s.set_config(sans_config))
-    await kubernetes_cluster.wait_for_idle(status="active", timeout=5 * 60)
+    async with ops_test.fast_forward(ONE_MIN):
+        await asyncio.gather(k8s.set_config(sans_config))
+        await kubernetes_cluster.wait_for_idle(status="active", timeout=timeout * 60)
 
     # Get the server endpoint
     action = await k8s.units[0].run_action("get-kubeconfig")


### PR DESCRIPTION
Backport #596 

### Overview
* Use configurable timeout for all tests
* Use `ops_test.fast_forward` to speed up tests (by adjusting the update-status rate to 10s)