### PR TITLE
feat: support YAML cluster-annotations for BGP peers

### DIFF
--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -67,6 +67,23 @@ config:
                 topology.kubernetes.io/zone: zone-a
           k8sd/v1alpha1/metallb/advertise-all-pools: "true"
 
+        Example (manual test) to configure BGP peers via charm config:
+
+          juju config k8s \
+            load-balancer-enabled=true \
+            load-balancer-bgp-mode=true \
+            load-balancer-bgp-local-asn=65000 \
+            cluster-annotations="$(cat <<'EOF'
+          k8sd/v1alpha1/metallb/bgp-peers: |
+            - peerAddress: 192.0.2.1
+              peerASN: 65001
+              myASN: 65000
+              nodeSelector:
+                topology.kubernetes.io/zone: zone-a
+          k8sd/v1alpha1/metallb/advertise-all-pools: "true"
+          EOF
+          )"
+
         When this config is non-empty it overrides any annotations currently
         set on the cluster.  Leave it empty to preserve existing annotations.
     bootstrap-datastore:

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -48,49 +48,12 @@ config:
       type: string
       default: ""
       description: |
-        YAML mapping of key/value pairs that can be used to add arbitrary
-        metadata configuration to the Canonical Kubernetes cluster.
-        For more information, see the upstream Canonical Kubernetes documentation
-        about annotations:
+        Cluster annotations for Canonical Kubernetes.
+        Preferred format: YAML mapping (supports multi-line values).
+        Legacy format: space-separated key=value pairs.
 
+        See:
         https://documentation.ubuntu.com/canonical-kubernetes/latest/src/snap/reference/annotations/
-
-        The preferred value format is a YAML mapping. Multi-line string values
-        (YAML block literals) are supported, which makes it possible to pass
-        structured annotations such as the alpha multi-peer BGP config:
-
-          k8sd/v1alpha1/metallb/bgp-peers: |
-            - peerAddress: 10.0.0.1
-              peerASN: 65001
-              myASN: 65000
-              nodeSelector:
-                topology.kubernetes.io/zone: zone-a
-          k8sd/v1alpha1/metallb/advertise-all-pools: "true"
-
-        Backward compatibility: legacy space-separated key=value pairs are
-        still accepted for simple annotations:
-
-          key1=value1 key2=value2
-
-        Example (manual test) to configure BGP peers via charm config:
-
-          juju config k8s \
-            load-balancer-enabled=true \
-            load-balancer-bgp-mode=true \
-            load-balancer-bgp-local-asn=65000 \
-            cluster-annotations="$(cat <<'EOF'
-          k8sd/v1alpha1/metallb/bgp-peers: |
-            - peerAddress: 192.0.2.1
-              peerASN: 65001
-              myASN: 65000
-              nodeSelector:
-                topology.kubernetes.io/zone: zone-a
-          k8sd/v1alpha1/metallb/advertise-all-pools: "true"
-          EOF
-          )"
-
-        When this config is non-empty it overrides any annotations currently
-        set on the cluster.  Leave it empty to preserve existing annotations.
     bootstrap-datastore:
       type: string
       default: ""

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -55,7 +55,7 @@ config:
 
         https://documentation.ubuntu.com/canonical-kubernetes/latest/src/snap/reference/annotations/
 
-        The value must be a YAML-formatted mapping.  Multi-line string values
+        The preferred value format is a YAML mapping. Multi-line string values
         (YAML block literals) are supported, which makes it possible to pass
         structured annotations such as the alpha multi-peer BGP config:
 
@@ -66,6 +66,11 @@ config:
               nodeSelector:
                 topology.kubernetes.io/zone: zone-a
           k8sd/v1alpha1/metallb/advertise-all-pools: "true"
+
+        Backward compatibility: legacy space-separated key=value pairs are
+        still accepted for simple annotations:
+
+          key1=value1 key2=value2
 
         Example (manual test) to configure BGP peers via charm config:
 

--- a/charms/worker/k8s/charmcraft.yaml
+++ b/charms/worker/k8s/charmcraft.yaml
@@ -48,15 +48,27 @@ config:
       type: string
       default: ""
       description: |
