### PR TITLE
chore(release-1.34): update k8s snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -5,9 +5,9 @@ amd64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 4699
+  revision: 4990
 arm64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 4700
+  revision: 4993

--- a/tests/integration/terraform/main.tf
+++ b/tests/integration/terraform/main.tf
@@ -39,7 +39,7 @@ variable "csi_integration" {
 }
 
 module "k8s" {
-  source        = "git::https://github.com/canonical/k8s-bundles//terraform?ref=main"
+  source        = "git::https://github.com/canonical/k8s-bundles//terraform?ref=release-1.34"
   model         = {
     name = var.model
     cloud = var.cloud


### PR DESCRIPTION
## Overview

Updates the K8s snap revisions for the `1.34` track.

## Revisions

| Architecture | Revision |
|--------------|----------|
| amd64 | 4990 |
| arm64 | 4993 |

## Source Commits

Both architectures are built from the same commit:
- https://github.com/canonical/k8s-snap/commit/702b3a1cabee04c1b2a6204c4a8471b4518565ed