### PR TITLE
feat(workflow): add GitHub Actions security analysis with zizmor

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["**"]
   schedule:
     - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
 
@@ -15,7 +14,7 @@ jobs:
     name: Run zizmor
     runs-on: ubuntu-latest
     permissions:
-      security-events: write # Required for upload-sarif to upload SARIF files
+      security-events: write # Required for upload-sarif to upload SARIF files due to `advanced-security:true`
       contents: read # Needed to clone the repo
       actions: read # Needed for upload-sarif to read workflow run info
 
@@ -29,5 +28,6 @@ jobs:
         uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
         with:
           zizmor-args: --pedantic
+          advanced-security: "true"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,33 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+  schedule:
+    - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif to upload SARIF files
+      contents: read # Needed to clone the repo
+      actions: read # Needed for upload-sarif to read workflow run info
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          zizmor-args: --pedantic
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow for automated security analysis using zizmor. The workflow is configured to run on pushes to the main branch, on all pull requests, and on a weekly schedule. It ensures that security scanning is integrated into the CI/CD process.

**Security and CI/CD automation:**

* Added a `.github/workflows/zizmor.yaml` file to set up a GitHub Actions workflow that runs the zizmor security analysis tool on pushes, pull requests, and on a weekly schedule. The workflow checks out the repository, runs zizmor with pedantic checks, and is configured with the necessary permissions for security scanning and reporting.