### PR TITLE
[Release 1.33] Update K8s revisions ["amd64-4755"]

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -1,13 +1,10 @@
-# Copyright 2026 Canonical Ltd.
-# See LICENSE file for licensing details.
-
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 amd64:
 - install-type: store
   name: k8s
-  revision: 4710
+  revision: 4755
 arm64:
 - install-type: store
   name: k8s


### PR DESCRIPTION
Updates K8s revisions for 1.33
* amd64-4755
* amd64 revision commit: https://github.com/canonical/k8s-snap/commit/912b889816e6dc2c235f81c19dce654148c02299
* arm64 revision commit: https://github.com/canonical/k8s-snap/commit/7965b9e014642a0fb3ddf30a48c36c6e774361a4