### PR TITLE
test: Add juju 4.x to testing matrix

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -53,6 +53,9 @@ jobs:
     secrets: inherit
     strategy:
       matrix:
+        juju:
+          - channel: 3/stable
+          - channel: 4/candidate
         arch:
           # built on azure, test on self-hosted
           - id: amd64
@@ -73,7 +76,7 @@ jobs:
       extra-arguments: >-
         ${{ matrix.arch.id == 'arm64' && ' --lxd-containers --series=noble' || '' }}
       modules: ${{ matrix.arch.modules }}
-      juju-channel: 3/stable
+      juju-channel: ${{ matrix.juju.channel }}
       load-test-enabled: false
       provider: lxd
       self-hosted-runner: true


### PR DESCRIPTION
### Rationale

This pull request updates the integration test workflow configuration to support testing against multiple Juju channels, improving flexibility and coverage for different Juju versions.

**Integration test workflow enhancements:**

* Added a Juju channel matrix to the `jobs` strategy, allowing tests to run against both `3/stable` and `4/candidate` channels (`.github/workflows/integration_test.yaml`).
* Updated the `juju-channel` input for test jobs to use the matrix value, enabling dynamic selection of the Juju channel per test run (`.github/workflows/integration_test.yaml`).

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
