### PR TITLE
[DRAFT] - Add Prometheus alert rule for when host out of disk space

### DIFF
--- a/charms/worker/k8s/src/prometheus_alert_rules/kubernetesControlPlane-prometheusRule.yaml
+++ b/charms/worker/k8s/src/prometheus_alert_rules/kubernetesControlPlane-prometheusRule.yaml
@@ -708,6 +708,22 @@ groups:
     for: 10m
     labels:
       severity: info
+  - alert: HostOutOfDiskSpace
+    annotations:
+      summary: "Host out of disk space (instance {{ $labels.instance }})"
+      description: |
+        Disk is almost full (< 10% left) on instance {{ $labels.instance }}, mountpoint {{ $labels.mountpoint }}.
+        VALUE = {{ $value }}
+        DEVICE = {{ $labels.device }}
+        FILESYSTEM TYPE = {{ $labels.fstype }}
+    expr: |
+      (node_filesystem_avail_bytes{fstype!~"^(fuse.*|tmpfs|cifs|nfs)"} 
+        / node_filesystem_size_bytes) < 0.10 
+      and on (instance, device, mountpoint) 
+      node_filesystem_readonly == 0
+    for: 2m
+    labels:
+      severity: critical
   - alert: KubeNodeUnreachable
     annotations:
       description: '{{ $labels.node }} is unreachable and some workloads may be rescheduled


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Adds a Prometheus alert rule for when the host runs out of disk space. Along the same lines as the [KubeNodePressure](https://github.com/canonical/k8s-operator/blob/808ca91103db71ee7597a10f6173ec55af7b5e0d/charms/worker/k8s/src/prometheus_alert_rules/kubernetesControlPlane-prometheusRule.yaml#L697) alert rule.
### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
