### PR TITLE
release: Prepare for `1.34`

### DIFF
--- a/charms/worker/k8s/src/literals.py
+++ b/charms/worker/k8s/src/literals.py
@@ -183,10 +183,10 @@ DEPENDENCIES = {
     },
     # NOTE: Update the dependencies for the k8s-service before releasing.
     "k8s_service": {
-        "dependencies": {"k8s-worker": "^1.32, < 1.34"},
+        "dependencies": {"k8s-worker": "^1.33, < 1.35"},
         "name": "k8s",
-        "upgrade_supported": "^1.32, < 1.34",
-        "version": "1.33.0",
+        "upgrade_supported": "^1.33, < 1.35",
+        "version": "1.34.0",
     },
 }
 

--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -5,9 +5,9 @@ amd64:
   - name: k8s
     install-type: store
     classic: true
-    channel: latest/edge
+    revision: 4539
 arm64:
   - name: k8s
     install-type: store
     classic: true
-    channel: latest/edge
+    revision: 4540


### PR DESCRIPTION
## Overview
Initialize the 1.34 release of `k8s-operator` charms.