### PR TITLE
[Release 1.34] Update K8s revisions ["amd64-4711"]

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -1,11 +1,11 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 amd64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 4699
+  revision: 4711
 arm64:
 - classic: true
   install-type: store


### PR DESCRIPTION
Updates K8s revisions for 1.34
* amd64-4711
* amd64 revision commit: https://github.com/canonical/k8s-snap/commit/604a9b78ced88aefe96f6e0c38cd2ab3241b28b0
* arm64 revision commit: https://github.com/canonical/k8s-snap/commit/786778b73be34d33c59617c084084a1ca65cd671