### PR TITLE
Do not manage service restarts when performing a snap refresh

### DIFF
--- a/charms/worker/k8s/src/snap.py
+++ b/charms/worker/k8s/src/snap.py
@@ -13,7 +13,7 @@ import shutil
 import subprocess
 import tarfile
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, Tuple, Union
+from typing import List, Literal, Optional, Tuple, Union
 
 import yaml
 from config.resource import CharmResource
@@ -368,61 +368,3 @@ def version(snap: str) -> Tuple[Optional[str], bool]:
 
     log.info("Snap k8s not found or no version available.")
     return None, overridden
-
-
-def stop(snap_name: str, services: List[str]) -> None:
-    """Stop the services of the snap on this machine.
-
-    Arguments:
-        snap_name: The name of the snap
-        services: The services to stop
-
-    Raises:
-        SnapError: If the snap isn't installed
-    """
-    cache = snap_lib.SnapCache()
-    if snap_name not in cache:
-        message = f"Snap '{snap_name}' not installed"
-        log.error(message)
-        raise snap_lib.SnapError(message)
-    snap = cache[snap_name]
-    snap.stop(services=services)
-
-
-def start(snap_name: str, services: List[str]) -> None:
-    """Start the services of the snap on this machine.
-
-    Arguments:
-        snap_name: The name of the snap
-        services: The services to start
-
-    Raises:
-        SnapError: If the snap isn't installed
-    """
-    cache = snap_lib.SnapCache()
-    if snap_name not in cache:
-        message = f"Snap '{snap_name}' not installed"
-        log.error(message)
-        raise snap_lib.SnapError(message)
-    snap = cache[snap_name]
-    snap.start(services=services)
-
-
-def list(snap_name: str) -> Dict[str, snap_lib.SnapServiceDict]:
-    """List the services of the snap on this machine.
-
-    Arguments:
-        snap_name: The name of the snap
-
-    Returns:
-        Dict[str, snap_lib.SnapServiceDict]: The list of services of the snap
-
-    Raises:
-        SnapError: If the snap isn't installed
-    """
-    cache = snap_lib.SnapCache()
-    if snap_name not in cache:
-        message = f"Snap '{snap_name}' not installed"
-        log.error(message)
-        raise snap_lib.SnapError(message)
-    return cache[snap_name].services

--- a/charms/worker/k8s/src/upgrade.py
+++ b/charms/worker/k8s/src/upgrade.py
@@ -18,9 +18,7 @@ from protocols import K8sCharmProtocol
 # TODO: (mateoflorido) We are using the compatibility layer for pydantic.v1
 #  because the upgrade model does not support pydantic v2 yet.
 from pydantic.v1 import BaseModel
-from snap import list as list_services
 from snap import management as snap_management
-from snap import start, stop
 from snap import version as snap_version
 
 import charms.contextual_status as status
@@ -184,19 +182,6 @@ class K8sUpgrade(DataUpgrade):
 
         return not incompatible
 
