### PR TITLE
fix: narrow the scope of `system:cos`

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -64,10 +64,9 @@ jobs:
           - id: arm64
             builder-label: ARM64
             tester-arch: ARM64
-            tester-size: xlarge
+            tester-size: large
             modules: ${{ needs.select-tests.outputs.arm64 }}
     with:
-      bootstrap-options: "--agent-version=3.6.13"
       identifier: ${{ matrix.arch.id }}
       builder-runner-label: ${{ matrix.arch.builder-label }}
       charmcraft-channel: ${{ needs.charmcraft-channel.outputs.channel }}


### PR DESCRIPTION
## Overview

Narrow the ClusterRole scope for the required observability endpoints

## Changes
* Limited access to the `nodes/metrics` resource to only the `get` verb, and removed unnecessary access to `pods/metrics`, `services/metrics`, and `services`.
* Added a new rule granting `get` access to the `services/proxy` resource, required for kube-state-metrics via the API server proxy.
* Clarified that access to the `/metrics` non-resource URL is retained for API server and other components (such as k-c-m and kube-scheduler) metrics scraping.

## Validation

- Started with a `latest/stable`cluster, using the previous ClusterRole definition.
- Updated to the new charm, reducing the scope of the ClusterRole:
```
Name:         system:cos
Labels:       <none>
Annotations:  <none>
PolicyRule:
  Resources       Non-Resource URLs  Resource Names  Verbs
  ---------       -----------------  --------------  -----
                  [/metrics]         []              [get]
  nodes/metrics   []                 []              [get]
  services/proxy  []                 []              [get]
  ``` 
- After the change, all the dashboards and endpoints are still reporting metrics back:
<img width="922" height="272" alt="image" src="https://github.com/user-attachments/assets/13fa8587-f17b-4cc4-97c0-a706f48f1e4d" />
