### PR TITLE
chore: [1.34] bump k8s snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -5,9 +5,9 @@ amd64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 4990
+  revision: 5268
 arm64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 4993
+  revision: 5272


### PR DESCRIPTION
bump k8s snap revisions:

```
snapcraft status k8s
...
1.34-classic  amd64    stable        v1.34.4          5268        -           -
                       candidate     v1.34.4          5268        -           -
                       beta          v1.34.4          5268        -           -
                       edge          v1.34.4          5268        -           -
              arm64    stable        v1.34.4          5272        -           -
                       candidate     v1.34.4          5272        -           -
                       beta          v1.34.4          5272        -           -
                       edge          v1.34.4          5272        -           -
```