### PR TITLE
backport(release-1.35): test: Switch Ceph to `squid/stable`

### DIFF
--- a/tests/integration/data/test-bundle-ceph.yaml
+++ b/tests/integration/data/test-bundle-ceph.yaml
@@ -25,7 +25,7 @@ applications:
 # see tests/integration/terraform/ceph-manifest.yaml
   ceph-mon:
     charm: ceph-mon
-    channel: &ceph-channel quincy/stable
+    channel: &ceph-channel squid/stable
     constraints: cores=2 mem=2G root-disk=4G
     num_units: 1
     options:

--- a/tests/integration/terraform/ceph-manifest.yaml
+++ b/tests/integration/terraform/ceph-manifest.yaml
@@ -27,7 +27,7 @@ ceph-csi:
 ceph-mon:
   cluster-name: main
   csi_integration: ceph
-  channel: &ceph-channel quincy/stable
+  channel: &ceph-channel squid/stable
   constraints: &mon-constraints arch=amd64 cores=2 mem=2048M root-disk=4096M
   units: 1
   config:


### PR DESCRIPTION
### Overview

Backport testing with Ceph in `squid/stable` (#854)
