### PR TITLE
chore(release-1.34): update k8s snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -5,9 +5,9 @@ amd64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 5268
+  revision: 5499
 arm64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 5272
+  revision: 5496


### PR DESCRIPTION
## Overview

Updates the K8s snap revisions for the `1.34` track.

## Revisions

| Architecture | Revision |
|--------------|----------|
| amd64 | 5499 |
| arm64 | 5496 |

## Source Commits

Both architectures are built from the same commit:
- https://github.com/canonical/k8s-snap/commit/f7e1b7c799cbfc03ce358ceff396f5c57d767569