### PR TITLE
chore(release-1.33): update k8s snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -1,14 +1,11 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-# Copyright 2025 Canonical Ltd.
-# See LICENSE file for licensing details.
-
 amd64:
 - install-type: store
   name: k8s
-  revision: 4710
+  revision: 4755
 arm64:
 - install-type: store
   name: k8s
-  revision: 4709
+  revision: 4756


### PR DESCRIPTION
## Overview

Updates the K8s snap revisions for the `1.33` track.

## Revisions

| Architecture | Revision |
|--------------|----------|
| amd64 | 4755 |
| arm64 | 4756 |

## Source Commits

Both architectures are built from the same commit:
- https://github.com/canonical/k8s-snap/commit/912b889816e6dc2c235f81c19dce654148c02299