### PR TITLE
[Release 1.35] Update K8s revisions ["amd64-4708"]

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -1,13 +1,13 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 amd64:
-  - name: k8s
-    install-type: store
-    classic: true
-    revision: 4695
+- classic: true
+  install-type: store
+  name: k8s
+  revision: 4708
 arm64:
-  - name: k8s
-    install-type: store
-    classic: true
-    revision: 4698
+- classic: true
+  install-type: store
+  name: k8s
+  revision: 4698


### PR DESCRIPTION
Updates K8s revisions for 1.35
* amd64-4708
* amd64 revision commit: https://github.com/canonical/k8s-snap/commit/7241419c701ba2e2ad96e2202a98367fe3b7e028
* arm64 revision commit: https://github.com/canonical/k8s-snap/commit/ddac37335dfda669a6261a1a96c1a3d7ef6cbe7c