### PR TITLE
fix: sort keys in proxied systemd environment files

### DIFF
--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -903,11 +903,11 @@ class K8sCharm(ops.CharmBase):
             str: A multi-line string containing the systemd [Service] section configuration
             with proxy environment variables.
         """
-        proxy_env_keys = {
+        proxy_env_keys = [
             "JUJU_CHARM_HTTP_PROXY",
             "JUJU_CHARM_HTTPS_PROXY",
             "JUJU_CHARM_NO_PROXY",
-        }
+        ]
         proxy_settings = []
         for key in proxy_env_keys:
             env_value = os.getenv(key)


### PR DESCRIPTION
Addresses issue #603 

### Overview
* Prevents constant restarting of systemd service containerd as well as running `systemctl daemon-reload` on any hook

### Details
* Because `proxy_env_keys` was defined as a set, and python sets are orderless, every invocation of the charm could come up with a different sort order
* The charm would detect this sort order as changed containerd config of the environment, and restart services needlessly.