### PR TITLE
docs: kubelet and kube-proxy extra args are runtime configurable

### DIFF
--- a/charms/worker/charmcraft.yaml
+++ b/charms/worker/charmcraft.yaml
@@ -93,9 +93,6 @@ config:
         Space separated list of flags and key=value pairs that will be passed as arguments to
         kube-proxy.
 
-        Notes:
-          Options may only be set on charm deployment
-
         For example a value like this:
           runtime-config=batch/v2alpha1=true profiling=true
         will result in kube-proxy being run with the following options:
@@ -106,9 +103,6 @@ config:
       description: |
         Space separated list of flags and key=value pairs that will be passed as arguments to
         kubelet.
-
-        Notes:
-          Options may only be set on charm deployment
 
         For example a value like this:
           runtime-config=batch/v2alpha1=true profiling=true

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -271,9 +271,6 @@ config:
         Space separated list of flags and key=value pairs that will be passed as arguments to
         kube-proxy.
 
-        Notes:
-          Options may only be set on charm deployment
-
         For example a value like this:
           runtime-config=batch/v2alpha1=true profiling=true
         will result in kube-proxy being run with the following options:
@@ -312,9 +309,6 @@ config:
       description: |
         Space separated list of flags and key=value pairs that will be passed as arguments to
         kubelet.
-
-        Notes:
-          Options may only be set on charm deployment
 
         For example a value like this:
           runtime-config=batch/v2alpha1=true profiling=true


### PR DESCRIPTION
Backport 1.32: https://github.com/canonical/k8s-operator/pull/697

### Overview

k8s and k8s-worker charm documentation on charmhub is incorrect due to old restrictions on the config items `kube-proxy-extra-args` and `kubelet-extra-args`

### Rationale

Update charmcraft.yaml

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
