### PR TITLE
chore(release-1.36): update k8s snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -2,12 +2,12 @@
 # See LICENSE file for licensing details.
 
 amd64:
-  - name: k8s
-    install-type: store
-    classic: true
-    revision: 5501
+- classic: true
+  install-type: store
+  name: k8s
+  revision: 5526
 arm64:
-  - name: k8s
-    install-type: store
-    classic: true
-    revision: 5500
+- classic: true
+  install-type: store
+  name: k8s
+  revision: 5527


### PR DESCRIPTION
## Overview

Updates the K8s snap revisions for the `1.36` track.

## Revisions

| Architecture | Revision |
|--------------|----------|
| amd64 | 5526 |
| arm64 | 5527 |

## Source Commits

Both architectures are built from the same commit:
- https://github.com/canonical/k8s-snap/commit/8516ed7064ea115c5c16db2473ac65b8018c0978