### PR TITLE
chore(release-1.32): update k8s snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 5279
+  revision: 5473
 arm64:
 - install-type: store
   name: k8s
-  revision: 5280
+  revision: 5476


### PR DESCRIPTION
## Overview

Updates the K8s snap revisions for the `1.32` track.

## Revisions

| Architecture | Revision |
|--------------|----------|
| amd64 | 5473 |
| arm64 | 5476 |

## Source Commits

Both architectures are built from the same commit:
- https://github.com/canonical/k8s-snap/commit/388c9d93a5f15beee5cdc8c62a7c5170ff6e19bb