### PR TITLE
feat: migrate from `rocks.c.c` to `ghcr.io`

### DIFF
--- a/charms/worker/k8s/src/kube_control.py
+++ b/charms/worker/k8s/src/kube_control.py
@@ -67,7 +67,7 @@ def configure(charm: K8sCharmProtocol):
         charm.kube_control.set_dns_port(53)
 
     charm.kube_control.set_default_cni("")
-    charm.kube_control.set_image_registry("rocks.canonical.com/cdk")
+    charm.kube_control.set_image_registry("ghcr.io/canonical/cdk")
 
     charm.kube_control.set_cluster_name(charm.get_cluster_name())
     charm.kube_control.set_has_external_cloud_provider(charm.xcp.has_xcp)

--- a/tests/integration/data/test_dualstack/nginx-dualstack.yaml
+++ b/tests/integration/data/test_dualstack/nginx-dualstack.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: nginxdualstack
-        image: rocks.canonical.com/cdk/diverdane/nginxdualstack:1.0.0
+        image: ghcr.io/canonical/cdk/diverdane/nginxdualstack:1.0.0
         ports:
         - containerPort: 80
 ---

--- a/tests/integration/data/test_ipv6only/nginx-ipv6-only.yaml
+++ b/tests/integration/data/test_ipv6only/nginx-ipv6-only.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: nginxipv6
-        image: rocks.canonical.com/cdk/diverdane/nginxdualstack:1.0.0
+        image: ghcr.io/canonical/cdk/diverdane/nginxdualstack:1.0.0
         ports:
         - containerPort: 80
 ---

--- a/tests/integration/data/test_storage_provider/pv-reader-pod.yaml
+++ b/tests/integration/data/test_storage_provider/pv-reader-pod.yaml
@@ -14,7 +14,7 @@ spec:
       claimName: test-pvc
   containers:
   - name: pv-reader
-    image: rocks.canonical.com/cdk/busybox:1.36
+    image: ghcr.io/canonical/cdk/busybox:1.36
     command: ["/bin/sh", "-c", "cat /pv/test_file"]
     volumeMounts:
     - name: test-pv

--- a/tests/integration/data/test_storage_provider/pv-writer-pod.yaml
+++ b/tests/integration/data/test_storage_provider/pv-writer-pod.yaml
@@ -14,7 +14,7 @@ spec:
       claimName: test-pvc
   containers:
   - name: pv-writer
-    image: rocks.canonical.com/cdk/busybox:1.36
+    image: ghcr.io/canonical/cdk/busybox:1.36
     command: ["/bin/sh", "-c", "echo 'PV test data.' > /pv/test_file"]
     volumeMounts:
     - name: test-pv

--- a/tests/integration/test_registry.py
+++ b/tests/integration/test_registry.py
@@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
 
 TEST_DATA_PATH = Path(__file__).parent / "data" / "test_registries" / "pod.yaml"
 TEST_IMAGE = "busybox:1.36"
-TEST_SOURCE_IMAGE = f"rocks.canonical.com/cdk/{TEST_IMAGE}"
+TEST_SOURCE_IMAGE = f"ghcr.io/canonical/cdk/{TEST_IMAGE}"
 
 
 @pytest.mark.abort_on_fail


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Repoint the registry to `rocks.c.c` to `ghcr.io`.

### Rationale

We are deprecating rocks.c.c, so we need to repoint all the images to the new registry. 

