### PR TITLE
[Release 1.32] Update K8s revisions ["amd64-4661","arm64-4655"]

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 4588
+  revision: 4661
 arm64:
 - install-type: store
   name: k8s
-  revision: 4589
+  revision: 4655


### PR DESCRIPTION
Updates K8s revisions for 1.32
* amd64-4661 & arm64-4655
* amd64 revision commit: https://github.com/canonical/k8s-snap/commit/8ec451d3deb754a1babe150b810e0d4afb9369dd
* arm64 revision commit: https://github.com/canonical/k8s-snap/commit/8ec451d3deb754a1babe150b810e0d4afb9369dd