-        Space-separated list of (key/value) pairs) that can be
-        used to add arbitrary metadata configuration to the Canonical
-        Kubernetes cluster. For more information, see the upstream Canonical
-        Kubernetes documentation about annotations:
+        YAML mapping of key/value pairs that can be used to add arbitrary
+        metadata configuration to the Canonical Kubernetes cluster.
+        For more information, see the upstream Canonical Kubernetes documentation
+        about annotations:
 
         https://documentation.ubuntu.com/canonical-kubernetes/latest/src/snap/reference/annotations/
 
-        Example:
-          e.g.: key1=value1 key2=value2
+        The value must be a YAML-formatted mapping.  Multi-line string values
+        (YAML block literals) are supported, which makes it possible to pass
+        structured annotations such as the alpha multi-peer BGP config:
+
+          k8sd/v1alpha1/metallb/bgp-peers: |
+            - peerAddress: 10.0.0.1
+              peerASN: 65001
+              myASN: 65000
+              nodeSelector:
+                topology.kubernetes.io/zone: zone-a
+          k8sd/v1alpha1/metallb/advertise-all-pools: "true"
+
+        When this config is non-empty it overrides any annotations currently
+        set on the cluster.  Leave it empty to preserve existing annotations.
     bootstrap-datastore:
       type: string
       default: ""

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -26,7 +26,7 @@ from collections import defaultdict
 from functools import cached_property
 from pathlib import Path
 from time import sleep
-from typing import Dict, FrozenSet, List, Optional, Tuple, Union
+from typing import Dict, FrozenSet, List, NoReturn, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 import charmlibs.snap as snap_lib
@@ -607,6 +607,37 @@ class K8sCharm(ops.CharmBase):
         if relation := self.model.get_relation(COS_TOKENS_RELATION):
             self.collector.request(relation)
 
+    def _raise_invalid_annotations(self, msg: str, raw_annotations: str) -> NoReturn:
+        log.error("%s: %s", msg, raw_annotations)
+        status.add(ops.BlockedStatus("Invalid Annotations"))
+        raise ReconcilerError(msg)
+
+    def _parse_yaml_annotations(self, raw_annotations: str) -> Optional[dict]:
+        try:
+            parsed = yaml.safe_load(raw_annotations)
+        except yaml.YAMLError:
+            return None
+
+        if not isinstance(parsed, dict):
+            return None
+
+        annotations = {}
+        for key, value in parsed.items():
+            if not isinstance(key, str):
+                msg = f"cluster-annotations key must be a string, got {type(key).__name__}"
+                self._raise_invalid_annotations(msg, raw_annotations)
+            annotations[str(key)] = str(value) if not isinstance(value, str) else value
+        return annotations or None
+
+    def _parse_legacy_annotations(self, raw_annotations: str) -> Optional[dict]:
+        annotations = {}
+        for token in raw_annotations.split():
+            key, value = token.split("=", 1)
+            if not key or not value:
+                raise ValueError("empty key/value")
+            annotations[key] = value
+        return annotations or None
+
     def _get_valid_annotations(self) -> Optional[dict]:
         """Fetch and validate cluster-annotations from charm configuration.
 
@@ -639,45 +670,14 @@ class K8sCharm(ops.CharmBase):
 
         raw_annotations = str(raw_annotations)
 
-        # Preferred format: YAML mapping.
-        try:
-            parsed = yaml.safe_load(raw_annotations)
-        except yaml.YAMLError:
-            parsed = None
-        else:
-            if isinstance(parsed, dict):
-                annotations: dict = {}
-                for key, value in parsed.items():
-                    if not isinstance(key, str):
-                        msg = f"cluster-annotations key must be a string, got {type(key).__name__}"
-                        log.error(msg)
-                        status.add(ops.BlockedStatus("Invalid Annotations"))
-                        raise ReconcilerError(msg)
-                    annotations[str(key)] = str(value) if not isinstance(value, str) else value
-                return annotations or None
+        if annotations := self._parse_yaml_annotations(raw_annotations):
+            return annotations
 
-        # Backward compatibility: legacy key=value key2=value2 format.
-        annotations = {}
         try:
-            for token in raw_annotations.split():
-                key, value = token.split("=", 1)
-                if not key or not value:
-                    raise ValueError("empty key/value")
-                annotations[key] = value
+            return self._parse_legacy_annotations(raw_annotations)
         except ValueError:
             msg = "cluster-annotations must be a YAML mapping or key=value pairs"
-            log.error("%s: %s", msg, raw_annotations)
-            status.add(ops.BlockedStatus("Invalid Annotations"))
-            raise ReconcilerError(msg)
-
-        for key, value in annotations.items():
-            if not isinstance(key, str):
-                msg = f"cluster-annotations key must be a string, got {type(key).__name__}"
-                log.error(msg)
-                status.add(ops.BlockedStatus("Invalid Annotations"))
-                raise ReconcilerError(msg)
-
-        return annotations or None
+            self._raise_invalid_annotations(msg, raw_annotations)
 
     def _configure_datastore(self, config: Union[BootstrapConfig, UpdateClusterConfigRequest]):
         """Configure the datastore for the Kubernetes cluster.

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -610,13 +610,23 @@ class K8sCharm(ops.CharmBase):
     def _get_valid_annotations(self) -> Optional[dict]:
         """Fetch and validate cluster-annotations from charm configuration.
 
-        The values are expected to be a space-separated string of key-value pairs.
+        Accepts a YAML-formatted string where each key maps to a string value.
+        Multi-line values (e.g. YAML block literals) are supported, making it
+        possible to pass annotations such as k8sd/v1alpha1/metallb/bgp-peers.
+
+        Example (set via ``juju config k8s cluster-annotations=@bgp.yaml``):
+
+            k8sd/v1alpha1/metallb/bgp-peers: |
+              - peerAddress: 10.0.0.1
+                peerASN: 65001
+                myASN: 65000
+            k8sd/v1alpha1/metallb/advertise-all-pools: "true"
 
         Returns:
             dict: The parsed annotations if valid, otherwise None.
 
         Raises:
-            ReconcilerError: If any annotation is invalid.
+            ReconcilerError: If the value is not a valid YAML mapping of strings.
         """
         raw_annotations = self.config.get("cluster-annotations")
         if not raw_annotations:
