### PR TITLE
feat: [1.35] bump snap revision to the rev with watch fix

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -5,9 +5,9 @@ amd64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 5267
+  revision: 5324
 arm64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 5269
+  revision: 5333


### PR DESCRIPTION
```
1.35-classic  amd64    stable        v1.35.3          5324        -           -
                       candidate     v1.35.3          5324        -           -
                       beta          v1.35.3          5324        -           -
                       edge          v1.35.3          5324        -           -
              arm64    stable        v1.35.3          5333        -           -
                       candidate     v1.35.3          5333        -           -
                       beta          v1.35.3          5333        -           -
                       edge          v1.35.3          5333        -           -
```