### PR TITLE
chore(release-1.32): update k8s snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 4754
+  revision: 5044
 arm64:
 - install-type: store
   name: k8s
-  revision: 4758
+  revision: 5047


### PR DESCRIPTION
## Overview

Updates the K8s snap revisions for the `1.32` track.

## Revisions

| Architecture | Revision |
|--------------|----------|
| amd64 | 5044 |
| arm64 | 5047 |

## Source Commits

Both architectures are built from the same commit:
- https://github.com/canonical/k8s-snap/commit/c2afb0f2d0def64b72b8dd1d0943c6304279af2c