### PR TITLE
feat: [backport 1.34] add 26.04 support

### DIFF
--- a/.charmcraft-channel
+++ b/.charmcraft-channel
@@ -1,1 +1,1 @@
-3.x/stable
+latest/stable

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -48,7 +48,7 @@ jobs:
           echo "arm64=${arm64}" >> "$GITHUB_OUTPUT"
 
   integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@72ba44455ad0ba7ec1c51027d5360357d1925733 # main
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@011250c1cbc944fd99b1a16ebb995f55483a57b3 # main
     needs: [charmcraft-channel, select-tests]
     permissions:
       contents: read
@@ -87,3 +87,46 @@ jobs:
       trivy-image-config: "trivy.yaml"
       tmate-debug: true
       with-uv: true
+
+  integration-tests-resolute:
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@011250c1cbc944fd99b1a16ebb995f55483a57b3 # main
+    needs: [charmcraft-channel]
+    permissions:
+      contents: read
+      actions: write
+    secrets: inherit
+    strategy:
+      matrix:
+        arch:
+          - id: amd64
+            builder-label: ubuntu-26.04
+            tester-arch: AMD64
+            tester-size: xlarge
+            modules: '["test_k8s", "test_smoke", "test_dualstack", "test_ipv6_only", "test_openstack"]'
+          - id: arm64
+            builder-label: ubuntu-26.04-arm
+            tester-arch: ARM64
+            tester-size: xlarge
+            modules: '["test_k8s", "test_smoke", "test_dualstack", "test_ipv6_only", "test_openstack"]'
+    with:
+      identifier: ${{ matrix.arch.id }}
+      builder-runner-label: ${{ matrix.arch.builder-label }}
+      charmcraft-channel: ${{ needs.charmcraft-channel.outputs.channel }}
+      extra-arguments: >-
+        ${{ matrix.arch.id == 'arm64' && ' --lxd-containers --series=resolute' || ' --series=resolute' }}
+      modules: ${{ matrix.arch.modules }}
+      juju-channel: 3/stable
+      provider: lxd
+      self-hosted-runner: true
+      self-hosted-runner-arch: ${{ matrix.arch.tester-arch }}
+      self-hosted-runner-label: ${{ matrix.arch.tester-size }}
+      test-timeout: 900
+      test-tox-env: integration
+      trivy-fs-enabled: false
+      trivy-image-config: "trivy.yaml"
+      tmate-debug: true
+      with-uv: true
+      # this is a workaround since "resolute" is not supported in operator-workflows and hence 3.14 that comes with it
+      python-version: 3.14
+      # operator-workflows appends "noble" to the request labels by default. we need to change it to resolute
+      self-hosted-runner-image: resolute

--- a/charms/worker/charmcraft.yaml
+++ b/charms/worker/charmcraft.yaml
@@ -33,6 +33,8 @@ platforms:
   ubuntu@22.04:arm64:
   ubuntu@24.04:amd64:
   ubuntu@24.04:arm64:
+  ubuntu@26.04:amd64:
+  ubuntu@26.04:arm64:
 
 config:
   options:

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -42,6 +42,8 @@ platforms:
   ubuntu@22.04:arm64:
   ubuntu@24.04:amd64:
   ubuntu@24.04:arm64:
+  ubuntu@26.04:amd64:
+  ubuntu@26.04:arm64:
 config:
   options:
     cluster-annotations:

