### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/auto-merge-prs.yaml
+++ b/.github/workflows/auto-merge-prs.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   auto-merge-successful-prs:
     name: Auto-merge K8s charm PRs
-    uses: canonical/k8s-workflows/.github/workflows/auto-merge-successful-prs.yaml@main
+    uses: canonical/k8s-workflows/.github/workflows/auto-merge-successful-prs.yaml@6b24c265636d618fb98d5f56231c5581a1b429ab # main
     secrets: inherit
     with:
       approve-msg: "Approved for merge by 'auto-merge-prs' action"

--- a/.github/workflows/auto-update-libs-k8s-worker.yaml
+++ b/.github/workflows/auto-update-libs-k8s-worker.yaml
@@ -10,14 +10,14 @@ jobs:
     outputs:
       channel: ${{ steps.charmcraft.outputs.channel }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
     - id: charmcraft
       run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
   auto-update-libs:
     needs: [charmcraft-channel]
-    uses: canonical/operator-workflows/.github/workflows/auto_update_charm_libs.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/auto_update_charm_libs.yaml@27f280ed34b54bd9f65451dc966bfde701e84b62 # main
     secrets: inherit
     with:
       working-directory:  ./charms/worker/k8s

--- a/.github/workflows/auto-update-snap-revision.yaml
+++ b/.github/workflows/auto-update-snap-revision.yaml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       branches: ${{ steps.release-branches.outputs.data }}
     steps:
-    - uses: octokit/request-action@v2.x
+    - uses: octokit/request-action@02f5e7c637a73a3b12ed81015fa7fb5f11cc5d7d # v2.x
       id: list-branches
       with:
         route: GET /repos/${{ github.repository }}/branches
@@ -48,14 +48,14 @@ jobs:
         MATRIX_BRANCH: ${{matrix.branch}}
 
     - name: Checkout ${{ matrix.branch }}
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ matrix.branch }}
         token: ${{ secrets.REPO_ACCESS_TOKEN }}
         persist-credentials: false
 
     - name: Fetch update-snap-revision.py into a separate path
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         repository: ${{ github.repository }}
         path: update-scripts
@@ -70,7 +70,7 @@ jobs:
         cp update-scripts/.github/workflows/update-snap-revision.py .github/workflows/update-snap-revision.py
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: '3.14'
 
@@ -128,7 +128,7 @@ jobs:
         STEPS_UPDATE_AMD64_REVISION_OUTPUTS_COMMIT_SHA: ${{ steps.update-amd64-revision.outputs.commit_sha }}
 
     - name: Create pull request
-      uses: peter-evans/create-pull-request@v8
+      uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
       if: ${{ github.event_name == 'schedule' && (steps.assemble-revisions.outputs.revisions != '[]') }}
       with:
         commit-message: 'chore(release-${{ env.TRACK }}): update k8s snap revisions'

--- a/.github/workflows/bot_pr_approval.yaml
+++ b/.github/workflows/bot_pr_approval.yaml
@@ -5,5 +5,5 @@ on:
 
 jobs:
   bot_pr_approval:
-    uses: canonical/operator-workflows/.github/workflows/bot_pr_approval.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/bot_pr_approval.yaml@27f280ed34b54bd9f65451dc966bfde701e84b62 # main
     secrets: inherit

--- a/.github/workflows/charm-analysis.yaml
+++ b/.github/workflows/charm-analysis.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   unit-tests:
-    uses: canonical/operator-workflows/.github/workflows/test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/test.yaml@27f280ed34b54bd9f65451dc966bfde701e84b62 # main
     secrets: inherit
     strategy:
       fail-fast: false

--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -6,4 +6,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v2
+        uses: canonical/has-signed-canonical-cla@19bae73390fdbfdc1ef9a9bb9408d87a1de755f6 # v2

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   comment-on-pr:
-    uses: canonical/operator-workflows/.github/workflows/comment.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/comment.yaml@27f280ed34b54bd9f65451dc966bfde701e84b62 # main
     secrets: inherit

--- a/.github/workflows/comment_contributing.yaml
+++ b/.github/workflows/comment_contributing.yaml
@@ -9,5 +9,5 @@ on:
 
 jobs:
   comment-on-pr:
