### PR TITLE
[Release 1.33] Update K8s revisions ["amd64-4558","arm64-4525"]

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 4472
+  revision: 4558
 arm64:
 - install-type: store
   name: k8s
-  revision: 4483
+  revision: 4525


### PR DESCRIPTION
Updates K8s revisions for 1.33
* amd64-4558 & arm64-4525
* amd64 revision commit: https://github.com/canonical/k8s-snap/commit/1a574774f652683fd51ffcd6957274874c624fc3
* arm64 revision commit: https://github.com/canonical/k8s-snap/commit/59e6fb8a1a841dc10f6c3ce9ec5daaab680d9305