### PR TITLE
Release-1.33 branch follows 1.33-classic snaps

### DIFF
--- a/.github/workflows/update-snap-revision.py
+++ b/.github/workflows/update-snap-revision.py
@@ -13,7 +13,7 @@ import yaml
 
 logging.basicConfig(format="%(levelname)-8s: %(message)s", level=logging.INFO)
 log = logging.getLogger("update-snap-revision")
-TRACK = "1.32-classic"
+TRACK = f"{t}-classic" if (t := os.getenv("TRACK")) else ""
 RISK = "stable"
 ROOT = Path(__file__).parent / ".." / ".."
 INSTALLATION = ROOT / "charms/worker/k8s/templates/snap_installation.yaml"
@@ -46,7 +46,7 @@ def find_snapstore_revision(arch: str, track: str, risk: str) -> str:
         if (channel := mapping.get("channel")) and (
             channel.get("architecture") == arch
             and (channel.get("risk") == risk if risk else True)
-            and track in channel.get("track")
+            and track.startswith(channel.get("track"))
         ):
             rev = mapping.get("revision")
             log.info(

--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -2,10 +2,10 @@
 # See LICENSE file for licensing details.
 
 amd64:
-  - install-type: store
-    name: k8s
-    revision: 4181
+- install-type: store
+  name: k8s
+  revision: 4191
 arm64:
-  - install-type: store
-    name: k8s
-    revision: 4182
+- install-type: store
+  name: k8s
+  revision: 4195


### PR DESCRIPTION
Release branch 1.33 should follow the `TRACK`  in the environment of the [auto-update-snap-revision](https://github.com/canonical/k8s-operator/actions/workflows/auto-update-snap-revision.yaml) job