### PR TITLE
WIP: Test amd64 etcd 3.6 on release-1.32 branch

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,7 +4,7 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 3952
+  revision: 4019
 arm64:
 - install-type: store
   name: k8s


### PR DESCRIPTION
### DO NOT MERGE

This was pushed to a test branch

```
charmcraft status k8s | grep etcd
                               edge/etcd-3.6              1162       1162        snap-installation (r2)  2025-08-29T00:00:00Z
                               edge/etcd-3.6              1163       1163        snap-installation (r2)  2025-08-29T00:00:00Z
                               edge/etcd-3.6              1164       1164        snap-installation (r2)  2025-08-29T00:00:00Z
````