### PR TITLE
feat: add a k8s-inspect juju crashdump addon

### DIFF
--- a/tests/integration/data/crash_dump_addons/k8s-inspect.yaml
+++ b/tests/integration/data/crash_dump_addons/k8s-inspect.yaml
@@ -1,0 +1,7 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+k8s-inspect:
+  remote: |
+    sudo k8s inspect | tee {output}/k8s-inspect.txt
+    mv {location}/inspection-report-* {output}/

--- a/tox.ini
+++ b/tox.ini
@@ -125,7 +125,7 @@ commands =
       --log-date-format "%Y-%m-%d %H:%M:%S" \
       --exitfirst \
       --crash-dump=on-failure \
-      --crash-dump-args='-j snap.k8s.* --as-root' \
+      --crash-dump-args='-j snap.k8s.* --as-root --addons-file {[vars]int_path}/data/crash_dump_addons/k8s-inspect.yaml -a k8s-inspect' \
       {posargs}
 
 [testenv:deploy-terraform]


### PR DESCRIPTION
Adds a k8s-inspect addon for dumping the k8s inspect report into the juju crashdump