### PR TITLE
chore(release-1.32): update k8s snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 4754
+  revision: 4988
 arm64:
 - install-type: store
   name: k8s
-  revision: 4758
+  revision: 4992


### PR DESCRIPTION
## Overview

Updates the K8s snap revisions for the `1.32` track.

## Revisions

| Architecture | Revision |
|--------------|----------|
| amd64 | 4988 |
| arm64 | 4992 |

## Source Commits

Both architectures are built from the same commit:
- https://github.com/canonical/k8s-snap/commit/443b627e9fba0b0032b57fe9a64283b56308ee3e