### PR TITLE
fix: re-trigger partial release and publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ This charm can optionally disable the following components:
 
 ## Other resources
 
-* [Contributing](CONTRIBUTING.md) <!-- or link to other contribution documentation -->
+* [Contributing](CONTRIBUTING.md) <!-- or link to other contribution documentation --> 
 
 * See the [Juju SDK documentation](https://juju.is/docs/sdk) for more information about developing and improving charms.

--- a/charms/worker/k8s/src/charm.py
+++ b/charms/worker/k8s/src/charm.py
@@ -115,7 +115,7 @@ def _get_juju_public_address() -> str:
     """Get public address from juju.
 
     Returns:
-        (str) public ip address of the unit
+        (str) public ip address of the unit.
     """
     cmd = ["unit-get", "public-address"]
     return subprocess.check_output(cmd).decode("UTF-8").strip()


### PR DESCRIPTION
Merging this PR is the only way to re-trigger a broken release and publish.
During the following failed job, 1.36 was released to 24.04 (amd64 and arm64) and 26.04 (amd64). However, 26.04 (arm64) failed to get published due to connection resets.
Retrying the release fails since it tries to publish to every single base and every single arch, and duplicate releases are not allowed. 
https://github.com/canonical/k8s-operator/actions/runs/34326277229/job/102385611519
```
1.36     ubuntu 24.04 (amd64)  stable     -          -           -
                               candidate  1970       1970        snap-installation (r2)
                               beta       1972       1972        snap-installation (r2)
                               edge       ↑          ↑           ↑
         ubuntu 24.04 (arm64)  stable     -          -           -
                               candidate  1968       1968        snap-installation (r2)
                               beta       1974       1974        snap-installation (r2)
                               edge       ↑          ↑           ↑
         ubuntu 26.04 (amd64)  stable     -          -           -
                               candidate  1971       1971        snap-installation (r2)
                               beta       1973       1973        snap-installation (r2)
                               edge       ↑          ↑           ↑
         ubuntu 26.04 (arm64)  stable     -          -           -
                               candidate  1969       1969        snap-installation (r2)
                               beta       1969       1969        snap-installation (r2)
                               edge       ↑          ↑           ↑
```
