### PR TITLE
chore: [1.32] bump k8s snap revision

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 5044
+  revision: 5266
 arm64:
 - install-type: store
   name: k8s
-  revision: 5047
+  revision: 5270


### PR DESCRIPTION
bump k8s snap revisions:

```
$ snapcraft status k8s
...
1.32-classic  amd64    stable        v1.32.13         5266        -           -
                       candidate     v1.32.13         5266        -           -
                       beta          v1.32.13         5266        -           -
                       edge          v1.32.13         5266        -           -
              arm64    stable        v1.32.13         5270        -           -
                       candidate     v1.32.13         5270        -           -
                       beta          v1.32.13         5270        -           -
                       edge          v1.32.13         5270        -           -
```