### PR TITLE
[Release 1.33] Update K8s revisions ["amd64-4660","arm64-4607"]

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 4599
+  revision: 4660
 arm64:
 - install-type: store
   name: k8s
-  revision: 4600
+  revision: 4607


### PR DESCRIPTION
Updates K8s revisions for 1.33
* amd64-4660 & arm64-4607
* amd64 revision commit: https://github.com/canonical/k8s-snap/commit/b58584a1f7abc5a80e4529326fb2ee1aac8150ea
* arm64 revision commit: https://github.com/canonical/k8s-snap/commit/049c04d3bea118c9d22a0a4099fa0fda818aebb8