### PR TITLE
Allow the bot action to use a canonical email address

### DIFF
--- a/.github/workflows/auto-update-snap-revision.yaml
+++ b/.github/workflows/auto-update-snap-revision.yaml
@@ -88,6 +88,13 @@ jobs:
       run: |
         echo "Would have created pull-request"
         echo '[Release ${{ env.TRACK }}] Update K8s revisions ${{steps.assemble-revisions.outputs.revisions}}'
+
+    - name: Setup Bot User
+      if: ${{ github.event_name == 'schedule' }}
+      run: |
+        git config user.name  "Canonical Github Bot"
+        git config user.email "actions@canonical.com"
+
     - name: Create pull request
       uses: peter-evans/create-pull-request@v7
       if: ${{ github.event_name == 'schedule' && (steps.assemble-revisions.outputs.revisions != '[]') }}


### PR DESCRIPTION
Let the bot set an email address for its own commits:

* https://github.com/canonical/has-signed-canonical-cla/issues/89