### PR TITLE
[Backport 1.33] ARM tests on noble containers

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -71,7 +71,7 @@ jobs:
       builder-runner-label: ${{ matrix.arch.builder-label }}
       charmcraft-channel: ${{ needs.charmcraft-channel.outputs.channel }}
       extra-arguments: >-
-        ${{ matrix.arch.id == 'arm64' && ' --lxd-containers --series=jammy' || '' }}
+        ${{ matrix.arch.id == 'arm64' && ' --lxd-containers --series=noble' || '' }}
       modules: ${{ matrix.arch.modules }}
       juju-channel: 3/stable
       load-test-enabled: false

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -170,7 +170,7 @@ async def cloud_profile(ops_test: OpsTest):
     if _type == "lxd" and not _vms and ops_test.model:
         # lxd-profile to the model if the juju cloud is lxd.
         lxd = LXDSubstrate("", "")
-        profile_name = f"juju-{ops_test.model.name}"
+        profile_name = f"juju-{ops_test.model.name}-{ops_test.model.uuid[:6]}"
         lxd.remove_profile(profile_name)
         lxd.apply_profile("k8s.profile", profile_name)
     elif _type in ("ec2", "openstack") and ops_test.model:

--- a/tests/integration/data/test-smoke.yaml
+++ b/tests/integration/data/test-smoke.yaml
@@ -1,0 +1,16 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: integration-test
+description: |-
+  Used to deploy or refresh within an integration test model
+series: jammy
+applications:
+  k8s:
+    charm: k8s
+    num_units: 1
+    constraints: cores=2 mem=8G root-disk=16G
+    expose: true
+    options:
+      bootstrap-datastore: managed-etcd
+      node-labels: "node-role.kubernetes.io/control-plane= k8sd.io/role=control-plane"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -391,7 +391,7 @@ class Bundle:
         arch = await cloud_arch(ops_test)
         assert arch, "Architecture must be known before customizing the bundle"
 
-        series = ops_test.request.config.getoption("--series")
+        series = ops_test.request.config.option.series
 
         bundle = cls(path=path, arch=arch, series=series)
         assert not all(_ in kwargs for _ in ("apps_local", "apps_channel")), (
@@ -409,7 +409,7 @@ class Bundle:
         """
         if not self._content:
             loaded = yaml.safe_load(self.path.read_bytes())
-            self.series = loaded.get("series")
+            self.series = self.series or loaded.get("series")
             for app in loaded["applications"].values():
                 url = URL.parse(app["charm"])
                 url.architecture = self.arch

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests."""
+
+import asyncio
+import logging
+from pathlib import Path
+
+import juju.model
+import juju.unit
+import pytest
+import pytest_asyncio
+from helpers import get_leader, ready_nodes, wait_pod_phase
+from literals import ONE_MIN
+
+log = logging.getLogger(__name__)
+LOCAL_APPS = ["k8s"]
+
+pytestmark = [
+    pytest.mark.bundle(file="test-smoke.yaml", apps_local=LOCAL_APPS),
+]
+
+pinned_revision = (
+    "latest/edge" not in Path("charms/worker/k8s/templates/snap_installation.yaml").read_text()
+)
+
+
+@pytest_asyncio.fixture
+async def preserve_charm_config(ops_test, kubernetes_cluster: juju.model.Model, timeout: int):
+    """Preserve the charm config changes from a test."""
+    apps = (kubernetes_cluster.applications[a] for a in LOCAL_APPS)
+    pre = await asyncio.gather(*[app.get_config() for app in apps])
+    yield pre
+    post = await asyncio.gather(*[app.get_config() for app in apps])
+
+    for app_before, app_after in zip(pre, post):
+        for key in app_after.keys():
+            # Reset any new config keys added by the test to their default
+            app_before[key] = str(
+                app_after[key]["default"] if key not in app_before else app_before[key]["value"]
+            )
+
+    async with ops_test.fast_forward(ONE_MIN):
+        await asyncio.gather(*[app.set_config(pre[i]) for i, app in enumerate(apps)])
+        await kubernetes_cluster.wait_for_idle(
+            apps=LOCAL_APPS, status="active", timeout=timeout * 60
+        )
+
+
+async def test_nodes_ready(kubernetes_cluster: juju.model.Model):
+    """Deploy the charm and wait for active/idle status."""
+    apps = [kubernetes_cluster.applications[a] for a in LOCAL_APPS]
+    units = [u for a in apps for u in a.units]
+    expected_nodes = sum(len(a.units) for a in apps)
+    await ready_nodes(units[0], expected_nodes)
+
+
+async def test_kube_system_pods(kubernetes_cluster: juju.model.Model):
+    """Test that the kube-system pods are running."""
+    k8s = kubernetes_cluster.applications["k8s"]
+    leader_idx = await get_leader(k8s)
+    leader = k8s.units[leader_idx]
+    await wait_pod_phase(leader, None, "Running", namespace="kube-system")


### PR DESCRIPTION
Backport #718 to 1.33 branch

-------
### Overview

* Address issues where snap installation on jammy contianers running on noble machines don't cooperate
* Address changes to juju where the lxd profile name must first change https://github.com/juju/juju/pull/20357

### Details
* by running ARM tests on a noble gh runner with  noble containers, we expand our noble testing support
* swapping the lxd profile name from `juju-<model>` to `juju-<model>-<model-uuid[:6]>` we still apply the profile for kubernetes to operate
* addition of a new test called `test_smoke` that is a single node k8s (to speed up testing)

