### PR TITLE
charmcraft: mark non-required endpoints as optional

### DIFF
--- a/charms/worker/charmcraft.yaml
+++ b/charms/worker/charmcraft.yaml
@@ -130,13 +130,16 @@ peers:
 provides:
   cos-agent:
     interface: cos_agent
+    optional: true
 
 requires:
   aws:
     interface: aws-integration
     limit: 1
+    optional: true
   azure:
     interface: azure-integration
+    optional: true
   cluster:
     # interface to connect with the k8s charm to provide
     # authentication token via a secret in order to cluster
@@ -147,11 +150,14 @@ requires:
   cos-tokens:
     interface: cos-k8s-tokens
     limit: 1
+    optional: true
   containerd:
     # Interface provided by the control-plane charm to
     # share containerd configuration.
     interface: containerd
     limit: 1
+    optional: true
   gcp:
     interface: gcp-integration
     limit: 1
+    optional: true

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -460,28 +460,40 @@ peers:
 provides:
   cos-agent:
     interface: cos_agent
+    optional: true
   cos-worker-tokens:
     interface: cos-k8s-tokens
+    optional: true
   containerd:
     interface: containerd
+    optional: true
   ceph-k8s-info:
     interface: kubernetes-info
+    optional: true
   k8s-cluster:
     interface: k8s-cluster
+    optional: true
   kube-control:
     interface: kube-control
+    optional: true
 
 requires:
   aws:
     interface: aws-integration
+    optional: true
   azure:
     interface: azure-integration
+    optional: true
   etcd:
     interface: etcd
     limit: 1
+    optional: true
   external-cloud-provider:
     interface: external_cloud_provider
+    optional: true
   gcp:
     interface: gcp-integration
+    optional: true
   external-load-balancer:
     interface: loadbalancer
+    optional: true

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -472,7 +472,6 @@ provides:
     optional: true
   k8s-cluster:
     interface: k8s-cluster
-    optional: true
   kube-control:
     interface: kube-control
     optional: true


### PR DESCRIPTION
Adds `optional: true` to endpoints that the charm handles gracefully without a relation and that are not part of the recommended deployment.

**Not marked optional:** `k8s-cluster` (provides, k8s) and `cluster` (requires, k8s-worker) - these are part of the standard multi-node setup or cause `BlockedStatus` when absent.