### PR TITLE
feat: [release-1.36] prep 1.36 release

### DIFF
--- a/charms/worker/k8s/src/literals.py
+++ b/charms/worker/k8s/src/literals.py
@@ -185,10 +185,10 @@ DEPENDENCIES = {
     },
     # NOTE: Update the dependencies for the k8s-service before releasing.
     "k8s_service": {
-        "dependencies": {"k8s-worker": "^1.33, < 1.35"},
+        "dependencies": {"k8s-worker": "^1.35, < 1.37"},
         "name": "k8s",
-        "upgrade_supported": "^1.33, < 1.35",
-        "version": "1.34.0",
+        "upgrade_supported": "^1.35, < 1.37",
+        "version": "1.36.0",
     },
 }
 

--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -5,9 +5,9 @@ amd64:
   - name: k8s
     install-type: store
     classic: true
-    channel: latest/edge
+    revision: 5501
 arm64:
   - name: k8s
     install-type: store
     classic: true
-    channel: latest/edge
+    revision: 5500


### PR DESCRIPTION
This PR prepares k8s-operator for the 1.36 release.
```
$ snapcraft status k8s | grep 1.36-classic

1.36-classic  amd64    stable        v1.36.4    5501        -           -
1.36-classic  amd64    candidate     v1.36.4    5501        -           -
1.36-classic  amd64    beta          v1.36.4    5501        -           -
1.36-classic  amd64    edge          v1.36.4    5501        -           -
1.36-classic  arm64    stable        v1.36.4    5500        -           -
1.36-classic  arm64    candidate     v1.36.4    5500        -           -
1.36-classic  arm64    beta          v1.36.4    5500        -           -
1.36-classic  arm64    edge          v1.36.4    5500        -           -
```