### PR TITLE
chore(release-1.35): update k8s snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -2,12 +2,12 @@
 # See LICENSE file for licensing details.
 
 amd64:
-  - name: k8s
-    install-type: store
-    classic: true
-    revision: 4695
+- classic: true
+  install-type: store
+  name: k8s
+  revision: 4746
 arm64:
-  - name: k8s
-    install-type: store
-    classic: true
-    revision: 4698
+- classic: true
+  install-type: store
+  name: k8s
+  revision: 4749


### PR DESCRIPTION
## Overview

Updates the K8s snap revisions for the `1.35` track.

## Revisions

| Architecture | Revision |
|--------------|----------|
| amd64 | 4746 |
| arm64 | 4749 |

## Source Commits

Both architectures are built from the same commit:
- https://github.com/canonical/k8s-snap/commit/22f3cee317b74234b84010046a6b2a19f1e7651b