--- a/charms/worker/k8s/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/charms/worker/k8s/lib/charms/data_platform_libs/v0/upgrade.py
@@ -260,6 +260,11 @@ class ZooKeeperCharm(CharmBase):
 ```
 """
 
+# NOTE: pydantic.v1 (used below) relies on eager __annotations__, which PEP 649
+# defers on Python 3.14+ (26.04 base), breaking field detection. Stringized
+# annotations restore eager population. Re-apply if this lib is re-fetched.
+from __future__ import annotations
+
 import json
 import logging
 from abc import ABC, abstractmethod

--- a/charms/worker/k8s/pyproject.toml
+++ b/charms/worker/k8s/pyproject.toml
@@ -47,7 +47,6 @@ lint = [
 ]
 integration = [
     "async-lru",
-    "juju",
     "pydantic",
     "pylxd",
     "pytest",
@@ -56,6 +55,7 @@ integration = [
     "pytest-sugar",
     "tenacity",
     "requests <2.33",  # https://github.com/canonical/pylxd/issues/579
+    "juju-resolute>=3.6.1.3",
 ]
 conformance = ["yq"]
 
@@ -159,3 +159,6 @@ markers = [
 
 [tool.pyright]
 extraPaths = ["src", "lib"]
+
+[tool.uv]
+override-dependencies = ["juju ; sys_platform == 'never'"]

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -392,7 +392,12 @@ class K8sCharm(ops.CharmBase):
         """
         return self.xcp.name or ""
 
-    @on_error(ops.BlockedStatus("Failed to install snaps."), snap_lib.SnapError)
+    @on_error(
+        ops.BlockedStatus("Failed to install snaps."),
+        snap_lib.SnapError,
+        snap_lib.SnapAPIError,
+        snap_lib.SnapNotFoundError,
+    )
     def _install_snaps(self):
         """Install snap packages."""
         status.add(ops.MaintenanceStatus("Ensuring snap installation"))

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -393,6 +393,18 @@ class K8sCharm(ops.CharmBase):
         return self.xcp.name or ""
 
     @on_error(
+        ops.WaitingStatus("Ensuring /sbin -> /usr/sbin symlink."),
+        subprocess.CalledProcessError,
+    )
+    def _ensure_sbin_symlink(self):
+        """Ensure /sbin is a symlink to /usr/sbin."""
+        status.add(ops.MaintenanceStatus("Ensuring /sbin -> /usr/sbin symlink"))
+        if os.path.islink("/sbin") and os.path.realpath("/sbin") == "/usr/sbin":
+            return
+        subprocess.run(["/usr/bin/sudo", "/usr/bin/rm", "-rf", "/sbin"], check=True)
+        subprocess.run(["/usr/bin/sudo", "/usr/bin/ln", "-s", "/usr/sbin", "/sbin"], check=True)
+
+    @on_error(
         ops.BlockedStatus("Failed to install snaps."),
         snap_lib.SnapError,
         snap_lib.SnapAPIError,
@@ -989,6 +1001,7 @@ class K8sCharm(ops.CharmBase):
 
         self.upgrade.handler(event)
         self._apply_proxy_environment()
+        self._ensure_sbin_symlink()
         self._install_snaps()
         self._apply_snap_requirements()
         self._check_k8sd_ready()

--- a/charms/worker/k8s/src/upgrade.py
+++ b/charms/worker/k8s/src/upgrade.py
@@ -3,6 +3,11 @@
 
 """A module for upgrading the k8s and k8s-worker charms."""
 
+# NOTE: K8sDependenciesModel below uses the pydantic.v1 compat layer, which relies
+# on eager __annotations__. PEP 649 defers those on Python 3.14+ (26.04 base),
+# breaking field detection; stringized annotations restore the eager population.
+from __future__ import annotations
+
 import logging
 from typing import List, Optional, Union
 

--- a/charms/worker/k8s/terraform/README.md
+++ b/charms/worker/k8s/terraform/README.md
@@ -15,7 +15,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required | Default |
 | - | - | - | - | - |
 | `app_name`| string | Application name | False | k8s |
-| `base` | string | Ubuntu base to deploy the carm onto | False | ubuntu@24.04 |
+| `base` | string | Ubuntu base to deploy the carm onto | False | ubuntu@26.04 |
 | `channel`| string | Channel that the charm is deployed from | False | 1.30/edge |
 | `config`| map(string) | Map of the charm configuration options | False | {} |
 | `constraints` | string | Juju constraints to apply for this application | False | arch=amd64 |

--- a/charms/worker/k8s/terraform/variables.tf
+++ b/charms/worker/k8s/terraform/variables.tf
@@ -10,11 +10,11 @@ variable "app_name" {
 variable "base" {
   description = "Ubuntu base to deploy the charm onto"
   type        = string
-  default     = "ubuntu@24.04"
+  default     = "ubuntu@26.04"
 
   validation {
-    condition     = contains(["ubuntu@22.04", "ubuntu@24.04"], var.base)
-    error_message = "Base must be one of ubuntu@22.04, ubuntu@24.04"
+    condition     = contains(["ubuntu@22.04", "ubuntu@24.04", "ubuntu@26.04"], var.base)
+    error_message = "Base must be one of ubuntu@22.04, ubuntu@24.04, ubuntu@26.04"
   }
 }
 

--- a/charms/worker/k8s/uv.lock
+++ b/charms/worker/k8s/uv.lock
@@ -6,6 +6,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[manifest]
+overrides = [{ name = "juju", marker = "sys_platform == 'never'" }]
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
@@ -940,6 +943,30 @@ wheels = [
 ]
 
 [[package]]
+name = "juju-resolute"
+version = "3.6.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-datetime-fromisoformat" },
+    { name = "backports-strenum", marker = "python_full_version < '3.11'" },
+    { name = "hvac" },
+    { name = "kubernetes" },
+    { name = "macaroonbakery" },
+    { name = "packaging" },
+    { name = "paramiko" },
+    { name = "pyasn1" },
+    { name = "pyyaml" },
+    { name = "toposort" },
+    { name = "typing-extensions" },
+    { name = "typing-inspect" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/79/3e8a50a235f3912bb46fce0a4a0b77bd0ddb360c27ed44a27449071ed5f3/juju_resolute-3.6.1.3.tar.gz", hash = "sha256:8e2a26f2fee4276accd33a6c6977867146872083191c0264000223c05f633e47", size = 306235, upload-time = "2026-06-25T08:27:29.913Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/60/aa806a596a2d81cdf200fb5d2d5d556603a5ca9b96f956b2460b501c26f2/juju_resolute-3.6.1.3-py3-none-any.whl", hash = "sha256:88e46ce5453be0e16b26b787afd688cf3b3e3c187bc5e574bb11193378ac3dc0", size = 288043, upload-time = "2026-06-25T08:27:26.421Z" },
+]
+
+[[package]]
 name = "k8s"
 version = "0.0.0"
 source = { virtual = "." }
@@ -978,7 +1005,7 @@ docs = [
 ]
 integration = [
     { name = "async-lru" },
-    { name = "juju" },
+    { name = "juju-resolute" },
     { name = "pydantic" },
     { name = "pylxd" },
     { name = "pytest" },
@@ -1038,7 +1065,7 @@ conformance = [{ name = "yq" }]
 docs = [{ name = "vale" }]
 integration = [
     { name = "async-lru" },
-    { name = "juju" },
+    { name = "juju-resolute", specifier = ">=3.6.1.3" },
     { name = "pydantic" },
     { name = "pylxd" },
     { name = "pytest" },
@@ -1901,7 +1928,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ipdb" },
     { name = "jinja2" },
-    { name = "juju" },
+    { name = "juju", marker = "sys_platform == 'never'" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pyyaml" },

--- a/charms/worker/terraform/README.md
+++ b/charms/worker/terraform/README.md
@@ -15,7 +15,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required | Default |
 | - | - | - | - | - |
 | `app_name`| string | Application name | False | k8s-worker |
-| `base` | string | Ubuntu base to deploy the charm onto | False | ubuntu@24.04 |
+| `base` | string | Ubuntu base to deploy the charm onto | False | ubuntu@26.04 |
 | `channel`| string | Channel that the charm is deployed from | False | 1.30/edge |
 | `config`| map(string) | Map of the charm configuration options | False | {} |
 | `constraints` | string | Juju constraints to apply for this application | False | arch=amd64 |

--- a/charms/worker/terraform/variables.tf
+++ b/charms/worker/terraform/variables.tf
@@ -10,11 +10,11 @@ variable "app_name" {
 variable "base" {
   description = "Ubuntu bases to deploy the charm onto"
   type        = string
-  default     = "ubuntu@24.04"
+  default     = "ubuntu@26.04"
 
   validation {
-    condition     = contains(["ubuntu@22.04", "ubuntu@24.04"], var.base)
-    error_message = "Base must be one of ubuntu@22.04, ubuntu@24.04"
+    condition     = contains(["ubuntu@22.04", "ubuntu@24.04", "ubuntu@26.04"], var.base)
+    error_message = "Base must be one of ubuntu@22.04, ubuntu@24.04, ubuntu@26.04"
   }
 }
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -107,7 +107,7 @@ def pytest_addoption(parser: pytest.Parser):
             '"*.snap" file.'
         ),
     )
-    parser.addoption("--timeout", default=10, type=int, help="timeout for tests in minutes")
+    parser.addoption("--timeout", default=90, type=int, help="timeout for tests in minutes")
     parser.addoption(
         "--upgrade-from", dest="upgrade_from", default=None, help="Charms channel to upgrade from"
     )
@@ -388,7 +388,7 @@ async def cos_model(ops_test: OpsTest, cos_substrate: Path):
         )
         yield k8s_model
     finally:
-        await ops_test.forget_model("cos", timeout=10 * 60, allow_failure=True)
+        await ops_test.forget_model("cos", timeout=60 * 60, allow_failure=True)
 
 
 @pytest_asyncio.fixture(name="_cos_lite_installed", scope="module")
@@ -417,9 +417,9 @@ async def cos_lite_installed(ops_test: OpsTest, cos_model: Model):
 
     await cos_model.block_until(
         lambda: all(app in cos_model.applications for app in cos_charms),
-        timeout=5 * 60,
+        timeout=60 * 60,
     )
-    await cos_model.wait_for_idle(status="active", timeout=20 * 60, raise_on_error=False)
+    await cos_model.wait_for_idle(status="active", timeout=60 * 60, raise_on_error=False)
 
     yield
     log.info("Removing COS Lite charms...")
@@ -432,7 +432,7 @@ async def cos_lite_installed(ops_test: OpsTest, cos_model: Model):
             assert rc == 0
         await cos_model.block_until(
             lambda: all(app not in cos_model.applications for app in cos_charms),
-            timeout=60 * 10,
+            timeout=60 * 60,
         )
 
 

--- a/tests/integration/cos_substrate.py
+++ b/tests/integration/cos_substrate.py
@@ -143,7 +143,7 @@ class COSSubstrate(LXDSubstrate):
         commands = [
             "snap install k8s --classic",
             "k8s bootstrap",
-            "k8s status --wait-ready --timeout 30m",
+            "k8s status --wait-ready --timeout 60m",
             f"k8s set load-balancer.cidrs='{cidrs}'",
             "k8s enable load-balancer",
         ]

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -589,7 +589,7 @@ class Bundle:
                     min_units,
                 )
                 return False
-        await model.wait_for_idle(timeout=20 * 60, raise_on_error=False)
+        await model.wait_for_idle(timeout=60 * 60, raise_on_error=False)
         return True
 
 

--- a/tests/integration/lxd_substrate.py
+++ b/tests/integration/lxd_substrate.py
@@ -91,7 +91,7 @@ class LXDSubstrate:
             vm (Optional[VMOptions]): VM options. If provided, a virtual machine
                 will be created instead of a instance.
         """
-        self.client = Client(timeout=1200)  # 20 minutes
+        self.client = Client(timeout=60 * 60)
         self.vm_opts = vm
         self.profile_name: Optional[str] = None
 

--- a/tests/integration/test_cos.py
+++ b/tests/integration/test_cos.py
@@ -16,6 +16,9 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 
 log = logging.getLogger(__name__)
 
+# NOTE: (hue) Skipping entire module since the infra and test is flaky
+pytest.skip("Skipping: Infra and tests are flaky, skipping.", allow_module_level=True)
+
 
 pytestmark = [
     pytest.mark.bundle(file="test-bundle-cos.yaml", apps_local=["k8s"]),

--- a/tests/integration/test_etcd.py
+++ b/tests/integration/test_etcd.py
@@ -47,8 +47,8 @@ async def test_update_etcd_cluster(kubernetes_cluster: model.Model, timeout: int
     count = 3 - len(etcd.units)
     if count > 0:
         await etcd.add_unit(count=count)
-    at_least_twenty = max(20, timeout)
-    await kubernetes_cluster.wait_for_idle(status="active", timeout=at_least_twenty * 60)
+    at_least_sixty = max(60, timeout)
+    await kubernetes_cluster.wait_for_idle(status="active", timeout=at_least_sixty * 60)
 
     expected_servers = []
     for u in etcd.units:

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -108,7 +108,7 @@ async def test_upgrade(kubernetes_cluster: juju.model.Model, ops_test: OpsTest):
         }
         worker_apps = {k: v for k, v in k8s_apps.items() if k != CONTROL_PLANE_APP}
         worker_count = sum(len(w.units) for w in worker_apps.values())
-        await kubernetes_cluster.wait_for_idle(apps=list(charms.keys()), timeout=30)
+        await kubernetes_cluster.wait_for_idle(apps=list(charms.keys()), timeout=60)
 
         # Check workload status individually, as the k8s leader may be in a different state
         leader_idx: int = await get_leader(k8s)


### PR DESCRIPTION
Backports the following from main to 1.34:
* https://github.com/canonical/k8s-operator/pull/959
* https://github.com/canonical/k8s-operator/pull/949

Changes:
* use charmcraft from latest/stable
* ensure /sbin is a symlink to /usr/sbin
* add integration tests for 26.04
* use a custom python-libjuju with 26.04 support
* bump operator-workflows commit sha for integration tests to support 26.04
* increase test timeouts and skip test_cos

