### PR TITLE
Revert "chore(deps): update terraform juju to v1 (main)"

### DIFF
--- a/charms/worker/k8s/terraform/versions.tf
+++ b/charms/worker/k8s/terraform/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "< 2.0.0"
+      version = ">= 0.19.0, < 1.0.0"
     }
   }
 }

--- a/charms/worker/terraform/versions.tf
+++ b/charms/worker/terraform/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "< 2.0.0"
+      version = ">= 0.19.0, < 1.0.0"
     }
   }
 }


### PR DESCRIPTION
Reverts canonical/k8s-operator#739

Juju provider v1+ comes with breaking changes see: https://github.com/juju/terraform-provider-juju/releases/tag/v1.0.0

We can only bump the required juju provider version once we've made adjustments to accommodate for these breaking changes.