### PR TITLE
chore(release-1.32): update k8s snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -4,8 +4,8 @@
 amd64:
 - install-type: store
   name: k8s
-  revision: 5473
+  revision: 5524
 arm64:
 - install-type: store
   name: k8s
-  revision: 5476
+  revision: 5522


### PR DESCRIPTION
## Overview

Updates the K8s snap revisions for the `1.32` track.

## Revisions

| Architecture | Revision |
|--------------|----------|
| amd64 | 5524 |
| arm64 | 5522 |

## Source Commits

Both architectures are built from the same commit:
- https://github.com/canonical/k8s-snap/commit/ed00d55aa43862e93ef73dc29f58291a67e10276