### PR TITLE
[Backport 1.32] Integration tests can skip cos tests on arm64

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -5,24 +5,6 @@ on:
   pull_request:
 
 jobs:
-  extra-args:
-    runs-on: ubuntu-latest
-    outputs:
-      args: ${{ steps.flags.outputs.args }}
-    steps:
-      - name: Determine extra args
-        id: flags
-        env:
-          TITLE: ${{ github.event.pull_request.title }}
-          JOB: ${{ github.job }}
-          WORKFLOW: ${{ github.workflow }}
-        run: |
-          EXTRA_ARGS="--crash-dump=on-failure"
-          if [[ "$TITLE" == *"[COS]"* ]]; then
-            EXTRA_ARGS="$EXTRA_ARGS --cos"
-          fi
-          echo "args=$EXTRA_ARGS" >> "$GITHUB_OUTPUT"
-
   charmcraft-channel:
     runs-on: ubuntu-24.04
     outputs:
@@ -34,7 +16,7 @@ jobs:
 
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
-    needs: [charmcraft-channel, extra-args]
+    needs: [charmcraft-channel]
     secrets: inherit
     strategy:
       matrix:
@@ -44,7 +26,7 @@ jobs:
           builder-label: ubuntu-22.04
           tester-arch: AMD64
           tester-size: xlarge
-          modules: '["test_k8s", "test_etcd", "test_dqlite", "test_ceph", "test_upgrade"]'
+          modules: '["test_cos", "test_k8s", "test_etcd", "test_dqlite", "test_ceph", "test_upgrade"]'
         # built and test on on self-hosted
         - id: arm64
           builder-label: ARM64
@@ -56,7 +38,6 @@ jobs:
       builder-runner-label: ${{ matrix.arch.builder-label }}
       charmcraft-channel: ${{ needs.charmcraft-channel.outputs.channel }}
       extra-arguments: >-
