### PR TITLE
[Release 1.32] Update K8s revisions ["amd64-4557","arm64-4559"]

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 4501
+  revision: 4557
 arm64:
 - install-type: store
   name: k8s
-  revision: 4505
+  revision: 4559


### PR DESCRIPTION
Updates K8s revisions for 1.32
* amd64-4557 & arm64-4559
* amd64 revision commit: https://github.com/canonical/k8s-snap/commit/b9668b8bebed105d5728aa851e050e5585902789
* arm64 revision commit: https://github.com/canonical/k8s-snap/commit/b9668b8bebed105d5728aa851e050e5585902789