### PR TITLE
feat: add kube-proxy-enabled config option

### DIFF
--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -402,6 +402,19 @@ config:
         Space-separated list of namespaces to check for unready pods. This
         is used to determine the status of the cluster and its components.
         If not set, no namespaces will be checked.
+    kube-proxy-enabled:
+      type: string
+      default: "auto"
+      description: |
+        Determines if kube-proxy is going to be running on the nodes.
+        The admins can disable kube-proxy in case of a replacement like Cilium.
+
+        Allowed values are "auto", "false", and "true".
+
+        * auto:     The cluster automatically decides whether or not kube-proxy should be enabled.
+        * false:    Disable kube-proxy in the cluster nodes.
+        * true:     Enable kube-proxy in the cluster nodes.
+
 
 resources:
   snap-installation:

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -1076,7 +1076,7 @@ class K8sCharm(ops.CharmBase):
             busy_wait -= 1
         return reported_down == 3
 
-    @status.on_error(ops.BlockedStatus("Cannot apply node-labels"), LabelMaker.NodeLabelError)
+    @status.on_error(ops.WaitingStatus("Applying node labels"), LabelMaker.NodeLabelError)
     def _apply_node_labels(self):
         """Apply labels to the node."""
         status.add(ops.MaintenanceStatus("Ensuring Kubernetes Node Labels"))

--- a/charms/worker/k8s/src/config/cluster.py
+++ b/charms/worker/k8s/src/config/cluster.py
@@ -5,6 +5,7 @@
 
 """Cluster configuration options."""
 
+import logging
 from typing import Optional
 
 import literals
@@ -19,6 +20,8 @@ from k8sd_api_manager import (
     NetworkConfig,
     UserFacingClusterConfig,
 )
+
+log = logging.getLogger(__name__)
 
 
 def assemble_cluster_config(
@@ -79,6 +82,24 @@ def _assemble_network(charm: ops.CharmBase, assembled: UserFacingClusterConfig):
     if not (network := assembled.network):
         network = assembled.network = NetworkConfig()
     network.enabled = literals.NETWORK_ENABLED.get(charm)
+
+    kube_proxy_enabled = literals.KUBE_PROXY_ENABLED.get(charm).lower()
+    if kube_proxy_enabled not in literals.KUBE_PROXY_ENABLED_VALID_VALUES:
+        log.error(f"invalid value for kube-proxy-enabled config option: {kube_proxy_enabled}")
+
+    if kube_proxy_enabled == literals.KUBE_PROXY_ENABLED_TRUE:
+        network.kube_proxy_enabled = True
+        log.info("kube_proxy_enabled option is set to True in user-facing cluster config")
+    elif kube_proxy_enabled == literals.KUBE_PROXY_ENABLED_FALSE:
+        network.kube_proxy_enabled = False
+        log.info("kube_proxy_enabled option is set to False in user-facing cluster config")
+    elif kube_proxy_enabled == literals.KUBE_PROXY_ENABLED_AUTO:
+        # we do not set network.kube_proxy_enabled when the config option is "auto"
+        # so that the cluster decides automatically.
+        log.info(
+            "kube_proxy_enabled option is set to auto."
+            "Will not set it in user-facing cluster config"
+        )
 
 
 def _assemble_ingress(charm: ops.CharmBase, assembled: UserFacingClusterConfig):

--- a/charms/worker/k8s/src/k8sd_api_manager.py
+++ b/charms/worker/k8s/src/k8sd_api_manager.py
@@ -287,7 +287,13 @@ class LocalStorageConfig(FeatureConfig):
 
 
 class NetworkConfig(FeatureConfig):
-    """Configuration for the network settings of the cluster."""
+    """Configuration for the network settings of the cluster.
+
+    Attributes:
+        kube_proxy_enabled: Optional flag to determine kube-proxy state
+    """
+
+    kube_proxy_enabled: Optional[bool] = Field(default=None, alias="kube-proxy-enabled")
 
 
 class GatewayConfig(FeatureConfig):

--- a/charms/worker/k8s/src/literals.py
+++ b/charms/worker/k8s/src/literals.py
@@ -84,6 +84,15 @@ LOCAL_STORAGE_LOCAL_PATH = option.StrOption("local-storage-local-path")
 LOCAL_STORAGE_RECLAIM_POLICY = option.StrOption("local-storage-reclaim-policy")
 NETWORK_ENABLED = option.BoolOption("network-enabled")
 METRICS_SERVER_ENABLED = option.BoolOption("metrics-server-enabled")
+KUBE_PROXY_ENABLED = option.StrOption("kube-proxy-enabled")
+KUBE_PROXY_ENABLED_TRUE = "true"
+KUBE_PROXY_ENABLED_FALSE = "false"
+KUBE_PROXY_ENABLED_AUTO = "auto"
+KUBE_PROXY_ENABLED_VALID_VALUES = [
+    KUBE_PROXY_ENABLED_TRUE,
+    KUBE_PROXY_ENABLED_FALSE,
+    KUBE_PROXY_ENABLED_AUTO,
+]
 
 # Worker and Control Plane Options
 BOOTSTRAP_NODE_TAINTS = option.StrOption("bootstrap-node-taints")

--- a/tests/unit/config/test_cluster.py
+++ b/tests/unit/config/test_cluster.py
@@ -24,12 +24,22 @@ def test_configure_network_options(harness):
     harness.disable_hooks()
 
     harness.update_config({"network-enabled": False})
+    harness.update_config({"kube-proxy-enabled": "true"})
     ufcg = assemble_cluster_config(harness.charm, None)
     assert not ufcg.network.enabled, "Network should be disabled"
+    assert ufcg.network.kube_proxy_enabled, "kube-proxy-enabled sholud be True"
 
     harness.update_config({"network-enabled": True})
+    harness.update_config({"kube-proxy-enabled": "false"})
     ufcg = assemble_cluster_config(harness.charm, None)
     assert ufcg.network.enabled, "Network should be enabled"
+    assert not ufcg.network.kube_proxy_enabled, "kube-proxy-enabled sholud be False"
+
+    harness.update_config({"network-enabled": True})
+    harness.update_config({"kube-proxy-enabled": "auto"})
+    ufcg = assemble_cluster_config(harness.charm, None)
+    assert ufcg.network.enabled, "Network should be enabled"
+    assert ufcg.network.kube_proxy_enabled is None, "kube-proxy-enabled should not be set"
 
 
 def test_configure_ingress_options(harness):


### PR DESCRIPTION
### Overview

This PR adds a `kube-proxy-enabled` config option as a knob for admins to turn on/off kube-proxy (e.g. in case of a kube-proxy replacement solution like Cilium).