### PR TITLE
Switch charmed-etcd channel to stable

### DIFF
--- a/tests/integration/data/test-bundle-charmed-etcd.yaml
+++ b/tests/integration/data/test-bundle-charmed-etcd.yaml
@@ -19,7 +19,7 @@ applications:
     num_units: 1
   charmed-etcd:
     charm: charmed-etcd
-    channel: "3.6/edge"
+    channel: "3.6/stable"
     series: noble
     constraints: cores=2 mem=8G root-disk=16G
     num_units: 1


### PR DESCRIPTION
### Overview

This pull request makes a small change to the deployment configuration by updating the `charmed-etcd` application to use the stable channel instead of the edge channel.

* Updated the `charmed-etcd` application in `test-bundle-charmed-etcd.yaml` to use the `"3.6/stable"` channel instead of `"3.6/edge"`, ensuring more reliable and stable deployments.

### Rationale
We should use `charmed-etcd` stable now that it is. The edge channel is for development.

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
