### PR TITLE
chore(release-1.34): update k8s snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -5,9 +5,9 @@ amd64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 4699
+  revision: 4757
 arm64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 4700
+  revision: 4760


### PR DESCRIPTION
## Overview

Updates the K8s snap revisions for the `1.34` track.

## Revisions

| Architecture | Revision |
|--------------|----------|
| amd64 | 4757 |
| arm64 | 4760 |

## Source Commits

Both architectures are built from the same commit:
- https://github.com/canonical/k8s-snap/commit/2d0bb97c790ef522d5f28fcb72ad1b841915ff45