### PR TITLE
fix: [backport 1.34] remove deprecated arguments and bump commit hash (#939)

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -23,9 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup Astral UV
-        uses: astral-sh/setup-uv@v7.1.4
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
+          version: "0.11.11"
           python-version: "3.12"
+      - name: Setup Python
+        run: uv python install
       - name: Install tox with UV
         run: uv tool install tox --with tox-uv
       - name: Select tests
@@ -45,7 +48,7 @@ jobs:
           echo "arm64=${arm64}" >> "$GITHUB_OUTPUT"
 
   integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@72ba44455ad0ba7ec1c51027d5360357d1925733 # main
     needs: [charmcraft-channel, select-tests]
     permissions:
       contents: read
@@ -60,9 +63,9 @@ jobs:
             tester-arch: AMD64
             tester-size: xlarge
             modules: ${{ needs.select-tests.outputs.amd64 }}
-          # built and test on on self-hosted
+          # built on GitHub-hosted, test on self-hosted
           - id: arm64
-            builder-label: ARM64
+            builder-label: ubuntu-24.04-arm
             tester-arch: ARM64
             tester-size: large
             modules: ${{ needs.select-tests.outputs.arm64 }}
@@ -74,7 +77,6 @@ jobs:
         ${{ matrix.arch.id == 'arm64' && ' --lxd-containers --series=noble' || '' }}
       modules: ${{ matrix.arch.modules }}
       juju-channel: 3/stable
-      load-test-enabled: false
       provider: lxd
       self-hosted-runner: true
       self-hosted-runner-arch: ${{ matrix.arch.tester-arch }}
@@ -85,4 +87,3 @@ jobs:
       trivy-image-config: "trivy.yaml"
       tmate-debug: true
       with-uv: true
-      zap-enabled: false

--- a/.github/workflows/load_test.yaml
+++ b/.github/workflows/load_test.yaml
@@ -15,12 +15,10 @@ jobs:
       run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
 
   load-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@72ba44455ad0ba7ec1c51027d5360357d1925733 # main
     needs: [charmcraft-channel]
     secrets: inherit
     with:
       provider: lxd
       charmcraft-channel: ${{ needs.charmcraft-channel.outputs.channel }}
       juju-channel: 3/stable
-      load-test-enabled: true
-      load-test-run-args: "-e LOAD_TEST_HOST=localhost"


### PR DESCRIPTION
Backport https://github.com/canonical/k8s-operator/pull/939 to release-1.34