@@ -624,18 +634,29 @@ class K8sCharm(ops.CharmBase):
 
         raw_annotations = str(raw_annotations)
 
-        annotations = {}
         try:
-            for key, value in [pair.split("=", 1) for pair in raw_annotations.split()]:
-                if not key or not value:
-                    raise ReconcilerError("Invalid Annotation")
-                annotations[key] = value
-        except ReconcilerError:
-            log.exception("Invalid annotations: %s", raw_annotations)
+            parsed = yaml.safe_load(raw_annotations)
+        except yaml.YAMLError:
+            log.exception("Invalid annotations (YAML parse error): %s", raw_annotations)
             status.add(ops.BlockedStatus("Invalid Annotations"))
-            raise
+            raise ReconcilerError("Invalid Annotations: YAML parse error")
 
-        return annotations
+        if not isinstance(parsed, dict):
+            msg = f"cluster-annotations must be a YAML mapping, got {type(parsed).__name__}"
+            log.error(msg)
+            status.add(ops.BlockedStatus("Invalid Annotations"))
+            raise ReconcilerError(msg)
+
+        annotations: dict = {}
+        for key, value in parsed.items():
+            if not isinstance(key, str):
+                msg = f"cluster-annotations key must be a string, got {type(key).__name__}"
+                log.error(msg)
+                status.add(ops.BlockedStatus("Invalid Annotations"))
+                raise ReconcilerError(msg)
+            annotations[str(key)] = str(value) if not isinstance(value, str) else value
+
+        return annotations or None
 
     def _configure_datastore(self, config: Union[BootstrapConfig, UpdateClusterConfigRequest]):
         """Configure the datastore for the Kubernetes cluster.

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -649,9 +649,7 @@ class K8sCharm(ops.CharmBase):
                 annotations: dict = {}
                 for key, value in parsed.items():
                     if not isinstance(key, str):
-                        msg = (
-                            f"cluster-annotations key must be a string, got {type(key).__name__}"
-                        )
+                        msg = f"cluster-annotations key must be a string, got {type(key).__name__}"
                         log.error(msg)
                         status.add(ops.BlockedStatus("Invalid Annotations"))
                         raise ReconcilerError(msg)

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -610,9 +610,13 @@ class K8sCharm(ops.CharmBase):
     def _get_valid_annotations(self) -> Optional[dict]:
         """Fetch and validate cluster-annotations from charm configuration.
 
