### PR TITLE
chore(release-1.35): update k8s snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -5,9 +5,9 @@ amd64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 5267
+  revision: 5475
 arm64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 5269
+  revision: 5477


### PR DESCRIPTION
## Overview

Updates the K8s snap revisions for the `1.35` track.

## Revisions

| Architecture | Revision |
|--------------|----------|
| amd64 | 5475 |
| arm64 | 5477 |

## Source Commits

Both architectures are built from the same commit:
- https://github.com/canonical/k8s-snap/commit/ee72ef7ba4c4150641ef4410e20d35f4baf3e08c