### PR TITLE
chore(release-1.35): update k8s snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -5,9 +5,9 @@ amd64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 5475
+  revision: 5525
 arm64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 5477
+  revision: 5523


### PR DESCRIPTION
## Overview

Updates the K8s snap revisions for the `1.35` track.

## Revisions

| Architecture | Revision |
|--------------|----------|
| amd64 | 5525 |
| arm64 | 5523 |

## Source Commits

Both architectures are built from the same commit:
- https://github.com/canonical/k8s-snap/commit/09e362feb3a681f574fb7a92120ddbf868b9b4a4