-        Accepts a YAML-formatted string where each key maps to a string value.
-        Multi-line values (e.g. YAML block literals) are supported, making it
-        possible to pass annotations such as k8sd/v1alpha1/metallb/bgp-peers.
+        Accepts either:
+        - a YAML-formatted mapping where each key maps to a string value
+        - a legacy space-separated list of key=value pairs
+
+        YAML is preferred because it supports multi-line values (e.g. YAML
+        block literals), making it possible to pass annotations such as
+        k8sd/v1alpha1/metallb/bgp-peers.
 
         Example (set via ``juju config k8s cluster-annotations=@bgp.yaml``):
 
@@ -626,7 +630,8 @@ class K8sCharm(ops.CharmBase):
             dict: The parsed annotations if valid, otherwise None.
 
         Raises:
-            ReconcilerError: If the value is not a valid YAML mapping of strings.
+            ReconcilerError: If the value is neither a valid YAML mapping nor
+                valid legacy key=value pairs.
         """
         raw_annotations = self.config.get("cluster-annotations")
         if not raw_annotations:
@@ -634,27 +639,45 @@ class K8sCharm(ops.CharmBase):
 
         raw_annotations = str(raw_annotations)
 
+        # Preferred format: YAML mapping.
         try:
             parsed = yaml.safe_load(raw_annotations)
         except yaml.YAMLError:
-            log.exception("Invalid annotations (YAML parse error): %s", raw_annotations)
-            status.add(ops.BlockedStatus("Invalid Annotations"))
-            raise ReconcilerError("Invalid Annotations: YAML parse error")
+            parsed = None
+        else:
+            if isinstance(parsed, dict):
+                annotations: dict = {}
+                for key, value in parsed.items():
+                    if not isinstance(key, str):
+                        msg = (
+                            f"cluster-annotations key must be a string, got {type(key).__name__}"
+                        )
+                        log.error(msg)
+                        status.add(ops.BlockedStatus("Invalid Annotations"))
+                        raise ReconcilerError(msg)
+                    annotations[str(key)] = str(value) if not isinstance(value, str) else value
+                return annotations or None
 
-        if not isinstance(parsed, dict):
-            msg = f"cluster-annotations must be a YAML mapping, got {type(parsed).__name__}"
-            log.error(msg)
+        # Backward compatibility: legacy key=value key2=value2 format.
+        annotations = {}
+        try:
+            for token in raw_annotations.split():
+                key, value = token.split("=", 1)
+                if not key or not value:
+                    raise ValueError("empty key/value")
+                annotations[key] = value
+        except ValueError:
+            msg = "cluster-annotations must be a YAML mapping or key=value pairs"
+            log.error("%s: %s", msg, raw_annotations)
             status.add(ops.BlockedStatus("Invalid Annotations"))
             raise ReconcilerError(msg)
 
-        annotations: dict = {}
-        for key, value in parsed.items():
+        for key, value in annotations.items():
             if not isinstance(key, str):
                 msg = f"cluster-annotations key must be a string, got {type(key).__name__}"
                 log.error(msg)
                 status.add(ops.BlockedStatus("Invalid Annotations"))
                 raise ReconcilerError(msg)
-            annotations[str(key)] = str(value) if not isinstance(value, str) else value
 
         return annotations or None
 

--- a/charms/worker/k8s/src/config/cluster.py
+++ b/charms/worker/k8s/src/config/cluster.py
@@ -46,6 +46,7 @@ def assemble_cluster_config(
     _assemble_ingress(charm, assembled)
     _assemble_metrics_server(charm, assembled)
     _assemble_load_balancer(charm, assembled)
+    _assemble_annotations(charm, assembled)
     assembled.cloud_provider = cloud_provider
     return assembled
 
@@ -127,3 +128,33 @@ def _assemble_load_balancer(charm: ops.CharmBase, assembled: UserFacingClusterCo
     load_balancer.bgp_peer_address = literals.LOAD_BALANCER_BGP_PEER_ADDRESS.get(charm)
     load_balancer.bgp_peer_asn = literals.LOAD_BALANCER_BGP_PEER_ASN.get(charm)
     load_balancer.bgp_peer_port = literals.LOAD_BALANCER_BGP_PEER_PORT.get(charm)
+
+
+def _assemble_annotations(charm: ops.CharmBase, assembled: UserFacingClusterConfig):
+    """Populate annotations from the cluster-annotations charm config.
+
+    Annotations are only overwritten when the charm config is non-empty.
+    When the config is unset the current cluster annotations are left intact so
+    that out-of-band annotation changes (e.g. made directly via the k8s CLI)
+    are not silently discarded on the next reconcile cycle.
+    """
+    raw = charm.config.get("cluster-annotations", "")
+    if not raw:
+        return
+
+    import yaml  # local import — yaml is a standard library dep of ops
+
+    try:
+        parsed = yaml.safe_load(str(raw))
+    except yaml.YAMLError:
+        log.warning("cluster-annotations is not valid YAML — skipping annotation assembly")
+        return
+
+    if not isinstance(parsed, dict):
+        log.warning(
+            "cluster-annotations must be a YAML mapping — got %s, skipping",
+            type(parsed).__name__,
+        )
+        return
+
+    assembled.annotations = {str(k): str(v) for k, v in parsed.items()}

--- a/charms/worker/k8s/src/config/cluster.py
+++ b/charms/worker/k8s/src/config/cluster.py
@@ -144,17 +144,30 @@ def _assemble_annotations(charm: ops.CharmBase, assembled: UserFacingClusterConf
 
     import yaml  # local import — yaml is a standard library dep of ops
 
-    try:
-        parsed = yaml.safe_load(str(raw))
-    except yaml.YAMLError:
-        log.warning("cluster-annotations is not valid YAML — skipping annotation assembly")
-        return
+    raw = str(raw)
 
-    if not isinstance(parsed, dict):
+    # Preferred format: YAML mapping. Supports multiline block literals for BGP peers.
+    try:
+        parsed = yaml.safe_load(raw)
+    except yaml.YAMLError:
+        parsed = None
+    else:
+        if isinstance(parsed, dict):
+            assembled.annotations = {str(k): str(v) for k, v in parsed.items()}
+            return
+
+    # Backward compatibility: legacy space-separated key=value pairs.
+    annotations: dict[str, str] = {}
+    try:
+        for token in raw.split():
+            key, value = token.split("=", 1)
+            if not key or not value:
+                raise ValueError("empty key/value")
+            annotations[key] = value
+    except ValueError:
         log.warning(
-            "cluster-annotations must be a YAML mapping — got %s, skipping",
-            type(parsed).__name__,
+            "cluster-annotations must be a YAML mapping or space-separated key=value pairs"
         )
         return
 
-    assembled.annotations = {str(k): str(v) for k, v in parsed.items()}
+    assembled.annotations = annotations

--- a/tests/unit/config/test_cluster.py
+++ b/tests/unit/config/test_cluster.py
@@ -184,6 +184,22 @@ def test_assemble_annotations_simple(harness):
     }, f"Unexpected annotations: {ufcg.annotations}"
 
 
+def test_assemble_annotations_legacy_space_separated(harness):
+    """Legacy space-separated key=value format remains supported."""
+    if harness.charm.is_worker:
+        pytest.skip("Not applicable on workers")
+
+    harness.disable_hooks()
+    harness.update_config(
+        {"cluster-annotations": "k8sd/v1alpha1/metallb/advertise-all-pools=true key2=value2"}
+    )
+    ufcg = assemble_cluster_config(harness.charm, None)
+    assert ufcg.annotations == {
+        "k8sd/v1alpha1/metallb/advertise-all-pools": "true",
+        "key2": "value2",
+    }, f"Unexpected annotations: {ufcg.annotations}"
+
+
 def test_assemble_annotations_multiline_bgp_peers(harness):
     """Multi-line YAML block literal for bgp-peers is preserved as a string."""
     if harness.charm.is_worker:
@@ -230,4 +246,23 @@ def test_assemble_annotations_not_overwritten_when_empty(harness):
     ufcg = assemble_cluster_config(harness.charm, None, current=existing)
     assert ufcg.annotations == {"some-key": "some-value"}, (
         "Existing annotations should be preserved when cluster-annotations config is empty"
+    )
+
+
+def test_assemble_annotations_invalid_legacy_not_overwritten(harness):
+    """Invalid legacy format does not overwrite existing annotations."""
+    from k8sd_api_manager import UserFacingClusterConfig
+
+    if harness.charm.is_worker:
+        pytest.skip("Not applicable on workers")
+
+    harness.disable_hooks()
+    harness.update_config({"cluster-annotations": "key1=value1 broken-token"})
+
+    existing = UserFacingClusterConfig()
+    existing.annotations = {"some-key": "some-value"}
+
+    ufcg = assemble_cluster_config(harness.charm, None, current=existing)
+    assert ufcg.annotations == {"some-key": "some-value"}, (
+        "Existing annotations should be preserved when cluster-annotations is invalid"
     )

--- a/tests/unit/config/test_cluster.py
+++ b/tests/unit/config/test_cluster.py
@@ -179,9 +179,9 @@ def test_assemble_annotations_simple(harness):
         {"cluster-annotations": "k8sd/v1alpha1/metallb/advertise-all-pools: 'true'"}
     )
     ufcg = assemble_cluster_config(harness.charm, None)
-    assert ufcg.annotations == {
-        "k8sd/v1alpha1/metallb/advertise-all-pools": "true"
-    }, f"Unexpected annotations: {ufcg.annotations}"
+    assert ufcg.annotations == {"k8sd/v1alpha1/metallb/advertise-all-pools": "true"}, (
+        f"Unexpected annotations: {ufcg.annotations}"
+    )
 
 
 def test_assemble_annotations_legacy_space_separated(harness):

--- a/tests/unit/config/test_cluster.py
+++ b/tests/unit/config/test_cluster.py
@@ -156,3 +156,78 @@ def test_configure_datastore_extra_args(harness):
         "--listen-metrics-urls": "http://localhost:2381",
         "--clog": "true",
     }
+
+
+def test_assemble_annotations_empty(harness):
+    """Annotations stay None when cluster-annotations is empty."""
+    if harness.charm.is_worker:
+        pytest.skip("Not applicable on workers")
+
+    harness.disable_hooks()
+    harness.update_config({"cluster-annotations": ""})
+    ufcg = assemble_cluster_config(harness.charm, None)
+    assert ufcg.annotations is None, "Expected no annotations when config is empty"
+
+
+def test_assemble_annotations_simple(harness):
+    """Simple flat key/value YAML mapping is parsed into annotations."""
+    if harness.charm.is_worker:
+        pytest.skip("Not applicable on workers")
+
+    harness.disable_hooks()
+    harness.update_config(
+        {"cluster-annotations": "k8sd/v1alpha1/metallb/advertise-all-pools: 'true'"}
+    )
+    ufcg = assemble_cluster_config(harness.charm, None)
+    assert ufcg.annotations == {
+        "k8sd/v1alpha1/metallb/advertise-all-pools": "true"
+    }, f"Unexpected annotations: {ufcg.annotations}"
+
+
+def test_assemble_annotations_multiline_bgp_peers(harness):
+    """Multi-line YAML block literal for bgp-peers is preserved as a string."""
+    if harness.charm.is_worker:
+        pytest.skip("Not applicable on workers")
+
+    harness.disable_hooks()
+    bgp_peers_yaml = (
+        "- peerAddress: 192.0.2.1\n"
+        "  peerASN: 65001\n"
+        "  myASN: 65000\n"
+        "  nodeSelector:\n"
+        "    topology.kubernetes.io/zone: zone-a\n"
+    )
+    annotation_config = (
+        "k8sd/v1alpha1/metallb/bgp-peers: |\n"
+        + "".join(f"  {line}\n" for line in bgp_peers_yaml.splitlines())
+        + 'k8sd/v1alpha1/metallb/advertise-all-pools: "true"\n'
+    )
+    harness.update_config({"cluster-annotations": annotation_config})
+    ufcg = assemble_cluster_config(harness.charm, None)
+    assert ufcg.annotations is not None, "Expected annotations to be set"
+    assert "k8sd/v1alpha1/metallb/bgp-peers" in ufcg.annotations
+    assert "k8sd/v1alpha1/metallb/advertise-all-pools" in ufcg.annotations
+    assert ufcg.annotations["k8sd/v1alpha1/metallb/advertise-all-pools"] == "true"
+    # The bgp-peers value should contain the peer list as a YAML string
+    peers_val = ufcg.annotations["k8sd/v1alpha1/metallb/bgp-peers"]
+    assert "peerAddress: 192.0.2.1" in peers_val
+    assert "peerASN: 65001" in peers_val
+
+
+def test_assemble_annotations_not_overwritten_when_empty(harness):
+    """When cluster-annotations is empty, existing annotations from current config are kept."""
+    from k8sd_api_manager import UserFacingClusterConfig
+
+    if harness.charm.is_worker:
+        pytest.skip("Not applicable on workers")
+
+    harness.disable_hooks()
+    harness.update_config({"cluster-annotations": ""})
+
+    existing = UserFacingClusterConfig()
+    existing.annotations = {"some-key": "some-value"}
+
+    ufcg = assemble_cluster_config(harness.charm, None, current=existing)
+    assert ufcg.annotations == {"some-key": "some-value"}, (
+        "Existing annotations should be preserved when cluster-annotations config is empty"
+    )


### PR DESCRIPTION
## Summary
- parse `cluster-annotations` as a YAML mapping first
- keep backward compatibility by falling back to legacy space-separated `key=value` parsing
- wire annotations into assembled cluster config so they are sent to k8sd
- document YAML format (preferred) and legacy format (supported)
- add unit tests for YAML, multiline BGP, legacy format, and invalid legacy handling

## How to set BGP peers via charm config
This branch supports setting BGP peers through `cluster-annotations` YAML.

Example used in manual testing:

```bash
juju config k8s \
  load-balancer-enabled=true \
  load-balancer-bgp-mode=true \
  load-balancer-bgp-local-asn=65000 \
  cluster-annotations="$(cat <<'EOT'
k8sd/v1alpha1/metallb/bgp-peers: |
  - peerAddress: 192.0.2.1
    peerASN: 65001
    myASN: 65000
    nodeSelector:
      topology.kubernetes.io/zone: zone-a
k8sd/v1alpha1/metallb/advertise-all-pools: \"true\"
EOT
)"
```

## Backward compatibility
Legacy format remains supported for simple annotations:

```bash
juju config k8s cluster-annotations='key1=value1 key2=value2'
```

## Verification commands
```bash
juju config k8s cluster-annotations --format yaml
juju config k8s load-balancer-enabled --format yaml
juju config k8s load-balancer-bgp-mode --format yaml
juju config k8s load-balancer-bgp-local-asn --format yaml
```

## Testing
unit tests and 
<details>
<summary> manual testing (expand to see BGPPeer and BGPAdvertisement CRDs) </summary>

```
juju exec --unit k8s/1 -- 'sudo k8s kubectl get BGPPeer -A'
juju exec --unit k8s/1 -- 'sudo k8s kubectl get BGPPeer -A -o yaml'
juju exec --unit k8s/1 -- 'sudo k8s kubectl get BGPAdvertisement -A'
juju exec --unit k8s/1 -- 'sudo k8s kubectl get BGPAdvertisement -A -o yaml'
NAMESPACE        NAME                                     ADDRESS         ASN     BFD PROFILE   MULTI HOPS
metallb-system   metallb-loadbalancer-ck-loadbalancer     10.116.3.164    65001                 
metallb-system   metallb-loadbalancer-ck-loadbalancer-1   10.116.37.164   65002                 
metallb-system   metallb-loadbalancer-ck-loadbalancer-2   10.116.71.164   65003                 
apiVersion: v1
items:
- apiVersion: metallb.io/v1beta2
  kind: BGPPeer
  metadata:
    annotations:
      meta.helm.sh/release-name: metallb-loadbalancer
      meta.helm.sh/release-namespace: metallb-system
    creationTimestamp: "2026-07-16T13:11:26Z"
    generation: 2
    labels:
      app.kubernetes.io/instance: metallb-loadbalancer
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/name: ck-loadbalancer
      app.kubernetes.io/version: 0.1.1
      helm.sh/chart: ck-loadbalancer-0.1.2
    name: metallb-loadbalancer-ck-loadbalancer
    namespace: metallb-system
    resourceVersion: "11086"
    uid: f0946d22-62e6-4c6c-a4ef-299c2d7d158e
  spec:
    disableMP: false
    dualStackAddressFamily: false
    myASN: 65000
    nodeSelectors:
    - matchLabels:
        topology.kubernetes.io/zone: i1
    peerASN: 65001
    peerAddress: 10.116.3.164
    peerPort: 179
- apiVersion: metallb.io/v1beta2
  kind: BGPPeer
  metadata:
    annotations:
      meta.helm.sh/release-name: metallb-loadbalancer
      meta.helm.sh/release-namespace: metallb-system
    creationTimestamp: "2026-07-16T15:04:12Z"
    generation: 1
    labels:
      app.kubernetes.io/instance: metallb-loadbalancer
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/name: ck-loadbalancer
      app.kubernetes.io/version: 0.1.1
      helm.sh/chart: ck-loadbalancer-0.1.2
    name: metallb-loadbalancer-ck-loadbalancer-1
    namespace: metallb-system
    resourceVersion: "11087"
    uid: 28b62696-7a84-4b26-8392-1c8d68e9fd4b
  spec:
    disableMP: false
    dualStackAddressFamily: false
    myASN: 65000
    nodeSelectors:
    - matchLabels:
        topology.kubernetes.io/zone: i2
    peerASN: 65002
    peerAddress: 10.116.37.164
    peerPort: 179
- apiVersion: metallb.io/v1beta2
  kind: BGPPeer
  metadata:
    annotations:
      meta.helm.sh/release-name: metallb-loadbalancer
      meta.helm.sh/release-namespace: metallb-system
    creationTimestamp: "2026-07-16T15:04:12Z"
    generation: 1
    labels:
      app.kubernetes.io/instance: metallb-loadbalancer
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/name: ck-loadbalancer
      app.kubernetes.io/version: 0.1.1
      helm.sh/chart: ck-loadbalancer-0.1.2
    name: metallb-loadbalancer-ck-loadbalancer-2
    namespace: metallb-system
    resourceVersion: "11088"
    uid: b2a6edb8-50c9-4bd9-951a-084873ff6e99
  spec:
    disableMP: false
    dualStackAddressFamily: false
    myASN: 65000
    nodeSelectors:
    - matchLabels:
        topology.kubernetes.io/zone: i3
    peerASN: 65003
    peerAddress: 10.116.71.164
    peerPort: 179
kind: List
metadata:
  resourceVersion: ""
NAMESPACE        NAME                                   IPADDRESSPOOLS   IPADDRESSPOOL SELECTORS   PEERS
metallb-system   metallb-loadbalancer-ck-loadbalancer                                              
apiVersion: v1
items:
- apiVersion: metallb.io/v1beta1
  kind: BGPAdvertisement
  metadata:
    annotations:
      meta.helm.sh/release-name: metallb-loadbalancer
      meta.helm.sh/release-namespace: metallb-system
    creationTimestamp: "2026-07-16T13:11:26Z"
    generation: 1
    labels:
      app.kubernetes.io/instance: metallb-loadbalancer
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/name: ck-loadbalancer
      app.kubernetes.io/version: 0.1.1
      helm.sh/chart: ck-loadbalancer-0.1.2
    name: metallb-loadbalancer-ck-loadbalancer
    namespace: metallb-system
    resourceVersion: "1886"
    uid: ac0d35bb-43be-4995-898c-0b9e1989526c
  spec:
    aggregationLength: 32
    aggregationLengthV6: 128
kind: List
metadata:
  resourceVersion: ""
```

  </details>