-        ${{needs.extra-args.outputs.args}}
         ${{ matrix.arch.id == 'arm64' && ' --lxd-containers --series=jammy' || '' }}
       modules: ${{ matrix.arch.modules }}
       juju-channel: 3/stable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,10 +201,6 @@ Running the integration tests with extra arguments can be accomplished with
 tox run -e integration-tests -- --positional --arguments
 ```
 
-#### Canonical observability integration
-
-The COS integration tests are optional as these are slow/heavy tests. Currently, this suite only runs on LXD. If you are modifying something related to the COS integration, you can validate your changes through integration testing using the flag `--cos`. Also, when submitting a Pull Request with changes related to COS, you must include the `[COS]` tag in your Pull Request description. This will instruct GitHub Actions to execute the respective validation tests against your changes.
-
 #### Useful arguments
 
 `--keep-models`: Doesn't delete the model once the integration tests are finished

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
+async-lru
 juju
 pydantic<2
 pylxd

--- a/tests/integration/data/test-bundle-cos.yaml
+++ b/tests/integration/data/test-bundle-cos.yaml
@@ -1,0 +1,15 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: integration-test
+description: |-
+  Used to deploy or refresh within an integration test model
+series: jammy
+applications:
+  k8s:
+    charm: k8s
+    num_units: 1
+    constraints: cores=2 mem=8G root-disk=16G
+    expose: true
+    options:
+      bootstrap-datastore: managed-etcd

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -18,6 +18,7 @@ import juju.model
 import juju.unit
 import juju.utils
 import yaml
+from async_lru import alru_cache
 from juju.url import URL
 from pytest_operator.plugin import OpsTest
 from tenacity import AsyncRetrying, before_sleep_log, retry, stop_after_attempt, wait_fixed
@@ -554,6 +555,7 @@ class Bundle:
         return target
 
 
+@alru_cache
 async def cloud_arch(ops_test: OpsTest) -> str:
     """Return current architecture of the selected controller.
 
@@ -573,6 +575,7 @@ async def cloud_arch(ops_test: OpsTest) -> str:
     return arch.pop().strip()
 
 
+@alru_cache
 async def cloud_type(ops_test: OpsTest) -> Tuple[str, bool]:
     """Return current cloud type of the selected controller.
 

--- a/tests/integration/test_cos.py
+++ b/tests/integration/test_cos.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests."""
+
+import asyncio
+import logging
+
+import juju.model
+import pytest
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+from .grafana import Grafana
+from .prometheus import Prometheus
+
+log = logging.getLogger(__name__)
+
+
+pytestmark = [
+    pytest.mark.bundle(file="test-bundle-cos.yaml", apps_local=["k8s"]),
+    pytest.mark.architecture("amd64"),
+]
+
+
+@pytest.mark.cos
+@retry(reraise=True, stop=stop_after_attempt(12), wait=wait_fixed(60))
+async def test_grafana(
+    traefik_url: str,
+    grafana_password: str,
+    expected_dashboard_titles: set,
+    cos_model: juju.model.Model,
+    timeout: int,
+):
+    """Test integration with Grafana."""
+    grafana = Grafana(model_name=cos_model.name, base=traefik_url, password=grafana_password)
+    await asyncio.wait_for(grafana.is_ready(), timeout=timeout * 60)
+    dashboards = await grafana.dashboards_all()
+    actual_dashboard_titles = set()
+
+    for dashboard in dashboards:
+        actual_dashboard_titles.add(dashboard.get("title"))
+
+    assert expected_dashboard_titles.issubset(actual_dashboard_titles)
+
+
+@pytest.mark.cos
+@pytest.mark.usefixtures("related_prometheus")
+@retry(reraise=True, stop=stop_after_attempt(12), wait=wait_fixed(60))
+async def test_prometheus(traefik_url: str, cos_model: juju.model.Model, timeout: int):
+    """Test integration with Prometheus."""
+    prometheus = Prometheus(model_name=cos_model.name, base=traefik_url)
+    await asyncio.wait_for(prometheus.is_ready(), timeout=timeout * 60)
+
+    queries = [
+        'up{job="kubelet", metrics_path="/metrics"} > 0',
+        'up{job="kubelet", metrics_path="/metrics/cadvisor"} > 0',
+        'up{job="kubelet", metrics_path="/metrics/probes"} > 0',
+        'up{job="apiserver"} > 0',
+        'up{job="kube-controller-manager"} > 0',
+        'up{job="kube-scheduler"} > 0',
+        'up{job="kube-proxy"} > 0',
+        'up{job="kube-state-metrics"} > 0',
+    ]
+    results = await asyncio.gather(*[prometheus.get_metrics(query) for query in queries])
+    failed = [query for query, result in zip(queries, results) if not result]
+    assert not failed, f"Failed queries: {failed}"

--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -13,12 +13,9 @@ import juju.model
 import juju.unit
 import pytest
 import pytest_asyncio
-from tenacity import retry, stop_after_attempt, wait_fixed
 
-from .grafana import Grafana
 from .helpers import get_leader, get_rsc, ready_nodes, wait_pod_phase
 from .literals import ONE_MIN
-from .prometheus import Prometheus
 
 log = logging.getLogger(__name__)
 
@@ -219,47 +216,3 @@ async def test_override_snap_resource(kubernetes_cluster: juju.model.Model, requ
         with revert.open("rb") as obj:
             k8s.attach_resource("snap-installation", revert, obj)
             await kubernetes_cluster.wait_for_idle(status="active")
-
-
-@pytest.mark.cos
-@retry(reraise=True, stop=stop_after_attempt(12), wait=wait_fixed(60))
-async def test_grafana(
-    traefik_url: str,
-    grafana_password: str,
-    expected_dashboard_titles: set,
-    cos_model: juju.model.Model,
-    timeout: int,
-):
-    """Test integration with Grafana."""
-    grafana = Grafana(model_name=cos_model.name, base=traefik_url, password=grafana_password)
-    await asyncio.wait_for(grafana.is_ready(), timeout=timeout * 60)
-    dashboards = await grafana.dashboards_all()
-    actual_dashboard_titles = set()
-
-    for dashboard in dashboards:
-        actual_dashboard_titles.add(dashboard.get("title"))
-
-    assert expected_dashboard_titles.issubset(actual_dashboard_titles)
-
-
-@pytest.mark.cos
-@pytest.mark.usefixtures("related_prometheus")
-@retry(reraise=True, stop=stop_after_attempt(12), wait=wait_fixed(60))
-async def test_prometheus(traefik_url: str, cos_model: juju.model.Model, timeout: int):
-    """Test integration with Prometheus."""
-    prometheus = Prometheus(model_name=cos_model.name, base=traefik_url)
-    await asyncio.wait_for(prometheus.is_ready(), timeout=timeout * 60)
-
-    queries = [
-        'up{job="kubelet", metrics_path="/metrics"} > 0',
-        'up{job="kubelet", metrics_path="/metrics/cadvisor"} > 0',
-        'up{job="kubelet", metrics_path="/metrics/probes"} > 0',
-        'up{job="apiserver"} > 0',
-        'up{job="kube-controller-manager"} > 0',
-        'up{job="kube-scheduler"} > 0',
-        'up{job="kube-proxy"} > 0',
-        'up{job="kube-state-metrics"} > 0',
-    ]
-    results = await asyncio.gather(*[prometheus.get_metrics(query) for query in queries])
-    failed = [query for query, result in zip(queries, results) if not result]
-    assert not failed, f"Failed queries: {failed}"


### PR DESCRIPTION
Backport #653 

* Integration tests can skip cos tests on arm64
* Move cos tests to its own module
* Always run cos integration tests
