### PR TITLE
Revert "chore(deps): update terraform juju to v1"

### DIFF
--- a/charms/worker/k8s/terraform/versions.tf
+++ b/charms/worker/k8s/terraform/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "< 2.0.0"
+      version = ">= 0.19.0, < 1.0.0"
     }
   }
 }

--- a/charms/worker/terraform/versions.tf
+++ b/charms/worker/terraform/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "< 2.0.0"
+      version = ">= 0.19.0, < 1.0.0"
     }
   }
 }


### PR DESCRIPTION
Revert #739 

This pull request updates the version constraints for the `juju` provider in the Terraform configuration files for both `k8s` and standard worker charms. The new constraint ensures compatibility with versions from `0.19.0` up to, but not including, `1.0.0`.

Dependency version updates:

* Updated the `juju` provider version constraint to `>= 0.19.0, < 1.0.0` in `charms/worker/k8s/terraform/versions.tf`
* Updated the `juju` provider version constraint to `>= 0.19.0, < 1.0.0` in `charms/worker/terraform/versions.tf`