### PR TITLE
fix(terraform): update juju provider version constraint

### DIFF
--- a/charms/worker/k8s/terraform/versions.tf
+++ b/charms/worker/k8s/terraform/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.14.0"
+      version = ">= 0.14.0, < 1.0.0"
     }
   }
 }

--- a/charms/worker/terraform/versions.tf
+++ b/charms/worker/terraform/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.14.0"
+      version = ">= 0.14.0, < 1.0.0"
     }
   }
 }


### PR DESCRIPTION
### Overview

Change version constraint from `~> 0.14.0` to `>= 0.14.0, < 1.0.0`.

### Rationale

Sync with main and 1.33 branches
