### PR TITLE
feat: bump snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -5,9 +5,9 @@ amd64:
   - name: k8s
     install-type: store
     classic: true
-    revision: 5537
+    revision: 5546
 arm64:
   - name: k8s
     install-type: store
     classic: true
-    revision: 5538
+    revision: 5544


### PR DESCRIPTION
Bump snap revisions:
```
$ snapcraft status k8s
...
1.36-classic  amd64    stable        -          -           -           -
                       candidate     v1.36.4    5546        -           -
                       beta          v1.36.4    5546        -           -
                       edge          v1.36.4    5546        -           -
              arm64    stable        -          -           -           -
                       candidate     v1.36.4    5544        -           -
                       beta          v1.36.4    5544        -           -
                       edge          v1.36.4    5544        -           -
```