### PR TITLE
feat: bump snap revision to the rev with metallb 0.14.9-ck8

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -41,7 +41,7 @@ jobs:
         run: |
           list_modules() {
             ARCH=$1
-            MODULES=$(tox -e integration -- --collect-only -q --arch "$ARCH" 2>/dev/null \
+            MODULES=$(tox -e integration -- --collect-only -q 2>/dev/null \
               | grep -E '<Module test_.*\.py>' \
               | sed -E 's/.*<Module (test_[^.]*)\.py>.*/\1/' \
               | sort -u)
@@ -86,7 +86,7 @@ jobs:
       self-hosted-runner: true
       self-hosted-runner-arch: ${{ matrix.arch.tester-arch }}
       self-hosted-runner-label: ${{ matrix.arch.tester-size }}
-      test-timeout: 120
+      test-timeout: 600
       test-tox-env: integration
       trivy-fs-enabled: false
       trivy-image-config: "trivy.yaml"

--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 5266
+  revision: 5279
 arm64:
 - install-type: store
   name: k8s
-  revision: 5270
+  revision: 5280


### PR DESCRIPTION
This PR bumps the snap revision to one with the metallb patch (0.14.9-ck8).
```
snapcraft status k8s
...
1.32-classic  amd64    stable        v1.32.13         5279        -           -
                       candidate     v1.32.13         5279        -           -
                       beta          v1.32.13         5279        -           -
                       edge          v1.32.13         5279        -           -
              arm64    stable        v1.32.13         5280        -           -
                       candidate     v1.32.13         5280        -           -
                       beta          v1.32.13         5280        -           -
                       edge          v1.32.13         5280        -           -
```

Needs: https://github.com/canonical/k8s-operator/pull/940