### PR TITLE
[Release 1.32] Update K8s revisions ["arm64-4608"]

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -8,4 +8,4 @@ amd64:
 arm64:
 - install-type: store
   name: k8s
-  revision: 4589
+  revision: 4608


### PR DESCRIPTION
Updates K8s revisions for 1.32
* arm64-4608
* amd64 revision commit: https://github.com/canonical/k8s-snap/commit/e43f85847e1b9432c124275504cc6abacebc6076
* arm64 revision commit: https://github.com/canonical/k8s-snap/commit/cc0d9bf55e924996ef26527e980b5be715f89433