### PR TITLE
chore: [1.33] bump k8s snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 4755
+  revision: 5273
 arm64:
 - install-type: store
   name: k8s
-  revision: 4756
+  revision: 5271


### PR DESCRIPTION
bump k8s snap revisions:

```
snapcraft status k8s
...
1.33-classic  amd64    stable        v1.33.11         5273        -           -
                       candidate     v1.33.11         5273        -           -
                       beta          v1.33.11         5273        -           -
                       edge          v1.33.11         5273        -           -
              arm64    stable        v1.33.11         5271        -           -
                       candidate     v1.33.11         5271        -           -
                       beta          v1.33.11         5271        -           -
                       edge          v1.33.11         5271        -           -

```