### PR TITLE
chore(release-1.35): update k8s snap revisions

### DIFF
--- a/charms/worker/k8s/templates/snap_installation.yaml
+++ b/charms/worker/k8s/templates/snap_installation.yaml
@@ -5,9 +5,9 @@ amd64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 5475
+  revision: 5552
 arm64:
 - classic: true
   install-type: store
   name: k8s
-  revision: 5477
+  revision: 5556


### PR DESCRIPTION
## Overview

Updates the K8s snap revisions for the `1.35` track.

## Revisions

| Architecture | Revision |
|--------------|----------|
| amd64 | 5552 |
| arm64 | 5556 |

## Source Commits

Both architectures are built from the same commit:
- https://github.com/canonical/k8s-snap/commit/4bfa455b475d453c626785f18962f48b48c10a7f