### PR TITLE
[Release 1.34] Update K8s revisions ["arm64-4665"]

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -10,4 +10,4 @@ arm64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 4585
+  revision: 4665


### PR DESCRIPTION
Updates K8s revisions for 1.34
* arm64-4665
* amd64 revision commit: https://github.com/canonical/k8s-snap/commit/a57670092471d71845e24534d016f9ea09aa45ef
* arm64 revision commit: https://github.com/canonical/k8s-snap/commit/940a0b73d2c303542897538a3aa39dead6d9c20c