### PR TITLE
Pin ruff==0.12.12 for formatting/linting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ passenv =
 allowlist_externals = tox
 description = Apply coding style standards to code
 deps =
-    ruff
+    ruff==0.12.12
 commands =
     ruff format {[vars]all_path}
     ruff check --fix {[vars]all_path}
@@ -51,7 +51,7 @@ setenv =
   PYTHONPATH = {envdir}{:}{[vars]lib_path}
 deps =
     mypy
-    ruff
+    ruff==0.12.12
     pydantic[mypy]
     types-PyYAML
 commands =


### PR DESCRIPTION
### Dependency management

* Pin ruff to prevent linter/formatting errors in release branch