### PR TITLE
Ignore pinned source in integration tests

### DIFF
--- a/tests/integration/terraform/main.tf
+++ b/tests/integration/terraform/main.tf
@@ -39,6 +39,11 @@ variable "csi_integration" {
 }
 
 module "k8s" {
+  # This is ignored because we want to test the latest version of the module in main,
+  # and we don't want to have to update this reference every time we make a change to
+  # the module.
+
+  # tflint-ignore: terraform_module_pinned_source
   source        = "git::https://github.com/canonical/k8s-bundles//terraform?ref=main"
   model         = {
     name = var.model


### PR DESCRIPTION
This pull request includes a minor update to the Terraform integration test configuration. A `tflint` directive was added to explicitly ignore the requirement to pin the module source version, allowing the tests to always use the latest version of the `k8s-bundles` module from the `main` branch.

- **Terraform Linting Configuration:**
  * Added a `tflint-ignore` comment to the `module "k8s"` block in `main.tf` to suppress warnings about unpinned module sources, ensuring tests always run against the latest module version.