### PR TITLE
fix: use a flexible path to find the unit test coverage.xml

### DIFF
--- a/.github/workflows/tiobe-tics-cron.yaml
+++ b/.github/workflows/tiobe-tics-cron.yaml
@@ -44,7 +44,7 @@ jobs:
           tox -e unit,coverage-xml
           # TiCS expects the report to be under a "$(pwd)/cover" directory.
           mkdir -p "$GITHUB_WORKSPACE/cover"
-          GENERATED_COVERAGE_XML="$GITHUB_WORKSPACE/charms/worker/k8s/coverage.xml"
+          GENERATED_COVERAGE_XML=$(find "$GITHUB_WORKSPACE" -type f -name "coverage.xml")
           mv "$GENERATED_COVERAGE_XML" cover/coverage.xml
 
       - name: Run TICS


### PR DESCRIPTION
Fixes the nightly TICS scan
* https://github.com/canonical/k8s-operator/actions/workflows/tiobe-tics-cron.yaml