### PR TITLE
[COS][Backport 1.33] fix: cos-tokens shared in app databag

### DIFF
--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -669,7 +669,7 @@ class K8sCharm(ops.CharmBase):
             to_remove = unit
 
         if peer := self.model.get_relation(CLUSTER_RELATION):
-            self.distributor.revoke_tokens(
+            self.distributor.remove_units(
                 relation=peer,
                 token_strategy=TokenStrategy.CLUSTER,
                 token_type=ClusterTokenType.CONTROL_PLANE,
@@ -677,7 +677,7 @@ class K8sCharm(ops.CharmBase):
             )
 
         for relation in self.model.relations[CLUSTER_WORKER_RELATION]:
-            self.distributor.revoke_tokens(
+            self.distributor.remove_units(
                 relation=relation,
                 token_strategy=TokenStrategy.CLUSTER,
                 token_type=ClusterTokenType.WORKER,

--- a/charms/worker/k8s/src/token_distributor.py
+++ b/charms/worker/k8s/src/token_distributor.py
@@ -38,7 +38,7 @@ from charms.k8s.v0.k8sd_api_manager import (
 
 log = logging.getLogger(__name__)
 
-UNIT_RE = re.compile(r"k8s(-worker)?/\d+")
+UNIT_RE = re.compile(r"^k8s(-worker)?/\d+$")
 
 
 class TokenFailure(BaseModel):
@@ -157,18 +157,18 @@ class ClusterTokenType(Enum):
     NONE = ""
 
 
-class ClusterTokenManager:
-    """Class for managing cluster tokens.
+class TokenManager:
+    """Base class for managing tokens.
 
     Attributes:
-        allocator_needs_tokens: The allocating node does not need a cluster token to join
-        strategy: The cluster strategy for token creation.
-        revoke_on_join: Revoke a token once it's joined.
+        allocator_needs_tokens: Whether the allocating node needs a token to join
+        strategy: The token strategy for token creation.
+        revoke_on_join: Whether to revoke a token after node joins.
     """
 
-    allocator_needs_tokens: bool = False
-    strategy: TokenStrategy = TokenStrategy.CLUSTER
-    revoke_on_join = True
+    allocator_needs_tokens: bool
+    strategy: TokenStrategy
+    revoke_on_join: bool
 
     def __init__(self, api_manager: K8sdAPIManager):
         """Initialize a ClusterTokenManager instance.
@@ -177,6 +177,103 @@ class ClusterTokenManager:
             api_manager (K8sdAPIManager): An K8sdAPIManager object for interacting with k8sd API.
         """
         self.api_manager = api_manager
+
+    def create(self, name: str, token_type: ClusterTokenType) -> SecretStr:
+        """Create a cluster token."""
+        raise NotImplementedError
+
+    def remove(self, name: str, secret: Optional[ops.Secret], ignore_errors: bool):
+        """Remove a cluster token."""
+        raise NotImplementedError
+
+    def grant(
+        self,
+        relation: ops.Relation,
+        charm: ops.CharmBase,
+        unit: ops.Unit,
+        secret: ops.Secret,
+    ):
+        """Share and grant a secret with a unit on this relation.
+
+        Args:
+            relation (ops.Relation): Which relation
+            charm (ops.CharmBase): A charm object representing the current charm.
+            unit (ops.Unit): The unit the secret is intended for
+            secret (ops.Secret): The secret to share over the relation
+        """
+        secret_key = CLUSTER_SECRET_ID.format(unit.name)
+        log.info(
+            "Grant %s token for '%s' on %s",
+            self.strategy.name.title(),
+            secret_key,
+            relation.name,
+        )
+        if secret.id is None:
+            raise ReconcilerError("Secret ID is None, cannot grant secret")
+
+        relation.data[charm.unit].pop(secret_key, None)
+        relation.data[charm.app][secret_key] = secret.id
+        secret.grant(relation, unit=unit)
+
+    def revoke(self, relation: ops.Relation, charm: ops.CharmBase, unit: ops.Unit) -> None:
+        """Revoke a secret offered to a unit on this relation.
+
+        Args:
+            relation (ops.Relation): Which relation
+            charm (ops.CharmBase): A charm object representing the current charm.
+            unit (ops.Unit): The unit the secret is intended for
+        """
+        secret_key = CLUSTER_SECRET_ID.format(unit.name)
+        log.info(
+            "Revoke %s token for '%s' on %s",
+            self.strategy.name.title(),
+            secret_key,
+            relation.name,
+        )
+
+        by_app = relation.data[charm.app].pop(secret_key, None)
+        by_unit = relation.data[charm.unit].pop(secret_key, None)
+
+        if juju_secret := (by_app or by_unit):
+            secret = charm.model.get_secret(id=juju_secret)
+            secret.remove_all_revisions()
+
+    def get_juju_secret(
+        self, relation: ops.Relation, charm: ops.CharmBase, unit: ops.Unit
+    ) -> Optional[ops.Secret]:
+        """Lookup juju secret offered to a unit on this relation.
+
+        Args:
+            relation (ops.Relation): Which relation (cluster or k8s-cluster)
+            charm (ops.CharmBase): A charm object representing the current charm.
+            unit (ops.Unit): The unit the secret is intended for
+
+        Returns:
+            secret_id (None | ops.Secret) if on the relation
+        """
+        secret_key = CLUSTER_SECRET_ID.format(unit.name)
+        by_app = relation.data[charm.app].get(secret_key)
+        by_unit = relation.data[charm.unit].get(secret_key)
+        juju_secret = by_app or by_unit
+
+        log.info(
+            "%s %s token for '%s' on %s",
+            "Found" if juju_secret else "Didn't find",
+            self.strategy.name.title(),
+            secret_key,
+            relation.name,
+        )
+        if juju_secret:
+            return charm.model.get_secret(id=juju_secret)
+        return None
+
+
+class ClusterTokenManager(TokenManager):
+    """Class for managing cluster tokens."""
+
+    allocator_needs_tokens: bool = False
+    revoke_on_join = True
+    strategy: TokenStrategy = TokenStrategy.CLUSTER
 
     def create(self, name: str, token_type: ClusterTokenType) -> SecretStr:
         """Create a cluster token.
@@ -191,16 +288,16 @@ class ClusterTokenManager:
         worker = token_type == ClusterTokenType.WORKER
         return self.api_manager.create_join_token(name, worker=worker)
 
-    def revoke(self, name: str, _secret: Optional[ops.Secret], ignore_errors: bool):
+    def remove(self, name: str, secret: Optional[ops.Secret], ignore_errors: bool):
         """Remove a cluster token.
 
         Args:
             name (str):                     The name of the node.
-            _secret (Optional[ops.Secret]): The secret to revoke
+            secret (Optional[ops.Secret]):  The secret to remove
             ignore_errors (bool):           Whether or not errors can be ignored
 
         Raises:
-            K8sdConnectionError: reraises cluster token revoke failures
+            K8sdConnectionError: reraises cluster token remove failures
         """
         try:
             self.api_manager.remove_node(name)
@@ -215,26 +312,12 @@ class ClusterTokenManager:
                 raise
 
 
-class CosTokenManager:
-    """Class for managing COS tokens.
-
-    Attributes:
-        allocator_needs_tokens: The allocating node needs a cos-token to join
-        strategy: The cos strategy for token creation.
-        revoke_on_join: Don't revoke a token once it's joined.
-    """
+class CosTokenManager(TokenManager):
+    """Class for managing COS tokens."""
 
     allocator_needs_tokens: bool = True
-    strategy: TokenStrategy = TokenStrategy.COS
     revoke_on_join = False
-
-    def __init__(self, api_manager: K8sdAPIManager):
-        """Initialize a CosTokenManager instance.
-
-        Args:
-            api_manager (K8sdAPIManager): An K8sdAPIManager object for interacting with k8sd API.
-        """
-        self.api_manager = api_manager
+    strategy: TokenStrategy = TokenStrategy.COS
 
     def create(self, name: str, token_type: ClusterTokenType) -> SecretStr:
         """Create a COS token.
@@ -251,11 +334,11 @@ class CosTokenManager:
             username=f"system:cos:{name}", groups=["system:cos"]
         )
 
-    def revoke(self, _name: str, secret: Optional[ops.Secret], ignore_errors: bool):
+    def remove(self, name: str, secret: Optional[ops.Secret], ignore_errors: bool):
         """Remove a COS token intentionally left unimplemented.
 
         Args:
-            _name (str):                   The name of the node.
+            name (str):                   The name of the node.
             secret (Optional[ops.Secret]): The secret to revoke
             ignore_errors (bool):          Whether or not errors can be ignored
 
@@ -274,7 +357,7 @@ class CosTokenManager:
                 # "Remote end closed connection without response"
                 # "Failed to check if node is control-plane"
                 # Removing a node that doesn't exist
-                log.warning("Revoke_Auth_Token %s: but with an expected error: %s", _name, e)
+                log.warning("Revoke_Auth_Token %s: but with an expected error: %s", name, e)
             else:
                 raise
 
@@ -359,7 +442,7 @@ class TokenCollector:
         secret_key = CLUSTER_SECRET_ID.format(self.charm.unit.name)
         secret_ids = {
             secret_id
-            for unit in relation.units | {self.charm.unit}
+            for unit in relation.units | {self.charm.unit, relation.app}
             if (secret_id := relation.data[unit].get(secret_key))
         }
 
@@ -390,9 +473,6 @@ class TokenCollector:
         self.cluster_name(relation, True)
 
 
-TokenManager = Union[ClusterTokenManager, CosTokenManager]
-
-
 class TokenDistributor:
     """Helper class for distributing tokens to units in a relation."""
 
@@ -410,33 +490,6 @@ class TokenDistributor:
             TokenStrategy.CLUSTER: ClusterTokenManager(api_manager),
             TokenStrategy.COS: CosTokenManager(api_manager),
         }
-
-    def _get_juju_secret(self, relation: ops.Relation, unit: ops.Unit) -> Optional[ops.Secret]:
-        """Lookup juju secret offered to a unit on this relation.
-
-        Args:
-            relation (ops.Relation): Which relation (cluster or k8s-cluster)
-            unit (ops.Unit): The unit the secret is intended for
-
-        Returns:
-            secret_id (None | ops.Secret) if on the relation
-        """
-        secret_id = CLUSTER_SECRET_ID.format(unit.name)
-        if juju_secret := relation.data[self.charm.unit].get(secret_id):
-            return self.charm.model.get_secret(id=juju_secret)
-        return None
-
-    def _revoke_juju_secret(self, relation: ops.Relation, unit: ops.Unit) -> None:
-        """Revoke and remove juju secret offered to a unit on this relation.
-
-        Args:
-            relation (ops.Relation): Which relation (cluster or k8s-cluster)
-            unit (ops.Unit): The unit the secret is intended for
-        """
-        secret_id = CLUSTER_SECRET_ID.format(unit.name)
-        if juju_secret := relation.data[self.charm.unit].pop(secret_id, None):
-            secret = self.charm.model.get_secret(id=juju_secret)
-            secret.remove_all_revisions()
 
     def active_nodes(self, relation: ops.Relation):
         """Get nodes from application databag for given relation.
@@ -523,7 +576,7 @@ class TokenDistributor:
         for unit in units:
             remote_cluster = relation.data[unit].get(CLUSTER_JOINED)
             node = relation.data[unit].get(CLUSTER_NODE_NAME)
-            secret = self._get_juju_secret(relation, unit)
+            secret = tokenizer.get_juju_secret(relation, self.charm, unit)
             if not node:
                 log.info(
                     "Wait for %s token allocation of %s with unit=%s:%s",
@@ -559,8 +612,9 @@ class TokenDistributor:
                 )
                 self.update_node(relation, unit, f"joined-{node}")
                 if tokenizer.revoke_on_join:
-                    self._revoke_juju_secret(relation, unit)
-
+                    tokenizer.revoke(relation, self.charm, unit)
+                elif secret:
+                    tokenizer.grant(relation, self.charm, unit, secret)
                 continue  # unit reports its joined already
             if secret:
                 # unit has been assigned a join-token
@@ -585,6 +639,7 @@ class TokenDistributor:
                         unit.name,
                         node,
                     )
+                    tokenizer.grant(relation, self.charm, unit, secret)
                     continue
 
             log.info(
@@ -595,7 +650,6 @@ class TokenDistributor:
                 node,
             )
             token = tokenizer.create(node, token_type)
-            secret_id = CLUSTER_SECRET_ID.format(unit.name)
             if not secret:
                 content = TokenContent(token=token, revision=0)
                 secret = relation.app.add_secret(content.model_dump())
@@ -604,11 +658,10 @@ class TokenDistributor:
                 content.token = token
                 content.revision += 1
                 secret.set_content(content.model_dump())
-            secret.grant(relation, unit=unit)
-            relation.data[self.charm.unit][secret_id] = secret.id or ""
+            tokenizer.grant(relation, self.charm, unit, secret)
             self.update_node(relation, unit, f"pending-{node}")
 
-    def revoke_tokens(
+    def remove_units(
         self,
         relation: ops.Relation,
         token_strategy: TokenStrategy,
@@ -655,6 +708,9 @@ class TokenDistributor:
                 f"Revoking {token_type.name.title()} {token_strategy.name.title()} tokens"
             )
         )
+        tokenizer = self.token_strategies.get(token_strategy)
+        if not tokenizer:
+            raise ReconcilerError(f"Invalid token_strategy: {token_strategy}")
 
         for unit in remove:
             if node_state := app_databag.get(unit):
@@ -672,11 +728,10 @@ class TokenDistributor:
                 ignore_errors |= state == "pending"  # on pending tokens
                 # if cluster doesn't match
                 ignore_errors |= self.charm.get_cluster_name() != joined_cluster(relation, unit)
-                self.token_strategies[token_strategy].revoke(
-                    node, self._get_juju_secret(relation, unit), ignore_errors
-                )
+                secret = tokenizer.get_juju_secret(relation, self.charm, unit)
+                tokenizer.remove(node, secret, ignore_errors)
                 self.drop_node(relation, unit)
-                self._revoke_juju_secret(relation, unit)
+                tokenizer.revoke(relation, self.charm, unit)
 
 
 def joined_cluster(relation: ops.Relation, unit: ops.Unit) -> Optional[str]:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -316,7 +316,7 @@ async def grafana_agent(kubernetes_cluster: Model):
     series = juju.utils.get_version_series(data["base"].split("@")[1])
     url = URL("ch", name="grafana-agent", series=series, architecture=arch)
 
-    await kubernetes_cluster.deploy(url, channel="stable", series=series)
+    await kubernetes_cluster.deploy(url, channel="1/stable", series=series)
     await kubernetes_cluster.integrate("grafana-agent:cos-agent", "k8s:cos-agent")
     await kubernetes_cluster.integrate("grafana-agent:cos-agent", "k8s-worker:cos-agent")
     await kubernetes_cluster.integrate("k8s:cos-worker-tokens", "k8s-worker:cos-tokens")

--- a/tests/unit/test_token_distributor.py
+++ b/tests/unit/test_token_distributor.py
@@ -8,6 +8,7 @@
 
 import json
 import unittest.mock as mock
+from collections import defaultdict
 
 import ops
 import pytest
@@ -78,3 +79,67 @@ def test_token_content(revision, token):
         assert c.token.get_secret_value() == "my-token"
         assert c.model_dump() == {"revision": str_rev, "token": "my-token"}
         assert c.model_dump_json() == f'{{"revision":"{str_rev}","token":"my-token"}}'
+
+
+@pytest.mark.parametrize(
+    "manager_klass",
+    [
+        token_distributor.ClusterTokenManager,
+        token_distributor.CosTokenManager,
+    ],
+)
+def test_token_manager_grant(manager_klass, request, caplog):
+    """Test token manager can share into correct relation databag."""
+    api_manager_mock = mock.MagicMock(spec=token_distributor.K8sdAPIManager)
+    manager = manager_klass(api_manager_mock())
+    charm = mock.MagicMock(spec=ops.CharmBase)()
+    unit = mock.MagicMock(spec=ops.Unit)()
+    secret = mock.MagicMock(spec=ops.Secret)()
+    relation = mock.MagicMock()
+    relation.name = request.node.name
+    relation.data = defaultdict(dict)
+    secret_key = token_distributor.CLUSTER_SECRET_ID.format(unit.name)
+    relation.data[charm.unit][secret_key] = "my-value"
+
+    caplog.set_level("DEBUG")
+
+    manager.grant(relation, charm, unit, secret)
+    assert relation.data[charm.app][secret_key] == secret.id
+    assert secret_key not in relation.data[charm.unit]
+
+    title = manager_klass.strategy.name.title()
+    assert f"Grant {title} token for '{secret_key}' on {relation.name}" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "manager_klass",
+    [
+        token_distributor.ClusterTokenManager,
+        token_distributor.CosTokenManager,
+    ],
+)
+def test_token_manager_get_revoke(manager_klass, request, caplog):
+    """Test token manager can unshare from correct relation databag."""
+    api_manager_mock = mock.MagicMock(spec=token_distributor.K8sdAPIManager)
+    manager = manager_klass(api_manager_mock())
+    charm = mock.MagicMock(spec=ops.CharmBase)()
+    unit = mock.MagicMock(spec=ops.Unit)()
+    relation = mock.MagicMock()
+    relation.name = request.node.name
+    relation.data = defaultdict(dict)
+    secret_key = token_distributor.CLUSTER_SECRET_ID.format(unit.name)
+    relation.data[charm.app][secret_key] = "my-value"
+    relation.data[charm.unit][secret_key] = "my-value"
+    caplog.set_level("DEBUG")
+
+    secret = manager.get_juju_secret(relation, charm, unit)
+    charm.model.get_secret.assert_called_once_with(id="my-value")
+
+    manager.revoke(relation, charm, unit)
+    assert secret_key not in relation.data[charm.unit]
+    assert secret_key not in relation.data[charm.app]
+    secret.remove_all_revisions.assert_called_once_with()
+
+    title = manager_klass.strategy.name.title()
+    assert f"Found {title} token for '{secret_key}' on {relation.name}" in caplog.text
+    assert f"Revoke {title} token for '{secret_key}' on {relation.name}" in caplog.text


### PR DESCRIPTION
Backports #649 to release-1.33 branch

----

Fixes issue #648 

* Move get/share/unshare to the TokenManager class to control which relation buckets secret ids appear
* Fix unit name regex for finding unused tokens
* follow 1/stable grafana-agent