### PR TITLE
fix: restore cluster-annotations wiring in assemble_cluster_config

### DIFF
--- a/tests/integration/test_k8s.py
+++ b/tests/integration/test_k8s.py
@@ -139,8 +139,21 @@ def test_cluster_annotations(
         f"Expected annotation {testname}=true to reach k8sd, got: {annotations}"
     )
 
+    # Remove the annotation via the key=- deletion marker. Resetting the charm
+    # config to its default (empty) value alone would leave the annotation
+    # stored in the cluster config.
+    removal_config = {"cluster-annotations": f"{testname}=-"}
     with fast_forward(k8s_cluster, ONE_MIN):
-        k8s_cluster.config("k8s", reset=list(annotation_config))
+        k8s_cluster.config("k8s", removal_config)
+        wait_active(k8s_cluster, "k8s", timeout=timeout * 60)
+
+    annotations = get_k8sd_cluster_config_annotations(k8s_cluster, leader)
+    assert testname not in annotations, (
+        f"Expected annotation {testname} to be removed from k8sd, got: {annotations}"
+    )
+
+    with fast_forward(k8s_cluster, ONE_MIN):
+        k8s_cluster.config("k8s", reset=list(removal_config))
         wait_active(k8s_cluster, "k8s", timeout=timeout * 60)
 
 


### PR DESCRIPTION
## What

Restores the `cluster-annotations` charm config option, which currently has **zero effect** on the cluster on `main`.

## Why

This is a regression from #508 ("Prevent k8s snap restarts if the cluster config doesn't change"), which split `_assemble_cluster_config()` out of `charm.py` into a new `config/cluster.py` module. Every other config field (`dns`, `gateway`, `ingress`, `load_balancer`, `metrics_server`, `network`, `local_storage`) got its own `_assemble_*()` step ported into the new module — annotations did not. `_get_valid_annotations()` was left behind in `charm.py`, orphaned with no caller.

Before #508, this config option worked (introduced in #154, survived the #169 refactor). There was never any test coverage for it, so the regression went unnoticed.

## What this PR does (and doesn't do)

This is the **minimal fix**: adds `_assemble_annotations()` to `config/cluster.py` following the same pattern as the other `_assemble_*()` helpers, wired into `assemble_cluster_config()`, reusing the existing `_get_valid_annotations()` parser. Restores parity with the pre-#508 behavior — **legacy space-separated `key=value` format only**.

It does **not** add YAML/nested-annotation support (needed for multi-value keys like BGP peers) — that's a separate, larger feature discussed in #967, which this PR does not attempt to replace or preclude.

## Testing

- Added `test_configure_annotations` (verifies `cluster-annotations` config is now assembled into `UserFacingClusterConfig.annotations`)
- Added `test_configure_annotations_not_overwritten_when_empty` (verifies existing annotations, e.g. set out-of-band via the k8s CLI, are preserved when the charm config is unset — matches k8sd's key-level annotation merge semantics)
- `tox -e unit -- tests/unit/config/test_cluster.py` — all 8 tests pass (4 pre-existing + 2 new x 2 param variants)
- `tox -e lint` — clean (ruff + mypy)
