### PR TITLE
Setup lxd before invokeing auto_update_charm_libs

### DIFF
--- a/.github/workflows/auto-update-libs-k8s-worker.yaml
+++ b/.github/workflows/auto-update-libs-k8s-worker.yaml
@@ -3,6 +3,13 @@ name: Auto-update K8s charm libraries
 on:
   schedule:
     - cron: "0 1 * * *"
+  pull_request:
+    paths:
+      - .github/workflows/auto-update-libs-k8s-worker.yaml
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   charmcraft-channel:
@@ -13,6 +20,7 @@ jobs:
     - uses: actions/checkout@v6
     - id: charmcraft
       run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
+    - uses: canonical/setup-lxd@main
   auto-update-libs:
     needs: [charmcraft-channel]
     uses: canonical/operator-workflows/.github/workflows/auto_update_charm_libs.yaml@main


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for auto-updating Kubernetes charm libraries. The main changes improve workflow automation and environment setup.

**Workflow triggers:**
- The workflow now also runs on pull requests that modify the `.github/workflows/auto-update-libs-k8s-worker.yaml` file, in addition to the scheduled cron trigger.

**Environment setup:**
- Added the `canonical/setup-lxd@main` action to set up LXD before running the auto-update jobs.