-    uses: canonical/operator-workflows/.github/workflows/comment_contributing.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/comment_contributing.yaml@27f280ed34b54bd9f65451dc966bfde701e84b62 # main
     secrets: inherit

--- a/.github/workflows/download-charm.yaml
+++ b/.github/workflows/download-charm.yaml
@@ -47,7 +47,7 @@ jobs:
         echo CHARM_FILE=${CHARM_FILE} >> $GITHUB_ENV # update GitHub ENV vars
         juju download ${{ inputs.charm-name }} --channel ${{ inputs.charm-channel }} --base ${{ inputs.charm-base }} --arch ${{ inputs.charm-arch }} - > ${{ env.CHARM_FILE }}
     - name: Upload charm artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: ${{ inputs.charm-name }}-charm
         path: ${{ env.CHARM_FILE }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       channel: ${{ steps.charmcraft.outputs.channel }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - id: charmcraft
@@ -23,11 +23,11 @@ jobs:
       amd64: ${{ steps.select.outputs.amd64 }}
       arm64: ${{ steps.select.outputs.arm64 }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Setup Astral UV
-        uses: astral-sh/setup-uv@v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           python-version: "3.12"
       - name: Install tox with UV
@@ -49,7 +49,7 @@ jobs:
           echo "arm64=${arm64}" >> "$GITHUB_OUTPUT"
 
   integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@27f280ed34b54bd9f65451dc966bfde701e84b62 # main
     needs: [charmcraft-channel, select-tests]
     permissions:
       contents: read

--- a/.github/workflows/load_test.yaml
+++ b/.github/workflows/load_test.yaml
@@ -10,14 +10,14 @@ jobs:
     outputs:
       channel: ${{ steps.charmcraft.outputs.channel }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
     - id: charmcraft
       run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
 
   load-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@27f280ed34b54bd9f65451dc966bfde701e84b62 # main
     needs: [charmcraft-channel]
     secrets: inherit
     with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -26,17 +26,17 @@ jobs:
       TF_VAR_csi_integration: ${{ matrix.test.name == 'test_ceph' && '["ceph"]' || '[]'}}
     steps:
     - name: Setup Astral UV
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
     - name: Install tox with UV
       run: uv tool install tox --with tox-uv
     - name: Setup operator environment
-      uses: charmed-kubernetes/actions-operator@main
+      uses: charmed-kubernetes/actions-operator@ea90ed489690bf3b1c1fcca6ac5f9edab70aecb0 # main
       with:
         provider: lxd
         channel: latest/stable
         juju-channel: 3/stable
     - name: Checking out repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
     - name: Setup cluster with terraform
@@ -48,5 +48,5 @@ jobs:
         tox -e integration -- -s -k ${{ matrix.test.name }} --model ${{env.TF_VAR_model}} --no-deploy
     - name: Tmate debugging session (self-hosted)
       if: ${{ failure() && github.event_name == 'pull_request' }}
-      uses: canonical/action-tmate@main
+      uses: canonical/action-tmate@bda82e73586a62bf621881aab872a527c8a46e2d # main
       timeout-minutes: 10

--- a/.github/workflows/promote-charms.yaml
+++ b/.github/workflows/promote-charms.yaml
@@ -31,7 +31,7 @@ jobs:
     outputs:
       channel: ${{ steps.charmcraft.outputs.channel }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Read charmcraft version file
@@ -84,10 +84,10 @@ jobs:
       matrix:
         charm: ${{ fromJson(needs.select-charms.outputs.charms) }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
-    - uses: canonical/charming-actions/promote-charm@2.7.0
+    - uses: canonical/charming-actions/promote-charm@1753e0803f70445132e92acd45c905aba6473225 # 2.7.0
       with:
         credentials: ${{ secrets.CHARMHUB_TOKEN }}
         charm-path: ${{ matrix.charm.path }}

--- a/.github/workflows/publish-charms.yaml
+++ b/.github/workflows/publish-charms.yaml
@@ -35,7 +35,7 @@ jobs:
     outputs:
       channel: ${{ steps.charmcraft.outputs.channel }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Read charmcraft version file
@@ -43,7 +43,7 @@ jobs:
         run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
   publish-to-edge:
     needs: [configure-channel, charmcraft-channel]
-    uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@27f280ed34b54bd9f65451dc966bfde701e84b62 # main
     strategy:
       matrix:
         charm:

--- a/.github/workflows/stale-cron.yaml
+++ b/.github/workflows/stale-cron.yaml
@@ -16,7 +16,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:
           days-before-stale: 150
           days-before-close: 30

--- a/.github/workflows/tiobe-tics-cron.yaml
+++ b/.github/workflows/tiobe-tics-cron.yaml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout the Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{matrix.branch}}
           fetch-depth: 0
@@ -49,7 +49,7 @@ jobs:
           mv "$GENERATED_COVERAGE_XML" cover/coverage.xml
 
       - name: Run TICS
-        uses: tiobe/tics-github-action@v3
+        uses: tiobe/tics-github-action@a53037a6bb9f71b6a97cdeb0ac41632266804b9e # v3
         with:
           mode: qserver
           project: ${{ github.event.repository.name }}

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -11,7 +11,7 @@ jobs:
       branches: ${{ steps.branches.outputs.branches }}
     steps:
       - name: Checking out repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -36,7 +36,7 @@ jobs:
       security-events: write
     steps:
       - name: Checking out repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ matrix.branch }}
           fetch-depth: 0
@@ -56,7 +56,7 @@ jobs:
           SHA="$(git rev-parse HEAD)"
           echo "head_sha=$SHA" >> "$GITHUB_ENV"
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@d4b3ca9fa7f69d38bfcd667bdc45bc373d16277e # v4
         with:
           sarif_file: "output.sarif"
           sha: ${{ env.head_sha }}

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -27,17 +27,17 @@ jobs:
       TF_VAR_model: my-canonical-k8s
     steps:
     - name: Setup Astral UV
-      uses: astral-sh/setup-uv@v8.0.0
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
     - name: Install tox with UV
       run: uv tool install tox --with tox-uv
     - name: Setup operator environment
-      uses: charmed-kubernetes/actions-operator@main
+      uses: charmed-kubernetes/actions-operator@ea90ed489690bf3b1c1fcca6ac5f9edab70aecb0 # main
       with:
         provider: lxd
         channel: latest/stable
         juju-channel: 3/stable
     - name: Checking out repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         persist-credentials: false
     - name: Install dependencies
@@ -52,11 +52,11 @@ jobs:
         tox -e conformance -- DOCKER_REGISTRY_USERNAME=${{ secrets.DOCKER_REGISTRY_USERNAME }} DOCKER_REGISTRY_PASSWORD=${{ secrets.DOCKER_REGISTRY_PASSWORD }}
     - name: Upload CNCF conformance report artifact
       if: failure()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: sonobuoy-e2e-${{ env.test_name }}
         path: tests/conformance/sonobuoy_e2e.tar.gz
     - name: Tmate debugging session (self-hosted)
       if: ${{ failure() && github.event_name == 'pull_request' }}
-      uses: canonical/action-tmate@main
+      uses: canonical/action-tmate@bda82e73586a62bf621881aab872a527c8a46e2d # main
       timeout-minutes: 10


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to full commit SHAs for supply-chain security hardening, replacing mutable tag references.

## Why

Mutable tags (e.g. `@v4`) can be moved by upstream maintainers or by an attacker who compromises an action repo. Pinning to a SHA ensures workflows always run exactly the reviewed code.

This follows GitHub's own security hardening guidance and improves our OpenSSF Scorecard rating.\n\n

## Changes

Pinned all third-party and GitHub-maintained actions in workflow files to full 40-character commit SHAs- Pinned reusable workflow references (operator-workflows, k8s-workflows, charming-actions) to commit SHAs - Preserved original tag/branch versions in inline comments for readability (e.g. ` v4`, ` main`) - Left already-pinned actions unchanged

## Testing

Verified all `uses:` references in `.github/workflows/*.yaml` now use immutable SHAs