### PR TITLE
[Backport 1.33] Integration tests can skip cos tests on arm64

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -4,24 +4,6 @@ on:
   pull_request:
 
 jobs:
-  extra-args:
-    runs-on: ubuntu-latest
-    outputs:
-      args: ${{ steps.flags.outputs.args }}
-    steps:
-      - name: Determine extra args
-        id: flags
-        env:
-          TITLE: ${{ github.event.pull_request.title }}
-          JOB: ${{ github.job }}
-          WORKFLOW: ${{ github.workflow }}
-        run: |
-          EXTRA_ARGS="--crash-dump=on-failure"
-          if [[ "$TITLE" == *"[COS]"* ]]; then
-            EXTRA_ARGS="$EXTRA_ARGS --cos"
-          fi
-          echo "args=$EXTRA_ARGS" >> "$GITHUB_OUTPUT"
-
   charmcraft-channel:
     runs-on: ubuntu-24.04
     outputs:
@@ -33,7 +15,6 @@ jobs:
 
   select-tests:
     runs-on: ubuntu-24.04
-    needs: [extra-args]
     permissions:
       contents: read
     outputs:
@@ -52,7 +33,7 @@ jobs:
         run: |
           list_modules() {
             ARCH=$1
-            MODULES=$(tox -e integration -- --arch "$ARCH" --collect-only -q 2>/dev/null \
+            MODULES=$(tox -e integration -- --collect-only -q --arch "$ARCH" 2>/dev/null \
               | grep -E '<Module test_.*\.py>' \
               | sed -E 's/.*<Module (test_[^.]*)\.py>.*/\1/' \
               | sort -u)
@@ -65,7 +46,7 @@ jobs:
 
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
-    needs: [charmcraft-channel, extra-args, select-tests]
+    needs: [charmcraft-channel, select-tests]
     permissions:
       contents: read
       actions: write
@@ -90,7 +71,6 @@ jobs:
       builder-runner-label: ${{ matrix.arch.builder-label }}
       charmcraft-channel: ${{ needs.charmcraft-channel.outputs.channel }}
       extra-arguments: >-
-        ${{needs.extra-args.outputs.args}}
         ${{ matrix.arch.id == 'arm64' && ' --lxd-containers --series=jammy' || '' }}
       modules: ${{ matrix.arch.modules }}
       juju-channel: 3/stable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,10 +201,6 @@ Running the integration tests with extra arguments can be accomplished with
 tox run -e integration-tests -- --positional --arguments
 ```
 
-#### Canonical observability integration
-
-The COS integration tests are optional as these are slow/heavy tests. Currently, this suite only runs on LXD. If you are modifying something related to the COS integration, you can validate your changes through integration testing using the flag `--cos`. Also, when submitting a Pull Request with changes related to COS, you must include the `[COS]` tag in your Pull Request description. This will instruct GitHub Actions to execute the respective validation tests against your changes.
-
 #### Useful arguments
 
 `--keep-models`: Doesn't delete the model once the integration tests are finished

--- a/charms/worker/k8s/pyproject.toml
+++ b/charms/worker/k8s/pyproject.toml
@@ -44,6 +44,7 @@ lint = [
     "types-PyYAML"
 ]
 integration = [
+    "async-lru",
     "juju",
     "pydantic",
     "pylxd",

--- a/charms/worker/k8s/uv.lock
+++ b/charms/worker/k8s/uv.lock
@@ -40,6 +40,18 @@ wheels = [
 ]
 
 [[package]]
+name = "async-lru"
+version = "2.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/4d/71ec4d3939dc755264f680f6c2b4906423a304c3d18e96853f0a595dfe97/async_lru-2.0.5.tar.gz", hash = "sha256:481d52ccdd27275f42c43a928b4a50c3bfb2d67af4e78b170e3e0bb39c66e5bb", size = 10380, upload-time = "2025-03-16T17:25:36.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/49/d10027df9fce941cb8184e78a02857af36360d33e1721df81c5ed2179a1a/async_lru-2.0.5-py3-none-any.whl", hash = "sha256:ab95404d8d2605310d345932697371a5f40def0487c03d6d0ad9138de52c9943", size = 6069, upload-time = "2025-03-16T17:25:35.422Z" },
+]
+
+[[package]]
 name = "backports-datetime-fromisoformat"
 version = "2.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -796,6 +808,7 @@ docs = [
     { name = "vale" },
 ]
 integration = [
+    { name = "async-lru" },
     { name = "juju" },
     { name = "pydantic" },
     { name = "pylxd" },
@@ -852,6 +865,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 docs = [{ name = "vale" }]
 integration = [
+    { name = "async-lru" },
     { name = "juju" },
     { name = "pydantic" },
     { name = "pylxd" },

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -46,8 +46,6 @@ def pytest_addoption(parser: pytest.Parser):
         Example: k8s-worker_ubuntu-22.04-amd64_ubuntu-24.04-amd64.charm
         Some tests use subordinate charms (e.g. Ceph) that expect the charm
         base to match.
-    --cos
-        Add COS integration tests.
     --lxd-containers
         If cloud is LXD, use containers instead of LXD VMs.
         Note that some charms may not work in LXD containers (e.g. Ceph).
@@ -88,7 +86,6 @@ def pytest_addoption(parser: pytest.Parser):
             "base to match."
         ),
     )
-    parser.addoption("--cos", action="store_true", default=False, help="Run COS integration tests")
     parser.addoption(
         "--lxd-containers",
         action="store_true",
@@ -123,16 +120,12 @@ def pytest_collection_modifyitems(config, items):
         config (pytest.Config): The pytest config object.
         items (List[pytest.Item]): List of item objects.
     """
-    cos_active = config.getoption("--cos")
     arch_filter = config.getoption("--arch")
 
     selected, deselected = [], []
 
     for item in items:
-        if item.get_closest_marker("cos") and not cos_active:
-            # Any test marked cos only runs if --cos is activated.
-            deselected.append(item)
-        elif (
+        if (
             (arch_mark := item.get_closest_marker("architecture"))
             and arch_filter
             and arch_mark.args
@@ -310,23 +303,28 @@ async def api_client(
 @pytest_asyncio.fixture(name="_grafana_agent", scope="module")
 async def grafana_agent(kubernetes_cluster: Model):
     """Deploy Grafana Agent."""
-    primary = kubernetes_cluster.applications["k8s"]
-    data = primary.units[0].machine.safe_data
+    apps = ["k8s", "k8s-worker"]
+    k8s, worker = (kubernetes_cluster.applications.get(a) for a in apps)
+    if not k8s:
+        pytest.fail("k8s application not found in the model")
+    data = k8s.units[0].machine.safe_data
     arch = data["hardware-characteristics"]["arch"]
     series = juju.utils.get_version_series(data["base"].split("@")[1])
     url = URL("ch", name="grafana-agent", series=series, architecture=arch)
 
-    await kubernetes_cluster.deploy(url, channel="stable", series=series)
+    await kubernetes_cluster.deploy(url, channel="1/stable", series=series)
     await kubernetes_cluster.integrate("grafana-agent:cos-agent", "k8s:cos-agent")
-    await kubernetes_cluster.integrate("grafana-agent:cos-agent", "k8s-worker:cos-agent")
-    await kubernetes_cluster.integrate("k8s:cos-worker-tokens", "k8s-worker:cos-tokens")
+    if worker:
+        await kubernetes_cluster.integrate("grafana-agent:cos-agent", "k8s-worker:cos-agent")
+        await kubernetes_cluster.integrate("k8s:cos-worker-tokens", "k8s-worker:cos-tokens")
 
     yield
 
     await kubernetes_cluster.remove_application("grafana-agent")
-    await kubernetes_cluster.applications["k8s"].destroy_relation(
-        "cos-worker-tokens", "k8s-worker:cos-tokens", block_until_done=True
-    )
+    if worker:
+        await kubernetes_cluster.applications["k8s"].destroy_relation(
+            "cos-worker-tokens", "k8s-worker:cos-tokens", block_until_done=True
+        )
 
 
 @pytest_asyncio.fixture(scope="module")

--- a/tests/integration/data/test-bundle-cos.yaml
+++ b/tests/integration/data/test-bundle-cos.yaml
@@ -1,0 +1,15 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: integration-test
+description: |-
+  Used to deploy or refresh within an integration test model
+series: jammy
+applications:
+  k8s:
+    charm: k8s
+    num_units: 1
+    constraints: cores=2 mem=8G root-disk=16G
+    expose: true
+    options:
+      bootstrap-datastore: managed-etcd

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -18,6 +18,7 @@ import juju.model
 import juju.unit
 import juju.utils
 import yaml
+from async_lru import alru_cache
 from juju.url import URL
 from pytest_operator.plugin import OpsTest
 from tenacity import (
@@ -592,6 +593,7 @@ class Bundle:
         return True
 
 
+@alru_cache
 async def cloud_arch(ops_test: OpsTest) -> str:
     """Return current architecture of the selected controller.
 
@@ -611,6 +613,7 @@ async def cloud_arch(ops_test: OpsTest) -> str:
     return arch.pop().strip()
 
 
+@alru_cache
 async def cloud_type(ops_test: OpsTest) -> Tuple[str, bool]:
     """Return current cloud type of the selected controller.
 

--- a/tests/integration/test_cos.py
+++ b/tests/integration/test_cos.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests."""
+
+import asyncio
+import logging
+
+import juju.model
+import pytest
+from grafana import Grafana
+from prometheus import Prometheus
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+log = logging.getLogger(__name__)
+
+
+pytestmark = [
+    pytest.mark.bundle(file="test-bundle-cos.yaml", apps_local=["k8s"]),
+    pytest.mark.architecture("amd64"),
+]
+
+
+@pytest.mark.cos
+@retry(reraise=True, stop=stop_after_attempt(12), wait=wait_fixed(60))
+async def test_grafana(
+    traefik_url: str,
+    grafana_password: str,
+    expected_dashboard_titles: set,
+    cos_model: juju.model.Model,
+    timeout: int,
+):
+    """Test integration with Grafana."""
+    grafana = Grafana(model_name=cos_model.name, base=traefik_url, password=grafana_password)
+    await asyncio.wait_for(grafana.is_ready(), timeout=timeout * 60)
+    dashboards = await grafana.dashboards_all()
+    actual_dashboard_titles = set()
+
+    for dashboard in dashboards:
+        actual_dashboard_titles.add(dashboard.get("title"))
+
+    assert expected_dashboard_titles.issubset(actual_dashboard_titles)
+
+
+@pytest.mark.cos
+@pytest.mark.usefixtures("related_prometheus")
+@retry(reraise=True, stop=stop_after_attempt(12), wait=wait_fixed(60))
+async def test_prometheus(traefik_url: str, cos_model: juju.model.Model, timeout: int):
+    """Test integration with Prometheus."""
+    prometheus = Prometheus(model_name=cos_model.name, base=traefik_url)
+    await asyncio.wait_for(prometheus.is_ready(), timeout=timeout * 60)
+
+    queries = [
+        'up{job="kubelet", metrics_path="/metrics"} > 0',
+        'up{job="kubelet", metrics_path="/metrics/cadvisor"} > 0',
+        'up{job="kubelet", metrics_path="/metrics/probes"} > 0',
+        'up{job="apiserver"} > 0',
+        'up{job="kube-controller-manager"} > 0',
+        'up{job="kube-scheduler"} > 0',
+        'up{job="kube-proxy"} > 0',
+        'up{job="kube-state-metrics"} > 0',
+    ]
+    results = await asyncio.gather(*[prometheus.get_metrics(query) for query in queries])
+    failed = [query for query, result in zip(queries, results) if not result]
+    assert not failed, f"Failed queries: {failed}"

--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -13,11 +13,8 @@ import juju.model
 import juju.unit
 import pytest
 import pytest_asyncio
-from grafana import Grafana
 from helpers import get_leader, get_rsc, ready_nodes, wait_pod_phase
 from literals import ONE_MIN
-from prometheus import Prometheus
-from tenacity import retry, stop_after_attempt, wait_fixed
 
 log = logging.getLogger(__name__)
 
@@ -239,47 +236,3 @@ async def test_override_snap_resource(kubernetes_cluster: juju.model.Model, requ
         with revert.open("rb") as obj:
             k8s.attach_resource("snap-installation", revert, obj)
             await kubernetes_cluster.wait_for_idle(status="active")
-
-
-@pytest.mark.cos
-@retry(reraise=True, stop=stop_after_attempt(12), wait=wait_fixed(60))
-async def test_grafana(
-    traefik_url: str,
-    grafana_password: str,
-    expected_dashboard_titles: set,
-    cos_model: juju.model.Model,
-    timeout: int,
-):
-    """Test integration with Grafana."""
-    grafana = Grafana(model_name=cos_model.name, base=traefik_url, password=grafana_password)
-    await asyncio.wait_for(grafana.is_ready(), timeout=timeout * 60)
-    dashboards = await grafana.dashboards_all()
-    actual_dashboard_titles = set()
-
-    for dashboard in dashboards:
-        actual_dashboard_titles.add(dashboard.get("title"))
-
-    assert expected_dashboard_titles.issubset(actual_dashboard_titles)
-
-
-@pytest.mark.cos
-@pytest.mark.usefixtures("related_prometheus")
-@retry(reraise=True, stop=stop_after_attempt(12), wait=wait_fixed(60))
-async def test_prometheus(traefik_url: str, cos_model: juju.model.Model, timeout: int):
-    """Test integration with Prometheus."""
-    prometheus = Prometheus(model_name=cos_model.name, base=traefik_url)
-    await asyncio.wait_for(prometheus.is_ready(), timeout=timeout * 60)
-
-    queries = [
-        'up{job="kubelet", metrics_path="/metrics"} > 0',
-        'up{job="kubelet", metrics_path="/metrics/cadvisor"} > 0',
-        'up{job="kubelet", metrics_path="/metrics/probes"} > 0',
-        'up{job="apiserver"} > 0',
-        'up{job="kube-controller-manager"} > 0',
-        'up{job="kube-scheduler"} > 0',
-        'up{job="kube-proxy"} > 0',
-        'up{job="kube-state-metrics"} > 0',
-    ]
-    results = await asyncio.gather(*[prometheus.get_metrics(query) for query in queries])
-    failed = [query for query, result in zip(queries, results) if not result]
-    assert not failed, f"Failed queries: {failed}"


### PR DESCRIPTION
Backport #653 

* Integration tests can skip cos tests on arm64
* Move cos tests to its own module
* Always run cos integration tests
