### PR TITLE
fix: indicate to juju to no longer hold onto failed token content

### DIFF
--- a/charms/worker/k8s/src/token_distributor.py
+++ b/charms/worker/k8s/src/token_distributor.py
@@ -629,6 +629,8 @@ class TokenDistributor:
                         unit.name,
                         node,
                     )
+                    # Prevent secret revision leakage
+                    secret.remove_revision(secret.get_info().revision)
                 else:
                     log.info(
                         "Waiting for %s token to be recovered %s unit=%s:%s (%s)",


### PR DESCRIPTION
### Overview

Indicate to Juju the charm no longer needs this revision when the token reports a failure

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
