### PR TITLE
feat: bump snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -5,9 +5,9 @@ amd64:
   - name: k8s
     install-type: store
     classic: true
-    revision: 5501
+    revision: 5526
 arm64:
   - name: k8s
     install-type: store
     classic: true
-    revision: 5500
+    revision: 5527


### PR DESCRIPTION
This PR bumps snap revisions
```
$ snapcraft status k8s
...
1.36-classic  amd64    stable        -          -           -           -
                       candidate     v1.36.4    5526        -           -
                       beta          v1.36.4    5526        -           -
                       edge          v1.36.4    5526        -           -
              arm64    stable        -          -           -           -
                       candidate     v1.36.4    5527        -           -
                       beta          v1.36.4    5527        -           -
                       edge          v1.36.4    5527        -           -
```