### PR TITLE
[Release 1.32] Update K8s revisions ["amd64-4588","arm64-4589"]

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 4557
+  revision: 4588
 arm64:
 - install-type: store
   name: k8s
-  revision: 4559
+  revision: 4589


### PR DESCRIPTION
Updates K8s revisions for 1.32
* amd64-4588 & arm64-4589
* amd64 revision commit: https://github.com/canonical/k8s-snap/commit/e43f85847e1b9432c124275504cc6abacebc6076
* arm64 revision commit: https://github.com/canonical/k8s-snap/commit/e43f85847e1b9432c124275504cc6abacebc6076