### PR TITLE
chore: [1.35] bump k8s snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -5,9 +5,9 @@ amd64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 5046
+  revision: 5267
 arm64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 5049
+  revision: 5269


### PR DESCRIPTION
bump k8s snap revisions
```
snapcraft status k8s
...
1.35-classic  amd64    stable        v1.35.3          5267        -           -
                       candidate     v1.35.3          5267        -           -
                       beta          v1.35.3          5267        -           -
                       edge          v1.35.3          5267        -           -
              arm64    stable        v1.35.3          5269        -           -
                       candidate     v1.35.3          5269        -           -
                       beta          v1.35.3          5269        -           -
                       edge          v1.35.3          5269        -           -
```