### PR TITLE
chore(release-1.32): update k8s snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 4692
+  revision: 4754
 arm64:
 - install-type: store
   name: k8s
-  revision: 4690
+  revision: 4758


### PR DESCRIPTION
## Overview

Updates the K8s snap revisions for the `1.32` track.

## Revisions

| Architecture | Revision |
|--------------|----------|
| amd64 | 4754 |
| arm64 | 4758 |

## Source Commits

Both architectures are built from the same commit:
- https://github.com/canonical/k8s-snap/commit/6326ed150b0747b7de5f06a2dfd102b69b64e064