### PR TITLE
fix: publish job contents permission

### DIFF
--- a/.github/workflows/publish-charms.yaml
+++ b/.github/workflows/publish-charms.yaml
@@ -43,6 +43,11 @@ jobs:
         run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
   publish-to-edge:
     needs: [configure-channel, charmcraft-channel]
+    permissions:
+      contents: write
+    concurrency:
+      group: publish-charm-${{ github.ref }}-${{ matrix.charm.tagPrefix }}-${{ matrix.arch }}
+      cancel-in-progress: false
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@27f280ed34b54bd9f65451dc966bfde701e84b62 # main
     strategy:
       matrix:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Fix the charm publish job that has been broken since the new organization policy.

- May 18 successful job: Contents: write (https://github.com/canonical/k8s-operator/actions/runs/26040446708/job/76550338568)
- August 13 failing job: Contents: read (https://github.com/canonical/k8s-operator/actions/runs/31713480686/job/94492276537)