-    def _perform_upgrade(self, services: List[str]) -> None:
-        """Perform the upgrade.
-
-        Args:
-            services: The services to stop and start during the upgrade.
-        """
-        status.add(ops.MaintenanceStatus("Stopping the K8s services"))
-        stop(SNAP_NAME, services)
-        status.add(ops.MaintenanceStatus("Upgrading the k8s snap."))
-        snap_management(self.charm)
-        status.add(ops.MaintenanceStatus("Starting the K8s services"))
-        start(SNAP_NAME, services)
-
     def _on_upgrade_granted(self, event: UpgradeGrantedEvent) -> None:
         """Handle the upgrade granted event.
 
@@ -227,18 +212,13 @@ class K8sUpgrade(DataUpgrade):
             trigger.cancel()
             return ops.BlockedStatus(message)
 
-        snap_services = list_services(SNAP_NAME)
-        services = sorted(name for name, service in snap_services.items() if service["enabled"])
-
         self._upgrade_granted = True
-        status.add(ops.MaintenanceStatus("Upgrading the charm."))
+        status.add(ops.MaintenanceStatus("Upgrading the snap."))
         try:
-            self._perform_upgrade(services=services)
+            snap_management(self.charm)
             self.set_unit_completed()
-
             if self.charm.unit.is_leader():
                 self.on_upgrade_changed(event)
-
             trigger.cancel()
         except SnapError:
             log.exception("Failed to upgrade the snap. Will retry...")

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -11,10 +11,6 @@ from inspector import ClusterInspector
 from lightkube.models.core_v1 import Node
 from lightkube.models.meta_v1 import ObjectMeta
 from literals import (
-    K8S_CONTROL_PLANE_SERVICES,
-    K8S_DQLITE_SERVICE,
-    K8S_WORKER_SERVICES,
-    MANAGED_ETCD_SERVICE,
     UPGRADE_RELATION,
 )
 from upgrade import K8sDependenciesModel, K8sUpgrade
@@ -158,18 +154,6 @@ class TestK8sUpgrade(unittest.TestCase):
 
         self.assertFalse(result)
 
-    @mock.patch("upgrade.start")
-    @mock.patch("upgrade.stop")
-    @mock.patch("upgrade.snap_management")
-    def test_perform_upgrade(self, management, stop, start):
-        """Test perform_upgrade method."""
-        services = mock.MagicMock()
-
-        self.upgrade._perform_upgrade(services)
-        management.assert_called_once_with(self.charm)
-        stop.assert_called_once_with("k8s", services)
-        start.assert_called_once_with("k8s", services)
-
     @mock.patch("upgrade.K8sUpgrade._upgrade")
     def test_on_upgrade_granted(self, mock_upgrade):
         """Test _on_upgrade_granted method."""
@@ -184,34 +168,16 @@ class TestK8sUpgrade(unittest.TestCase):
         "upgrade.K8sUpgrade._verify_worker_versions",
         new=mock.MagicMock(return_value=True),
     )
-    @mock.patch("upgrade.list_services")
-    @mock.patch("upgrade.K8sUpgrade._perform_upgrade")
+    @mock.patch("upgrade.snap_management")
     @mock.patch("upgrade.K8sUpgrade.on_upgrade_changed")
-    def test_upgrade_control_plane(self, on_upgrade_changed, perform_upgrade, list_services):
+    def test_upgrade_control_plane(self, on_upgrade_changed, snap_management):
         """Test _upgrade method for control plane."""
         event = mock.MagicMock()
-        list_services.return_value = {
-            "containerd": {"enabled": True, "active": True},
-            "k8s-apiserver-proxy": {"enabled": False, "active": False},
-            "k8s-dqlite": {"enabled": False, "active": False},
-            "k8sd": {"enabled": True, "active": True},
-            "kube-apiserver": {"enabled": True, "active": True},
-            "kube-controller-manager": {"enabled": True, "active": True},
-            "kube-proxy": {"enabled": True, "active": True},
-            "kube-scheduler": {"enabled": True, "active": True},
-            "kubelet": {"enabled": True, "active": True},
-            "etcd": {"enabled": False, "active": False},
-        }
         self.charm.is_control_plane = True
         self.charm.is_worker = False
 
         self.upgrade._upgrade(event)
-        services = sorted(
-            s
-            for s in K8S_CONTROL_PLANE_SERVICES
-            if s != K8S_DQLITE_SERVICE and s != MANAGED_ETCD_SERVICE
-        )
-        perform_upgrade.assert_called_once_with(services=services)
+        snap_management.assert_called_once_with(self.charm)
         on_upgrade_changed.assert_called_once_with(event)
 
     @mock.patch("reschedule.PeriodicEvent", new=mock.MagicMock())
@@ -220,29 +186,16 @@ class TestK8sUpgrade(unittest.TestCase):
         "upgrade.K8sUpgrade._verify_worker_versions",
         new=mock.MagicMock(return_value=True),
     )
-    @mock.patch("upgrade.list_services")
-    @mock.patch("upgrade.K8sUpgrade._perform_upgrade")
+    @mock.patch("upgrade.snap_management")
     @mock.patch("upgrade.K8sUpgrade.on_upgrade_changed")
-    def test_upgrade_worker(self, on_upgrade_changed, perform_upgrade, list_services):
+    def test_upgrade_worker(self, on_upgrade_changed, snap_management):
         """Test _upgrade method for control plane."""
         event = mock.MagicMock()
-        list_services.return_value = {
-            "containerd": {"enabled": True, "active": True},
-            "k8s-apiserver-proxy": {"enabled": True, "active": True},
-            "k8s-dqlite": {"enabled": False, "active": False},
-            "k8sd": {"enabled": True, "active": True},
-            "kube-apiserver": {"enabled": False, "active": True},
-            "kube-controller-manager": {"enabled": False, "active": True},
-            "kube-proxy": {"enabled": True, "active": True},
-            "kube-scheduler": {"enabled": False, "active": True},
-            "kubelet": {"enabled": True, "active": True},
-            "etcd": {"enabled": False, "active": False},
-        }
         self.charm.is_control_plane = False
         self.charm.is_worker = True
 
         self.upgrade._upgrade(event)
-        perform_upgrade.assert_called_once_with(services=sorted(K8S_WORKER_SERVICES))
+        snap_management.assert_called_once_with(self.charm)
         on_upgrade_changed.assert_called_once_with(event)
 
     def test_handler_proceed(self):


### PR DESCRIPTION
Applicable spec: KU-182

### Overview
The snap should now be able to handle restarting its own services, this shouldn't be in the context of the charm.  

### Rationale

This was only ever here in order to workaround some issues with k8s 1.31, and it's masking some bad decisions.  A snap refresh should complete on its own without having to stop/start the k8s services.  It can badly impact quorum on applications which perform raft -- so we just need to not attempt restarts in the charm. 


- [ ] Backported to 1.32